### PR TITLE
Fix RCSPSP_MS LP solver

### DIFF
--- a/discrete_optimization/rcpsp_multiskill/solvers/lp_model.py
+++ b/discrete_optimization/rcpsp_multiskill/solvers/lp_model.py
@@ -190,16 +190,22 @@ class LP_Solver_MRSCPSP(PymipMilpSolver):
                                 - self.start_times[task][mode][t]
                                 <= 0
                             )
+                            len_calendar = len(
+                                self.rcpsp_model.employees[employee].calendar_employee
+                            )
                             if any(
                                 not self.rcpsp_model.employees[
                                     employee
                                 ].calendar_employee[tt]
                                 for tt in range(
                                     t,
-                                    t
-                                    + self.rcpsp_model.mode_details[task][mode][
-                                        "duration"
-                                    ],
+                                    min(
+                                        t
+                                        + self.rcpsp_model.mode_details[task][mode][
+                                            "duration"
+                                        ],
+                                        len_calendar,
+                                    ),
                                 )
                             ):
                                 self.model.add_constr(


### PR DESCRIPTION
The `init_model()` could crash if employees calendar were shorter than horizon + duration of longer task.
Indeed in [scikit-decide](https://github.com/airbus/scikit-decide), some scheduling tests were crashing because of that. 
This fix ensure that we do not try to access element not in the calendar.