### PR TITLE
Improve "trigger binder build" step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -335,7 +335,7 @@ jobs:
         run: |
           binder_env_full_ref=${GITHUB_REPOSITORY}/${BINDER_ENV_DEFAULT_REF}
           echo Triggering binder environment build for ${binder_env_full_ref}
-          binderhubs="gke ovh turing gesis"
+          binderhubs="gke gke2 ovh ovh2 turing gesis"
           return_code=0
           for binderhub in $binderhubs; do
             echo "** on ${binderhub}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -335,10 +335,11 @@ jobs:
         run: |
           binder_env_full_ref=${GITHUB_REPOSITORY}/${BINDER_ENV_DEFAULT_REF}
           echo Triggering binder environment build for ${binder_env_full_ref}
-          bash scripts/trigger_binder.sh https://gke.mybinder.org/build/gh/${binder_env_full_ref}
-          bash scripts/trigger_binder.sh https://ovh.mybinder.org/build/gh/${binder_env_full_ref}
-          bash scripts/trigger_binder.sh https://turing.mybinder.org/build/gh/${binder_env_full_ref}
-          bash scripts/trigger_binder.sh https://gesis.mybinder.org/build/gh/${binder_env_full_ref}
+          binderhubs="gke ovh turing gesis"
+          for binderhub in $binderhubs; do
+            echo "** on ${binderhub}"
+            bash scripts/trigger_binder.sh https://${binderhub}.mybinder.org/build/gh/${binder_env_full_ref}
+          done
 
   build-doc:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -336,10 +336,16 @@ jobs:
           binder_env_full_ref=${GITHUB_REPOSITORY}/${BINDER_ENV_DEFAULT_REF}
           echo Triggering binder environment build for ${binder_env_full_ref}
           binderhubs="gke ovh turing gesis"
+          return_code=0
           for binderhub in $binderhubs; do
             echo "** on ${binderhub}"
-            bash scripts/trigger_binder.sh https://${binderhub}.mybinder.org/build/gh/${binder_env_full_ref}
+            # go on even though the script crashes
+            bash scripts/trigger_binder.sh https://${binderhub}.mybinder.org/build/gh/${binder_env_full_ref} || ret_code=$?
+            # remember the potential crash
+            if [ $ret_code != 0 ]; then return_code=$ret_code; fi
           done
+          # exit with last non-zero return code if any
+          exit $return_code
 
   build-doc:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Simplify the commands with a for-loop
- Add binderhub servers ovh2 and gke2
- Avoid stopping when one server makes the `trigger_binder.sh` script failing, in order to trigger build on next servers