### PR TITLE
Fix "Fetch data for tests" workflow step for windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,10 +162,9 @@ jobs:
           key: data-${{ hashFiles('discrete_optimization/datasets.py') }}
       - name: Fetch data for tests
         if: steps.cache-data.outputs.cache-hit != 'true'
-        shell: python3 {0}
         run: |
-          from discrete_optimization.datasets import fetch_all_datasets
-          fetch_all_datasets()
+          export PATH=$PATH:${{ matrix.minizinc_path }}
+          python -m discrete_optimization.datasets
       - name: Test with pytest (no coverage)
         if: ${{ !matrix.coverage }}
         run: |


### PR DESCRIPTION
Since PR #48, minizinc is imported in
`discrete_optimization.__init__.py` to check the binary version, so even when fetching tests data.

On windows we need to redefine the `PATH` properly so that minizinc binary is found (while on mac and linux, having it defined at "Add MiniZinc to PATH" step seems sufficient).

The failure happens only if datasets cache retrieval fails itself. See this [job](https://github.com/nhuet/discrete-optimization/actions/runs/3154433525/jobs/5132021850) for instance.