### PR TITLE
Use Agg backend for matplotlib in github actions to avoid random issues in windows tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -227,7 +227,7 @@ jobs:
           # show library path used
           pytest -s tests/show_do_path.py
           # run test suite
-          NUMBA_BOUNDSCHECK=1 pytest \
+          MPLBACKEND="agg" NUMBA_BOUNDSCHECK=1 pytest \
             -v --durations=0 --durations-min=10 \
             tests
       - name: Test with pytest (with coverage)
@@ -242,7 +242,7 @@ jobs:
           # show library path used
           pytest -s ../tests/show_do_path.py
           # run test suite
-          NUMBA_BOUNDSCHECK=1 pytest \
+          MPLBACKEND="agg" NUMBA_BOUNDSCHECK=1 pytest \
             --cov discrete_optimization  \
             --cov-report xml:coverage.xml \
             --cov-report html:coverage_html \


### PR DESCRIPTION
Tests involving matplotlib plots randomly fail on windows with tkinter backend (e.g. that [workflow](https://github.com/airbus/discrete-optimization/actions/runs/4234233092/attempts/1)) . As suggested [here](https://discourse.matplotlib.org/t/azure-pipeline-is-failing-randomly-when-using-plt-subplots-because-of-tcl/22893/2), we use agg backend instead to avoid that.