### PR TITLE
Create binder environment for discrete-optimization 0.2.0 + python 3.9

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,9 @@
+name: nb-do0.2.0-py3.9
+channels:
+  - defaults
+dependencies:
+  - python=3.9
+  - pip
+  - pip:
+      - discrete-optimization==0.2.0
+      - nbgitpuller

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,16 @@
+ #!/bin/bash
+
+set -ex
+
+pwd
+ls
+
+# install minizinc
+mkdir minizinc_install
+cd minizinc_install
+curl -o minizinc.AppImage -L https://github.com/MiniZinc/MiniZincIDE/releases/download/2.6.3/MiniZincIDE-2.6.3-x86_64.AppImage
+chmod +x minizinc.AppImage
+./minizinc.AppImage --appimage-extract
+cd ..
+export PATH="$(pwd)/minizinc_install/squashfs-root/usr/bin/":$PATH
+minizinc --version

--- a/start
+++ b/start
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+export PATH="$(pwd)/minizinc_install/squashfs-root/usr/bin/":$PATH
+exec "$@"


### PR DESCRIPTION
Additional files needed to install minzinc properly:
- postBuild: download minizinc AppImage and extract it
- start: set path so that minizinc can be found, run just before jupyter