### PR TITLE
Fix logging messages

### DIFF
--- a/discrete_optimization/facility/solvers/facility_cp_solvers.py
+++ b/discrete_optimization/facility/solvers/facility_cp_solvers.py
@@ -61,8 +61,8 @@ class FacilitySolCP:
     def __init__(self, objective, _output_item, **kwargs):
         self.objective = objective
         self.dict = kwargs
-        logger.debug("One solution ", self.objective)
-        logger.debug("Output ", _output_item)
+        logger.debug(f"One solution {self.objective}")
+        logger.debug(f"Output {_output_item}")
 
     def check(self) -> bool:
         return True

--- a/discrete_optimization/pickup_vrp/solver/lp_solver_pymip.py
+++ b/discrete_optimization/pickup_vrp/solver/lp_solver_pymip.py
@@ -1656,7 +1656,7 @@ def rebuild_routine(
                 return None
             len_this_component = len(paths_component[min_component])
             logger.debug(list(range(0, -len_this_component, -1)))
-            logger.debug(f"len this component : ", len_this_component)
+            logger.debug(f"len this component : {len_this_component}")
             logger.debug(f"out edge : {min_out_edge}")
             logger.debug(f"in edge : {min_in_edge}")
             index_of_in_component = indexes[min_component][min_out_edge[1]]

--- a/discrete_optimization/rcpsp/solver/cp_solvers.py
+++ b/discrete_optimization/rcpsp/solver/cp_solvers.py
@@ -83,8 +83,8 @@ class RCPSPSolCP:
     def __init__(self, objective, _output_item, **kwargs):
         self.objective = objective
         self.dict = kwargs
-        logger.debug("One solution ", self.objective)
-        logger.debug("Output ", _output_item)
+        logger.debug(f"One solution {self.objective}")
+        logger.debug(f"Output {_output_item}")
 
     def check(self) -> bool:
         return True

--- a/discrete_optimization/rcpsp/solver/rcpsp_pile.py
+++ b/discrete_optimization/rcpsp/solver/rcpsp_pile.py
@@ -135,7 +135,7 @@ class PileSolverRCPSP(SolverDO):
         perm = []
         while len(schedule) < self.n_jobs:
             logger.debug(len(schedule))
-            logger.debug("available activities : ", available_activities)
+            logger.debug(f"available activities : {available_activities}")
             possible_activities = [
                 n
                 for n in available_activities
@@ -145,7 +145,7 @@ class PileSolverRCPSP(SolverDO):
                     for r in current_ressource_available
                 )
             ]
-            logger.debug("Ressources : ", current_ressource_available)
+            logger.debug(f"Ressources : {current_ressource_available}")
             while len(possible_activities) > 0:
                 next_activity = None
                 if greedy_choice == GreedyChoice.MOST_SUCCESSORS:

--- a/discrete_optimization/rcpsp_multiskill/solvers/lp_model.py
+++ b/discrete_optimization/rcpsp_multiskill/solvers/lp_model.py
@@ -384,5 +384,5 @@ class LP_Solver_MRSCPSP(PymipMilpSolver):
             logger.info("Init LP model ")
             t = time.time()
             self.init_model(greedy_start=False, **args)
-            logger.info("LP model initialized...in ", time.time() - t, " seconds")
+            logger.info(f"LP model initialized...in {time.time() - t} seconds")
         return super().solve(parameters_milp=parameters_milp, **args)


### PR DESCRIPTION
Some logging messages were bugged because coming from a previous print.

For instance: 
- `print("One solution ", self.objective)` is working while
- `logger.debug("One solution ", self.objective)` is crashing

To see these types of errors during test, one can use `--log-cli-level=DEBUG` option for pytest. We do not that in github workflow because the output is unreadable after that because of other libraries debug messages.

For instance, before this fix 
```
pytest --log-cli-level=DEBUG tests/facility/test_facility_cp.py
```
was crashing. It is now passing.