### PR TITLE
Fix github+binder links for notebooks when tagging a release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -251,6 +251,10 @@ jobs:
           then
               AUTODOC_NOTEBOOKS_REPO_URL=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
               AUTODOC_NOTEBOOKS_BRANCH=${GITHUB_REF/refs\/heads\//}
+          elif [[ $GITHUB_REF == refs/tags* ]];
+          then
+              AUTODOC_NOTEBOOKS_REPO_URL=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
+              AUTODOC_NOTEBOOKS_BRANCH=${GITHUB_REF/refs\/tags\//}
           fi
           # export in GITHUB_ENV for next steps
           echo "AUTODOC_BINDER_ENV_GH_REPO_NAME=${AUTODOC_BINDER_ENV_GH_REPO_NAME}" >> $GITHUB_ENV


### PR DESCRIPTION
The environment variables needed to generate the proper links were not defined when tagging a release. 
(In that case, $GITHUB_REF starts with "refs/tags")