### PR TITLE
Remove unused `nb_solutions` attribute from local search solvers

### DIFF
--- a/discrete_optimization/generic_rcpsp_tools/ls_solver.py
+++ b/discrete_optimization/generic_rcpsp_tools/ls_solver.py
@@ -108,7 +108,6 @@ class LS_RCPSP_Solver(SolverGenericRCPSP):
                 mode_mutation=ModeMutation.MUTATE,
                 params_objective_function=self.params_objective_function,
                 store_solution=False,
-                nb_solutions=10000,
             )
         elif self.ls_solver == LS_SOLVER.HC:
             ls = HillClimber(
@@ -118,7 +117,6 @@ class LS_RCPSP_Solver(SolverGenericRCPSP):
                 mode_mutation=ModeMutation.MUTATE,
                 params_objective_function=self.params_objective_function,
                 store_solution=True,
-                nb_solutions=10000,
             )
         result_sa = ls.solve(
             dummy,

--- a/discrete_optimization/generic_tools/ls/hill_climber.py
+++ b/discrete_optimization/generic_tools/ls/hill_climber.py
@@ -36,7 +36,6 @@ class HillClimber:
         mode_mutation: ModeMutation,
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
         store_solution: bool = False,
-        nb_solutions: int = 1000,
     ):
         self.evaluator = evaluator
         self.mutator = mutator
@@ -54,7 +53,6 @@ class HillClimber:
             evaluator, params_objective_function=self.params_objective_function
         )
         self.store_solution = store_solution
-        self.nb_solutions = nb_solutions
 
     def solve(
         self,
@@ -152,7 +150,6 @@ class HillClimberPareto(HillClimber):
         mode_mutation: ModeMutation,
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
         store_solution: bool = False,
-        nb_solutions: int = 1000,
     ):
         super().__init__(
             evaluator=evaluator,
@@ -161,7 +158,6 @@ class HillClimberPareto(HillClimber):
             mode_mutation=mode_mutation,
             params_objective_function=params_objective_function,
             store_solution=store_solution,
-            nb_solutions=nb_solutions,
         )
 
     def solve(

--- a/discrete_optimization/generic_tools/ls/simulated_annealing.py
+++ b/discrete_optimization/generic_tools/ls/simulated_annealing.py
@@ -51,7 +51,6 @@ class SimulatedAnnealing:
         mode_mutation: ModeMutation,
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
         store_solution: bool = False,
-        nb_solutions: int = 1000,
     ):
         self.evaluator = evaluator
         self.mutator = mutator
@@ -76,7 +75,6 @@ class SimulatedAnnealing:
             )
         self.mode_optim = self.params_objective_function.sense_function
         self.store_solution = store_solution
-        self.nb_solutions = nb_solutions
 
     def solve(
         self,

--- a/discrete_optimization/generic_tools/robustness/robustness_tool.py
+++ b/discrete_optimization/generic_tools/robustness/robustness_tool.py
@@ -207,7 +207,6 @@ def solve_model(
             mode_mutation=ModeMutation.MUTATE,
             params_objective_function=params_objective_function,
             store_solution=True,
-            nb_solutions=10000,
         )
         result_ls = sa.solve(dummy, nb_iteration_max=nb_iteration, pickle_result=False)
     else:
@@ -231,7 +230,6 @@ def solve_model(
             params_objective_function=params_objective_function,
             mode_mutation=ModeMutation.MUTATE,
             store_solution=True,
-            nb_solutions=10000,
         )
         result_ls = sa_mo.solve(
             dummy,

--- a/discrete_optimization/rcpsp/solver/rcpsp_lp_lns_solver.py
+++ b/discrete_optimization/rcpsp/solver/rcpsp_lp_lns_solver.py
@@ -138,7 +138,6 @@ class InitialSolutionRCPSP(InitialSolution):
                 mode_mutation=ModeMutation.MUTATE,
                 params_objective_function=self.params_objective_function,
                 store_solution=True,
-                nb_solutions=10000,
             )
             store_solution = sa.solve(
                 dummy, nb_iteration_max=10000, pickle_result=False

--- a/examples/rcpsp/robustness_experiments.py
+++ b/examples/rcpsp/robustness_experiments.py
@@ -156,7 +156,6 @@ def run_cp_multiscenario():
             temperature=1, restart_handler=res, coefficient=0.9999
         ),
         store_solution=True,
-        nb_solutions=10000000,
     )
     result_sa = simulated_annealing.solve(initial_variable=dummy, nb_iteration_max=300)
     best_solution: RCPSPSolution = result_sa.get_best_solution()
