### PR TITLE
Update dependencies to ease proper typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,8 @@ dependencies = [
     "typing-extensions>=4.0",
     "cpmpy>=0.9.9",
     "scipy",
+    "numpy>=1.21",
+    "typing_extensions>=4.4"
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
- Require numpy >=1.21 tu use numpy.typing module in particaular NDArray type
- Add typing_extensions as a dependency The goal is to use new typing usage even with older Python version (3.7)