### PR TITLE
Make mypy stricter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,3 +67,8 @@ version = {attr = "discrete_optimization.__version__"}
 
 [tool.mypy]
 ignore_missing_imports = true
+strict_optional = true
+implicit_optional = false
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_untyped_defs = true


### PR DESCRIPTION
We use options
- enforcing typing all functions/methods/classes
- parsing also functions/methods/classes only partially typed (up to now, they were discarded by mypy so that issues were not seen)