### PR TITLE
Fix the copy() function of RCPSPModel

### DIFF
--- a/discrete_optimization/rcpsp/rcpsp_model.py
+++ b/discrete_optimization/rcpsp/rcpsp_model.py
@@ -706,6 +706,9 @@ class RCPSPModel(Problem):
     def copy(self):
         return RCPSPModel(
             resources=self.resources,
+            tasks_list=self.tasks_list,
+            source_task=self.source_task,
+            sink_task=self.sink_task,
             non_renewable_resources=self.non_renewable_resources,
             mode_details=deepcopy(self.mode_details),
             successors=deepcopy(self.successors),


### PR DESCRIPTION
-pass additional argument to constructor of RCPSPModel in the copy() function (tasks_list, source_task, sink_task). 
This allows non integer name of task and custom source and sinks as expected.