### PR TITLE
Prepare gh-pages for doc deployment

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE HTML>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="refresh" content="0; url=master/" />
+        <link rel="canonical" href="master/" />
+    </head>
+
+    <body>
+        <h1>
+            The page been moved to <a href="master/">master/</a>
+        </h1>
+    </body>
+</html>


### PR DESCRIPTION
We prepare this branch to be used for github pages:
- tell that it is not a jekyll site
- redirect home page to master/ directory: in PR #56, we make so that all push to default branch build and deploy the doc to a directory in gh-pages with the name of the branch (here master). Release tags will trigger a build and deployment in a directory named after the version number. Having directories at the root of gh-pages with all versions of the documentation will ease the creation of a menu to navigate between versions. By default, the user will arrive on master doc.