### PR TITLE
Fix dependencies of the library and test importing each module correctly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,9 +155,19 @@ jobs:
       - name: Test minizinc install
         run: |
           minizinc --version
-      - name: Install test dependencies
+      - name: Install only discrete-optimization
         run: |
           python -m pip install -U pip
+          wheelfile=$(ls ./wheels/discrete_optimization*.whl)
+          pip install ${wheelfile}
+      - name: Check imports are working
+        run: |
+          # configure minizinc
+          export PATH=$PATH:${{ matrix.minizinc_path }}
+          # check imports
+          python tests/test_import_all_submodules.py
+      - name: Install test dependencies
+        run: |
           wheelfile=$(ls ./wheels/discrete_optimization*.whl)
           pip install ${wheelfile}[test]
           if [ "${{ matrix.wo_gurobi }}" != "without gurobi" ]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "deprecation",
     "typing-extensions>=4.0",
     "cpmpy>=0.9.9",
+    "scipy",
 ]
 dynamic = ["version"]
 

--- a/tests/test_import_all_submodules.py
+++ b/tests/test_import_all_submodules.py
@@ -53,3 +53,7 @@ def test_importing_all_submodules():
             f"{len(modules_with_errors)} submodules of discrete_optimization cannot be imported\n"
             + f"{modules_with_errors}"
         )
+
+
+if __name__ == "__main__":
+    test_importing_all_submodules()


### PR DESCRIPTION
We were missing scipy dependency needed in a lot of modules (espceially rcpsp ones).
Indeed test optional dependencies were installing it. So

- we fix pyproject.toml
- we add a step in workflow which is checking the imports *before* installing the optional dependencies