@@ -223,7 +222,6 @@ def local_search_postpro_multiobj_multimode(postpro=True):
             mode_mutation=ModeMutation.MUTATE,
             params_objective_function=params_objective_function,
             store_solution=True,
-            nb_solutions=10000,
         )
         result_ls = sa.solve(dummy, nb_iteration_max=2000, pickle_result=False)
     else:
@@ -240,7 +238,6 @@ def local_search_postpro_multiobj_multimode(postpro=True):
             params_objective_function=params_objective_function,
             mode_mutation=ModeMutation.MUTATE,
             store_solution=True,
-            nb_solutions=10000,
         )
         result_ls = sa.solve(
             dummy,
@@ -360,7 +357,6 @@ def solve_model(model, postpro=True, nb_iteration=500):
             mode_mutation=ModeMutation.MUTATE,
             params_objective_function=params_objective_function,
             store_solution=True,
-            nb_solutions=10000,
         )
         result_ls = sa.solve(dummy, nb_iteration_max=nb_iteration, pickle_result=False)
     else:
@@ -377,7 +373,6 @@ def solve_model(model, postpro=True, nb_iteration=500):
             params_objective_function=params_objective_function,
             mode_mutation=ModeMutation.MUTATE,
             store_solution=True,
-            nb_solutions=10000,
         )
         result_ls = sa.solve(
             dummy,

--- a/tests/knapsack/test_knapsack_ls_solver.py
+++ b/tests/knapsack/test_knapsack_ls_solver.py
@@ -74,7 +74,6 @@ def test_hc_knapsack_multiobj():
         mode_mutation=ModeMutation.MUTATE,
         params_objective_function=params_objective_function,
         store_solution=True,
-        nb_solutions=50000,
     )
     result_sa = sa.solve(
         initial_variable=solution,

--- a/tests/rcpsp/solver/test_rcpsp_local_search.py
+++ b/tests/rcpsp/solver/test_rcpsp_local_search.py
@@ -82,7 +82,6 @@ def test_local_search_sm(random_seed):
         mode_mutation=ModeMutation.MUTATE,
         params_objective_function=params_objective_function,
         store_solution=False,
-        nb_solutions=10,
     )
 
     sol = sa.solve(dummy, nb_iteration_max=500, pickle_result=False).get_best_solution()
@@ -135,7 +134,6 @@ def test_local_search_mm(random_seed):
         mode_mutation=ModeMutation.MUTATE,
         params_objective_function=params_objective_function,
         store_solution=False,
-        nb_solutions=10,
     )
 
     sol = sa.solve(dummy, nb_iteration_max=300, pickle_result=False).get_best_solution()
@@ -185,7 +183,6 @@ def test_local_search_sm_multiobj(random_seed):
         params_objective_function=params_objective_function,
         mode_mutation=ModeMutation.MUTATE,
         store_solution=True,
-        nb_solutions=100,
     )
     pareto_store = sa.solve(
         dummy, nb_iteration_max=100, pickle_result=False, update_iteration_pareto=100
@@ -227,7 +224,6 @@ def test_local_search_sm_postpro_multiobj(random_seed):
         mode_mutation=ModeMutation.MUTATE,
         params_objective_function=params_objective_function,
         store_solution=True,
-        nb_solutions=100,
     )
     store = sa.solve(dummy, nb_iteration_max=100, pickle_result=False)
     pareto_store = result_storage_to_pareto_front(
@@ -291,7 +287,6 @@ def test_local_search_mm_multiobj(random_seed):
         params_objective_function=params_objective_function,
         mode_mutation=ModeMutation.MUTATE,
         store_solution=True,
-        nb_solutions=100,
     )
     pareto_store = sa.solve(
         dummy,
@@ -364,7 +359,6 @@ def test_local_search_postpro_multiobj_multimode(random_seed):
         mode_mutation=ModeMutation.MUTATE,
         params_objective_function=params_objective_function,
         store_solution=True,
-        nb_solutions=100,
     )
     result_sa = sa.solve(dummy, nb_iteration_max=100, pickle_result=False)
     result_sa.list_solution_fits = [


### PR DESCRIPTION
This has probably been replaced at some point by `nb_iteration_max` in `solve ()` args.