### PR TITLE
Skip minizinc version check if DO_SKIP_MZN_CHECK env variable is set 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,6 +150,25 @@ jobs:
         with:
           name: wheels
           path: wheels
+      - name: Install only discrete-optimization
+        run: |
+          python -m pip install -U pip
+          wheelfile=$(ls ./wheels/discrete_optimization*.whl)
+          pip install ${wheelfile}
+      - name: Check import work without minizinc if DO_SKIP_MZN_CHECK set
+        run: |
+          export DO_SKIP_MZN_CHECK=1
+          python -c "import discrete_optimization"
+      - name: Check import fails without minizinc if DO_SKIP_MZN_CHECK unset
+        run: |
+          python -c "
+          try:
+            import discrete_optimization
+          except RuntimeError:
+            pass
+          else:
+            raise AssertionError('We should not be able to import discrete_optimization without minizinc being installed.')
+          "
       - name: Create bin/
         run: mkdir -p bin
       - name: get MininZinc path to cache
@@ -177,11 +196,6 @@ jobs:
       - name: Test minizinc install
         run: |
           minizinc --version
-      - name: Install only discrete-optimization
-        run: |
-          python -m pip install -U pip
-          wheelfile=$(ls ./wheels/discrete_optimization*.whl)
-          pip install ${wheelfile}
       - name: Check imports are working
         run: |
           # configure minizinc

--- a/discrete_optimization/__init__.py
+++ b/discrete_optimization/__init__.py
@@ -2,25 +2,34 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-import minizinc
+import os
 
 __version__ = "0.0.0"
 
-# Check that minimal minizinc binary version is respected
-_minizinc_minimal_parsed_version = (2, 6)
-_minizinc_minimal_str_version = ".".join(
-    str(i) for i in _minizinc_minimal_parsed_version
-)
 
-if minizinc.default_driver is None:
-    raise RuntimeError(
-        "Minizinc binary has not been found.\n"
-        "You need to install it and/or configure the PATH environment variable.\n"
-        "See minizinc documentation for more details: https://www.minizinc.org/doc-latest/en/installation.html"
+# Check that minimal minizinc binary version is respected,
+# except if environment variable DO_SKIP_MZN_CHECK is set to 1.
+if ("DO_SKIP_MZN_CHECK" not in os.environ) or not (os.environ["DO_SKIP_MZN_CHECK"]):
+    import minizinc
+
+    _minizinc_minimal_parsed_version = (2, 6)
+    _minizinc_minimal_str_version = ".".join(
+        str(i) for i in _minizinc_minimal_parsed_version
     )
-if minizinc.default_driver.parsed_version < _minizinc_minimal_parsed_version:
-    raise RuntimeError(
-        f"Minizinc binary version must be at least {_minizinc_minimal_str_version}.\n"
-        "Install an appropriate version of minizinc and/or configure the PATH environment variable.\n"
-        "See minizinc documentation for more details: https://www.minizinc.org/doc-latest/en/installation.html"
-    )
+
+    if minizinc.default_driver is None:
+        raise RuntimeError(
+            "Minizinc binary has not been found.\n"
+            "You need to install it and/or configure the PATH environment variable.\n"
+            "See minizinc documentation for more details: https://www.minizinc.org/doc-latest/en/installation.html\n\n"
+            "You can also bypass this check by setting the environment variable DO_SKIP_MZN_CHECK to 1, "
+            "at your own risk."
+        )
+    if minizinc.default_driver.parsed_version < _minizinc_minimal_parsed_version:
+        raise RuntimeError(
+            f"Minizinc binary version must be at least {_minizinc_minimal_str_version}.\n"
+            "Install an appropriate version of minizinc and/or configure the PATH environment variable.\n"
+            "See minizinc documentation for more details: https://www.minizinc.org/doc-latest/en/installation.html\n\n"
+            "You can also bypass this check by setting the environment variable DO_SKIP_MZN_CHECK to 1, "
+            "at your own risk."
+        )

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -10,7 +10,7 @@ See [minizinc documentation](https://www.minizinc.org/doc-latest/en/installation
 
 > **Tip:** You can easily install minizinc from the command line which can be useful when on cloud.
 > In order to make life easier to clous users, we reproduce the necessary lines. Pleas be careful that this
-> is not an official documentation for minzinc and that the following lines can stop working without notice
+> is not an official documentation for minizinc and that the following lines can stop working without notice
 > as we do not test them.
 
 #### Linux command line

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -56,6 +56,19 @@ export PATH="~/AppData/Local/Programs/MiniZinc":$PATH
 minizinc --version
 ```
 
+#### Skipping minizinc version check
+
+It may happen that you need to use only a part of the library which is not relying on minizinc at all,
+and that you do not want to install minzinc.
+This can be troublesome as the minizinc binary version is checked at library import.
+We provide a way to bypass this check by setting the environment variable DO_SKIP_MZN_CHECK:
+```shell
+export DO_SKIP_MZN_CHECK=1
+```
+Please note however that the library is never tested without minizinc (or minizinc versions < 2.6).
+Most modules related to solvers will fail to be imported without minizinc as they are heavily relying on it.
+
+
 ### Python 3.7+ environment
 
 The use of a virtual environment is recommended, and you will need to ensure that the environment use a Python version


### PR DESCRIPTION
To ensure the library can work, we check in `discrete_optimization.__init__.py` that minizinc binary is installed and configured with the correct version.

But it happens that some users want to use only a part of the library not relying on minizinc. We allow this by skipping the check step if the environment variable `DO_SKIP_MZN_CHECK` is set and evaluates as a boolean to True.

This can be done for instance in shell with
```
export DO_SKIP_MZN_CHECK=1
```