### PR TITLE
Set "trigger binder env build" step as optional in github workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -328,6 +328,7 @@ jobs:
           echo "binder_env_ref=$BINDER_ENV_REF" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v3  # checkout triggering branch to get scripts/trigger_binder.sh
       - name: Trigger a build for default binder env ref on each BinderHub deployments in the mybinder.org federation
+        continue-on-error: true
         if: |
           (needs.trigger.outputs.is_push_on_default_branch == 'true')
           || (needs.trigger.outputs.is_release == 'true')


### PR DESCRIPTION
Even if the build on binderhub servers failed to be launch for some reason (as network issues), it should not mark the whole job creating a new binder env as failed. As the binder environment as already been updated by first steps and the only drawback will be that the first user to click on a binder link will experiment a long waiting time before its notebook actually launches.