### PR TITLE
Add minizinc external lib directory to LD_LIBRARY_PATH in binder environment

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -13,4 +13,5 @@ chmod +x minizinc.AppImage
 ./minizinc.AppImage --appimage-extract
 cd ..
 export PATH="$(pwd)/minizinc_install/squashfs-root/usr/bin/":$PATH
+export LD_LIBRARY_PATH="$(pwd)/minizinc_install/squashfs-root/usr/lib":$LD_LIBRARY_PATH
 minizinc --version


### PR DESCRIPTION
This fixes potential issues when using gecode.