### PR TITLE
Modify prerequisites text for binder users

### DIFF
--- a/notebooks/knapsack.ipynb
+++ b/notebooks/knapsack.ipynb
@@ -27,13 +27,14 @@
    "source": [
     "## Prerequisites\n",
     "\n",
-    "Before running this notebook, you need to \n",
+    "Before running this notebook locally, you need to \n",
     "- install [minizinc](https://www.minizinc.org/) and config it so that it is found by the jupyter kernel (on linux, it means updating the `PATH` variable)\n",
     "- install discrete-optimization in your jupyter kernel\n",
     "    ```\n",
     "    pip install discrete-optimization\n",
     "    ```\n",
-    "\n"
+    "\n",
+    "If you followed a binder link in the documentation, no need to do anything, it has already been done for you!\n"
    ]
   },
   {


### PR DESCRIPTION
The prerequisites are useful only for local users as everything has already been done for binder environment.