### PR TITLE
Allow more time for rcpsp_ms to rcpsp solver

### DIFF
--- a/discrete_optimization/rcpsp_multiskill/multiskill_to_rcpsp.py
+++ b/discrete_optimization/rcpsp_multiskill/multiskill_to_rcpsp.py
@@ -42,7 +42,7 @@ class MultiSkillToRCPSP:
         one_worker_type_per_task: bool = False,
     ):
         params_cp = ParametersCP(
-            time_limit=0.5,
+            time_limit=30,
             pool_solutions=10000,
             intermediate_solution=True,
             all_solutions=False,

--- a/tests/rcpsp_multiskill/test_rcpsp_ms_to_rcpsp.py
+++ b/tests/rcpsp_multiskill/test_rcpsp_ms_to_rcpsp.py
@@ -61,7 +61,7 @@ def test_solve_rcpsp_imopse1(random_seed):
     result_storage = lns_solver.solve(
         parameters_cp=params_cp,
         nb_iteration_lns=5,
-        max_time_seconds=30,
+        max_time_seconds=100,
         nb_iteration_no_improvement=100,
         skip_first_iteration=False,
     )


### PR DESCRIPTION
From time to time, the tests in tests/rcpsp_multiskill/test_rcpsp_ms_to_rcpsp.py fail beacause they do not find a solution in time. We try to relax a bit the time conditions on the solver, going partially back on changes from commit df20a0e.