### PR TITLE
Check minizinc binary version and bump minizinc-python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ through different scenario handling mechanisms) and multi-objective optimization
 
 ### Prerequisites
 
-- Install [minizinc](https://www.minizinc.org/).
+- Install [minizinc](https://www.minizinc.org/), at least version 2.6, and update the `PATH` environment variable
+so that it can be found by Python. See [minizinc documentation](https://www.minizinc.org/doc-latest/en/installation.html) for more details.
 - Optionally, install [gurobi](https://www.gurobi.com/) with its python binding (gurobipy)
   and an appropriate license, if you want to try solvers that make use of gurobi.
 

--- a/discrete_optimization/__init__.py
+++ b/discrete_optimization/__init__.py
@@ -2,4 +2,25 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
+import minizinc
+
 __version__ = "0.0.0"
+
+# Check that minimal minizinc binary version is respected
+_minizinc_minimal_parsed_version = (2, 6)
+_minizinc_minimal_str_version = ".".join(
+    str(i) for i in _minizinc_minimal_parsed_version
+)
+
+if minizinc.default_driver is None:
+    raise RuntimeError(
+        "Minizinc binary has not been found.\n"
+        "You need to install it and/or configure the PATH environment variable.\n"
+        "See minizinc documentation for more details: https://www.minizinc.org/doc-latest/en/installation.html"
+    )
+if minizinc.default_driver.parsed_version < _minizinc_minimal_parsed_version:
+    raise RuntimeError(
+        f"Minizinc binary version must be at least {_minizinc_minimal_str_version}.\n"
+        "Install an appropriate version of minizinc and/or configure the PATH environment variable.\n"
+        "See minizinc documentation for more details: https://www.minizinc.org/doc-latest/en/installation.html"
+    )

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     install_requires=[
         "shapely>=1.7",
         "mip>=1.13",
-        "minizinc>=0.4.2",
+        "minizinc>=0.6.0",
         "deap>=1.3.1",
         "networkx>=2.5  ",
         "numba>=0.50",


### PR DESCRIPTION
- require version 2.6 for minizinc binary
- check at import of discrete_optimization package that
  - minizinc is installed and reachable from PATH
  - its version is greater or equal to 2.6.0
- bump minizinc-python to be able to do this check easily from python