### PR TITLE
Fix utility function creating sampled rcpsp instance

### DIFF
--- a/discrete_optimization/rcpsp/rcpsp_model.py
+++ b/discrete_optimization/rcpsp/rcpsp_model.py
@@ -1069,8 +1069,8 @@ class MethodRobustification:
 
 def create_poisson_laws_duration(rcpsp_model: RCPSPModel, range_around_mean=3):
     poisson_dict = {}
-    source = 1
-    sink = rcpsp_model.n_jobs + 2
+    source = rcpsp_model.source_task
+    sink = rcpsp_model.sink_task
     for job in rcpsp_model.mode_details:
         poisson_dict[job] = {}
         for mode in rcpsp_model.mode_details[job]:
@@ -1091,8 +1091,8 @@ def create_poisson_laws_duration(rcpsp_model: RCPSPModel, range_around_mean=3):
 
 def create_poisson_laws_resource(rcpsp_model: RCPSPModel, range_around_mean=1):
     poisson_dict = {}
-    source = 1
-    sink = rcpsp_model.n_jobs + 2
+    source = rcpsp_model.source_task
+    sink = rcpsp_model.sink_task
     limit_resource = rcpsp_model.resources
     resources = rcpsp_model.resources_list
     resources_non_renewable = rcpsp_model.non_renewable_resources
@@ -1197,7 +1197,10 @@ class UncertainRCPSPModel:
     def create_rcpsp_model(self, method_robustification: MethodRobustification):
         model = self.base_rcpsp_model.copy()
         for activity in self.probas:
-            if activity in {self.base_rcpsp_model.source_task, self.base_rcpsp_model.sink_task}:
+            if activity in {
+                self.base_rcpsp_model.source_task,
+                self.base_rcpsp_model.sink_task,
+            }:
                 continue
             for mode in self.probas[activity]:
                 for detail in self.probas[activity][mode]:

--- a/discrete_optimization/rcpsp/rcpsp_model.py
+++ b/discrete_optimization/rcpsp/rcpsp_model.py
@@ -1197,7 +1197,7 @@ class UncertainRCPSPModel:
     def create_rcpsp_model(self, method_robustification: MethodRobustification):
         model = self.base_rcpsp_model.copy()
         for activity in self.probas:
-            if activity in {self.base_rcpsp_model.n_jobs + 2, 1}:
+            if activity in {self.base_rcpsp_model.source_task, self.base_rcpsp_model.sink_task}:
                 continue
             for mode in self.probas[activity]:
                 for detail in self.probas[activity][mode]:

--- a/tests/rcpsp/test_rcpsp_uncertain_model.py
+++ b/tests/rcpsp/test_rcpsp_uncertain_model.py
@@ -312,7 +312,7 @@ def test_uncertain_resources_sm():
         119: {1: {"duration": 3, "R1": 1, "R2": 1, "R3": 1, "R4": 8}},
         120: {1: {"duration": 8, "R1": 1, "R2": 8, "R3": 1, "R4": 1}},
         121: {1: {"duration": 9, "R1": 7, "R2": 1, "R3": 1, "R4": 1}},
-        122: {1: {"duration": 0, "R1": 1, "R2": 1, "R3": 1, "R4": 1}},
+        122: {1: {"duration": 0, "R1": 0, "R2": 0, "R3": 0, "R4": 0}},
     }
     best_model = uncertain_model.create_rcpsp_model(
         MethodRobustification(
@@ -707,7 +707,7 @@ def test_uncertain_resources_sm():
         119: {1: {"duration": 3, "R1": 1, "R2": 1, "R3": 1, "R4": 8}},
         120: {1: {"duration": 8, "R1": 1, "R2": 8, "R3": 1, "R4": 1}},
         121: {1: {"duration": 9, "R1": 7, "R2": 1, "R3": 1, "R4": 1}},
-        122: {1: {"duration": 0, "R1": 1, "R2": 1, "R3": 1, "R4": 1}},
+        122: {1: {"duration": 0, "R1": 0, "R2": 0, "R3": 0, "R4": 0}},
     }
 
 


### PR DESCRIPTION
- the create_rcpsp_model function was not coherent with the new way of handling the source and sink task of the rcpsp problem : 
before, the source was supposed to be the task named "1" et the sink "n_jobs+2", which is no longer the case. 
