### PR TITLE
Add tips in doc to install minzinc easily in a terminal (works on cloud)

### DIFF
--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -8,6 +8,54 @@ You need to install [minizinc](https://www.minizinc.org/) (version greater than 
 so that it can be found by Python.
 See [minizinc documentation](https://www.minizinc.org/doc-latest/en/installation.html) for more details.
 
+> **Tip:** You can easily install minizinc from the command line which can be useful when on cloud.
+> In order to make life easier to clous users, we reproduce the necessary lines. Pleas be careful that this
+> is not an official documentation for minzinc and that the following lines can stop working without notice
+> as we do not test them.
+
+#### Linux command line
+On a Linux distribution, you can use the bundled [minizinc AppImage](https://www.minizinc.org/doc-latest/en/installation.html#appimage).
+
+If [FUSE](https://en.wikipedia.org/wiki/Filesystem_in_Userspace) is available:
+```
+mkdir minizinc_install
+curl -o minizinc_install/minizinc -L https://github.com/MiniZinc/MiniZincIDE/releases/download/2.6.3/MiniZincIDE-2.6.3-x86_64.AppImage
+chmod +x minizinc_install/minizinc
+export PATH="$(pwd)/minizinc_install/":$PATH
+minizinc --version
+```
+Else, this is still possible by extracting the files:
+```
+mkdir minizinc_install
+cd minizinc_install
+curl -o minizinc.AppImage -L https://github.com/MiniZinc/MiniZincIDE/releases/download/2.6.3/MiniZincIDE-2.6.3-x86_64.AppImage
+chmod +x minizinc.AppImage
+./minizinc.AppImage --appimage-extract
+cd ..
+export PATH="$(pwd)/minizinc_install/squashfs-root/usr/bin/":$PATH
+minizinc --version
+```
+
+#### MacOs command line
+```
+mkdir minizinc_install
+curl -o minizinc.dmg -L https://github.com/MiniZinc/MiniZincIDE/releases/download/2.6.3/MiniZincIDE-2.6.3-bundled.dmg
+hdiutil attach minizinc.dmg
+cp -R /Volumes/MiniZinc*/MiniZincIDE.app minizinc_install/.
+export PATH="$(pwd)/minizinc_install/MiniZincIDE.app/Contents/Resources":$PATH
+minizinc --version
+```
+
+#### Windows command line
+Works on Windows Server 2022 with bash shell:
+```
+mkdir minizinc_install
+curl -o minizinc_setup.exe -L https://github.com/MiniZinc/MiniZincIDE/releases/download/2.6.3/MiniZincIDE-2.6.3-bundled-setup-win64.exe
+cmd //c "minizinc_setup.exe /verysilent /currentuser /norestart /suppressmsgboxes /sp"
+export PATH="~/AppData/Local/Programs/MiniZinc":$PATH
+minizinc --version
+```
+
 ### Python 3.7+ environment
 
 The use of a virtual environment is recommended, and you will need to ensure that the environment use a Python version


### PR DESCRIPTION
Fix #77 