### PR TITLE
Use new way of setting output parameter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,7 +119,7 @@ jobs:
       - name: get MininZinc path to cache
         id: get-mzn-cache-path
         run: |
-          echo "::set-output name=path::${{ matrix.minizinc_cache_path }}"
+          echo "path=${{ matrix.minizinc_cache_path }}" >> $GITHUB_OUTPUT  # expands variables
       - name: Restore MiniZinc cache
         id: cache-minizinc
         uses: actions/cache@v3
@@ -144,7 +144,7 @@ jobs:
       - name: Get pip cache dir
         id: get-pip-cache-dir
         run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
       - name: Restore pip cache
         id: cache-pip
         uses: actions/cache@v3


### PR DESCRIPTION
The command set-output is now deprecated and we have now to use environment files to define step outputs:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/