### PR TITLE
Minor fixes and refactoring on local search and genetic algorithms

### DIFF
--- a/discrete_optimization/generic_rcpsp_tools/ls_solver.py
+++ b/discrete_optimization/generic_rcpsp_tools/ls_solver.py
@@ -91,8 +91,6 @@ class LS_RCPSP_Solver(SolverGenericRCPSP):
         )
         res = RestartHandlerLimit(
             nb_iteration_no_improvement=kwargs.get("nb_iteration_no_improvement", 300),
-            cur_solution=dummy,
-            cur_objective=model.evaluate(dummy),
         )
         ls = None
         if self.ls_solver == LS_SOLVER.SA:

--- a/discrete_optimization/generic_rcpsp_tools/ls_solver.py
+++ b/discrete_optimization/generic_rcpsp_tools/ls_solver.py
@@ -108,7 +108,6 @@ class LS_RCPSP_Solver(SolverGenericRCPSP):
                 mode_mutation=ModeMutation.MUTATE,
                 params_objective_function=self.params_objective_function,
                 store_solution=False,
-                nb_solutions=10000,
             )
         elif self.ls_solver == LS_SOLVER.HC:
             ls = HillClimber(
@@ -118,7 +117,6 @@ class LS_RCPSP_Solver(SolverGenericRCPSP):
                 mode_mutation=ModeMutation.MUTATE,
                 params_objective_function=self.params_objective_function,
                 store_solution=True,
-                nb_solutions=10000,
             )
         result_sa = ls.solve(
             dummy,

--- a/discrete_optimization/generic_tools/ea/alternating_ga.py
+++ b/discrete_optimization/generic_tools/ea/alternating_ga.py
@@ -10,6 +10,7 @@ from discrete_optimization.generic_tools.do_problem import (
     Problem,
     build_aggreg_function_and_params_objective,
 )
+from discrete_optimization.generic_tools.do_solver import SolverDO
 from discrete_optimization.generic_tools.ea.ga import (
     DeapCrossover,
     DeapMutation,
@@ -21,7 +22,7 @@ from discrete_optimization.generic_tools.result_storage.result_storage import (
 )
 
 
-class AlternatingGa:
+class AlternatingGa(SolverDO):
     """Multi-encoding single objective GA
 
     Args:

--- a/discrete_optimization/generic_tools/ea/ga.py
+++ b/discrete_optimization/generic_tools/ea/ga.py
@@ -20,6 +20,7 @@ from discrete_optimization.generic_tools.do_problem import (
     lower_bound_vector_encoding_from_dict,
     upper_bound_vector_encoding_from_dict,
 )
+from discrete_optimization.generic_tools.do_solver import SolverDO
 from discrete_optimization.generic_tools.ea.deap_wrappers import generic_mutate_wrapper
 from discrete_optimization.generic_tools.result_storage.result_storage import (
     ResultStorage,
@@ -67,7 +68,7 @@ _default_mutations = {
 }
 
 
-class Ga:
+class Ga(SolverDO):
     """Single objective GA
 
     Args:

--- a/discrete_optimization/generic_tools/ea/nsga.py
+++ b/discrete_optimization/generic_tools/ea/nsga.py
@@ -20,6 +20,7 @@ from discrete_optimization.generic_tools.do_problem import (
     TypeAttribute,
     build_evaluate_function_aggregated,
 )
+from discrete_optimization.generic_tools.do_solver import SolverDO
 from discrete_optimization.generic_tools.ea.deap_wrappers import generic_mutate_wrapper
 from discrete_optimization.generic_tools.ea.ga import (
     DeapCrossover,
@@ -48,7 +49,7 @@ _default_mutations = {
 }
 
 
-class Nsga:
+class Nsga(SolverDO):
     """NSGA
 
     Args:

--- a/discrete_optimization/generic_tools/ls/hill_climber.py
+++ b/discrete_optimization/generic_tools/ls/hill_climber.py
@@ -36,7 +36,6 @@ class HillClimber:
         mode_mutation: ModeMutation,
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
         store_solution: bool = False,
-        nb_solutions: int = 1000,
     ):
         self.evaluator = evaluator
         self.mutator = mutator
@@ -54,7 +53,6 @@ class HillClimber:
             evaluator, params_objective_function=self.params_objective_function
         )
         self.store_solution = store_solution
-        self.nb_solutions = nb_solutions
 
     def solve(
         self,
@@ -152,7 +150,6 @@ class HillClimberPareto(HillClimber):
         mode_mutation: ModeMutation,
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
         store_solution: bool = False,
-        nb_solutions: int = 1000,
     ):
         super().__init__(
             evaluator=evaluator,
@@ -161,7 +158,6 @@ class HillClimberPareto(HillClimber):
             mode_mutation=mode_mutation,
             params_objective_function=params_objective_function,
             store_solution=store_solution,
-            nb_solutions=nb_solutions,
         )
 
     def solve(

--- a/discrete_optimization/generic_tools/ls/hill_climber.py
+++ b/discrete_optimization/generic_tools/ls/hill_climber.py
@@ -85,6 +85,7 @@ class HillClimber:
         cur_best_objective = objective
         init_time = time.time()
         self.restart_handler.best_fitness = objective
+        self.restart_handler.solution_best = initial_variable.copy()
         iteration = 0
         while iteration < nb_iteration_max:
             accept = False
@@ -183,6 +184,7 @@ class HillClimberPareto(HillClimber):
         cur_objective = objective
         cur_best_objective = objective
         self.restart_handler.best_fitness = objective
+        self.restart_handler.solution_best = initial_variable.copy()
         iteration = 0
         while iteration < nb_iteration_max:
             accept = False

--- a/discrete_optimization/generic_tools/ls/hill_climber.py
+++ b/discrete_optimization/generic_tools/ls/hill_climber.py
@@ -15,6 +15,7 @@ from discrete_optimization.generic_tools.do_problem import (
     Solution,
     build_evaluate_function_aggregated,
 )
+from discrete_optimization.generic_tools.do_solver import SolverDO
 from discrete_optimization.generic_tools.ls.local_search import (
     ModeMutation,
     RestartHandler,
@@ -27,7 +28,7 @@ from discrete_optimization.generic_tools.result_storage.result_storage import (
 logger = logging.getLogger(__name__)
 
 
-class HillClimber:
+class HillClimber(SolverDO):
     def __init__(
         self,
         evaluator: Problem,

--- a/discrete_optimization/generic_tools/ls/local_search.py
+++ b/discrete_optimization/generic_tools/ls/local_search.py
@@ -56,13 +56,9 @@ class RestartHandlerLimit(RestartHandler):
     def __init__(
         self,
         nb_iteration_no_improvement: int,
-        cur_solution: Solution,
-        cur_objective: fitness_class,
     ):
         RestartHandler.__init__(self)
         self.nb_iteration_no_improvement = nb_iteration_no_improvement
-        self.solution_best = cur_solution.copy()
-        self.best_fitness = cur_objective
 
     def restart(
         self, cur_solution: Solution, cur_objective: fitness_class

--- a/discrete_optimization/generic_tools/ls/simulated_annealing.py
+++ b/discrete_optimization/generic_tools/ls/simulated_annealing.py
@@ -110,6 +110,7 @@ class SimulatedAnnealing:
                 nb_best_store=1,
             )
         self.restart_handler.best_fitness = objective
+        self.restart_handler.solution_best = initial_variable.copy()
         iteration = 0
         while iteration < nb_iteration_max:
             local_improvement = False

--- a/discrete_optimization/generic_tools/ls/simulated_annealing.py
+++ b/discrete_optimization/generic_tools/ls/simulated_annealing.py
@@ -51,7 +51,6 @@ class SimulatedAnnealing:
         mode_mutation: ModeMutation,
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
         store_solution: bool = False,
-        nb_solutions: int = 1000,
     ):
         self.evaluator = evaluator
         self.mutator = mutator
@@ -76,7 +75,6 @@ class SimulatedAnnealing:
             )
         self.mode_optim = self.params_objective_function.sense_function
         self.store_solution = store_solution
-        self.nb_solutions = nb_solutions
 
     def solve(
         self,

--- a/discrete_optimization/generic_tools/ls/simulated_annealing.py
+++ b/discrete_optimization/generic_tools/ls/simulated_annealing.py
@@ -20,6 +20,7 @@ from discrete_optimization.generic_tools.do_problem import (
     Solution,
     build_aggreg_function_and_params_objective,
 )
+from discrete_optimization.generic_tools.do_solver import SolverDO
 from discrete_optimization.generic_tools.ls.local_search import (
     ModeMutation,
     RestartHandler,
@@ -41,7 +42,7 @@ class TemperatureScheduling:
         ...
 
 
-class SimulatedAnnealing:
+class SimulatedAnnealing(SolverDO):
     def __init__(
         self,
         evaluator: Problem,

--- a/discrete_optimization/generic_tools/robustness/robustness_tool.py
+++ b/discrete_optimization/generic_tools/robustness/robustness_tool.py
@@ -207,7 +207,6 @@ def solve_model(
             mode_mutation=ModeMutation.MUTATE,
             params_objective_function=params_objective_function,
             store_solution=True,
-            nb_solutions=10000,
         )
         result_ls = sa.solve(dummy, nb_iteration_max=nb_iteration, pickle_result=False)
     else:
@@ -231,7 +230,6 @@ def solve_model(
             params_objective_function=params_objective_function,
             mode_mutation=ModeMutation.MUTATE,
             store_solution=True,
-            nb_solutions=10000,
         )
         result_ls = sa_mo.solve(
             dummy,

--- a/discrete_optimization/generic_tools/robustness/robustness_tool.py
+++ b/discrete_optimization/generic_tools/robustness/robustness_tool.py
@@ -194,9 +194,7 @@ def solve_model(
         aggreg_sol, _, _ = build_aggreg_function_and_params_objective(  # type: ignore
             model, params_objective_function
         )
-        res = RestartHandlerLimit(
-            200, cur_solution=dummy, cur_objective=aggreg_sol(dummy)
-        )
+        res = RestartHandlerLimit(200)
         sa = SimulatedAnnealing(
             evaluator=model,
             mutator=mixed_mutation,
@@ -220,9 +218,7 @@ def solve_model(
         aggreg_sol2, _, _ = build_aggreg_function_and_params_objective(  # type: ignore
             model, params_objective_function
         )
-        res = RestartHandlerLimit(
-            200, cur_solution=dummy, cur_objective=aggreg_sol2(dummy)
-        )
+        res = RestartHandlerLimit(200)
         sa_mo = HillClimberPareto(
             evaluator=model,
             mutator=mixed_mutation,

--- a/discrete_optimization/rcpsp/solver/rcpsp_lp_lns_solver.py
+++ b/discrete_optimization/rcpsp/solver/rcpsp_lp_lns_solver.py
@@ -138,7 +138,6 @@ class InitialSolutionRCPSP(InitialSolution):
                 mode_mutation=ModeMutation.MUTATE,
                 params_objective_function=self.params_objective_function,
                 store_solution=True,
-                nb_solutions=10000,
             )
             store_solution = sa.solve(
                 dummy, nb_iteration_max=10000, pickle_result=False

--- a/discrete_optimization/rcpsp/solver/rcpsp_lp_lns_solver.py
+++ b/discrete_optimization/rcpsp/solver/rcpsp_lp_lns_solver.py
@@ -127,9 +127,7 @@ class InitialSolutionRCPSP(InitialSolution):
             mixed_mutation = BasicPortfolioMutation(
                 list_mutation, np.ones((len(list_mutation)))
             )
-            res = RestartHandlerLimit(
-                500, cur_solution=dummy, cur_objective=self.problem.evaluate(dummy)
-            )
+            res = RestartHandlerLimit(500)
             sa = SimulatedAnnealing(
                 evaluator=self.problem,
                 mutator=mixed_mutation,

--- a/examples/knapsack/knapsack_multidimensional.py
+++ b/examples/knapsack/knapsack_multidimensional.py
@@ -71,7 +71,7 @@ def run_ls(multiscenario_model):
     mixed_mutation = BasicPortfolioMutation(
         list_mutation, np.ones((len(list_mutation)))
     )
-    res = RestartHandlerLimit(3000, solution, multiscenario_model.evaluate(solution))
+    res = RestartHandlerLimit(3000)
     sa = SimulatedAnnealing(
         evaluator=multiscenario_model,
         mutator=mixed_mutation,

--- a/examples/knapsack/multiscenario_knap.py
+++ b/examples/knapsack/multiscenario_knap.py
@@ -58,7 +58,7 @@ def initialize_multiscenario():
     mixed_mutation = BasicPortfolioMutation(
         list_mutation, np.ones((len(list_mutation)))
     )
-    res = RestartHandlerLimit(3000, solution, multiscenario_model.evaluate(solution))
+    res = RestartHandlerLimit(3000)
     sa = SimulatedAnnealing(
         evaluator=multiscenario_model,
         mutator=mixed_mutation,

--- a/examples/pickup_vrp/cp_solver_gpdp_example.py
+++ b/examples/pickup_vrp/cp_solver_gpdp_example.py
@@ -1665,7 +1665,7 @@ def run_tsp():
     )
     solution = tsp_model.get_random_dummy_solution()
     _, list_mutation = get_available_mutations(tsp_model, solution)
-    res = RestartHandlerLimit(3000, solution, tsp_model.evaluate(solution)["length"])
+    res = RestartHandlerLimit(3000)
     print(list_mutation)
     list_mutation = [
         mutate[0].build(tsp_model, solution, attribute="permutation", **mutate[1])

--- a/examples/rcpsp/robustness_experiments.py
+++ b/examples/rcpsp/robustness_experiments.py
@@ -156,7 +156,6 @@ def run_cp_multiscenario():
             temperature=1, restart_handler=res, coefficient=0.9999
         ),
         store_solution=True,
-        nb_solutions=10000000,
     )
     result_sa = simulated_annealing.solve(initial_variable=dummy, nb_iteration_max=300)
     best_solution: RCPSPSolution = result_sa.get_best_solution()
@@ -223,7 +222,6 @@ def local_search_postpro_multiobj_multimode(postpro=True):
             mode_mutation=ModeMutation.MUTATE,
             params_objective_function=params_objective_function,
             store_solution=True,
-            nb_solutions=10000,
         )
         result_ls = sa.solve(dummy, nb_iteration_max=2000, pickle_result=False)
     else:
@@ -240,7 +238,6 @@ def local_search_postpro_multiobj_multimode(postpro=True):
             params_objective_function=params_objective_function,
             mode_mutation=ModeMutation.MUTATE,
             store_solution=True,
-            nb_solutions=10000,
         )
         result_ls = sa.solve(
             dummy,
@@ -360,7 +357,6 @@ def solve_model(model, postpro=True, nb_iteration=500):
             mode_mutation=ModeMutation.MUTATE,
             params_objective_function=params_objective_function,
             store_solution=True,
-            nb_solutions=10000,
         )
         result_ls = sa.solve(dummy, nb_iteration_max=nb_iteration, pickle_result=False)
     else:
@@ -377,7 +373,6 @@ def solve_model(model, postpro=True, nb_iteration=500):
             params_objective_function=params_objective_function,
             mode_mutation=ModeMutation.MUTATE,
             store_solution=True,
-            nb_solutions=10000,
         )
         result_ls = sa.solve(
             dummy,

--- a/examples/rcpsp/robustness_experiments.py
+++ b/examples/rcpsp/robustness_experiments.py
@@ -144,9 +144,7 @@ def run_cp_multiscenario():
     mixed_mutation = BasicPortfolioMutation(
         list_mutation, np.ones((len(list_mutation)))
     )
-    res = RestartHandlerLimit(
-        500, cur_solution=dummy, cur_objective=model_aggreg_mean.evaluate(dummy)
-    )
+    res = RestartHandlerLimit(500)
     simulated_annealing = SimulatedAnnealing(
         evaluator=model_aggreg_mean,
         mutator=mixed_mutation,
@@ -200,9 +198,7 @@ def local_search_postpro_multiobj_multimode(postpro=True):
     mixed_mutation = BasicPortfolioMutation(
         list_mutation, np.ones((len(list_mutation)))
     )
-    res = RestartHandlerLimit(
-        500, cur_solution=dummy, cur_objective=rcpsp_model.evaluate(dummy)
-    )
+    res = RestartHandlerLimit(500)
     objectives = ["makespan", "mean_resource_reserve"]
     objective_weights = [-1, 5]
     if postpro:
@@ -335,9 +331,7 @@ def solve_model(model, postpro=True, nb_iteration=500):
     mixed_mutation = BasicPortfolioMutation(
         list_mutation, np.ones((len(list_mutation)))
     )
-    res = RestartHandlerLimit(
-        500, cur_solution=dummy, cur_objective=model.evaluate(dummy)
-    )
+    res = RestartHandlerLimit(500)
     objectives = ["makespan"]
     objective_weights = [-1]
     if postpro:

--- a/tests/knapsack/test_knapsack_ls_solver.py
+++ b/tests/knapsack/test_knapsack_ls_solver.py
@@ -74,7 +74,6 @@ def test_hc_knapsack_multiobj():
         mode_mutation=ModeMutation.MUTATE,
         params_objective_function=params_objective_function,
         store_solution=True,
-        nb_solutions=50000,
     )
     result_sa = sa.solve(
         initial_variable=solution,

--- a/tests/knapsack/test_knapsack_ls_solver.py
+++ b/tests/knapsack/test_knapsack_ls_solver.py
@@ -40,7 +40,7 @@ def test_sa_knapsack():
     mixed_mutation = BasicPortfolioMutation(
         list_mutation, np.ones((len(list_mutation)))
     )
-    res = RestartHandlerLimit(3000, solution, model.evaluate(solution))
+    res = RestartHandlerLimit(3000)
     sa = SimulatedAnnealing(
         evaluator=model,
         mutator=mixed_mutation,
@@ -65,7 +65,7 @@ def test_hc_knapsack_multiobj():
     mixed_mutation = BasicPortfolioMutation(
         list_mutation, np.ones((len(list_mutation)))
     )
-    res = RestartHandlerLimit(3000, solution, model.evaluate(solution))
+    res = RestartHandlerLimit(3000)
     params_objective_function = get_default_objective_setup(model)
     sa = HillClimberPareto(
         evaluator=model,

--- a/tests/rcpsp/solver/test_rcpsp_local_search.py
+++ b/tests/rcpsp/solver/test_rcpsp_local_search.py
@@ -65,9 +65,7 @@ def test_local_search_sm(random_seed):
     objectives = ["makespan"]
     objectives = ["mean_resource_reserve"]
     objective_weights = [-1]
-    res = RestartHandlerLimit(
-        200, cur_solution=dummy, cur_objective=rcpsp_model.evaluate(dummy)
-    )
+    res = RestartHandlerLimit(200)
     params_objective_function = ParamsObjectiveFunction(
         objective_handling=ObjectiveHandling.AGGREGATE,
         objectives=objectives,
@@ -117,9 +115,7 @@ def test_local_search_mm(random_seed):
     )
     objectives = ["makespan"]
     objective_weights = [-1]
-    res = RestartHandlerLimit(
-        200, cur_solution=dummy, cur_objective=rcpsp_model.evaluate(dummy)
-    )
+    res = RestartHandlerLimit(200)
     params_objective_function = ParamsObjectiveFunction(
         objective_handling=ObjectiveHandling.AGGREGATE,
         objectives=objectives,
@@ -165,9 +161,7 @@ def test_local_search_sm_multiobj(random_seed):
     mixed_mutation = BasicPortfolioMutation(
         list_mutation, np.ones((len(list_mutation)))
     )
-    res = RestartHandlerLimit(
-        200, cur_solution=dummy, cur_objective=rcpsp_model.evaluate(dummy)
-    )
+    res = RestartHandlerLimit(200)
     objectives = ["makespan", "mean_resource_reserve"]
     objective_weights = [-1, 1]
     params_objective_function = ParamsObjectiveFunction(
@@ -205,9 +199,7 @@ def test_local_search_sm_postpro_multiobj(random_seed):
     mixed_mutation = BasicPortfolioMutation(
         list_mutation, np.ones((len(list_mutation)))
     )
-    res = RestartHandlerLimit(
-        500, cur_solution=dummy, cur_objective=rcpsp_model.evaluate(dummy)
-    )
+    res = RestartHandlerLimit(500)
     objectives = ["makespan", "mean_resource_reserve"]
     objective_weights = [-1, 100]
     params_objective_function = ParamsObjectiveFunction(
@@ -269,9 +261,7 @@ def test_local_search_mm_multiobj(random_seed):
     mixed_mutation = BasicPortfolioMutation(
         list_mutation, np.ones((len(list_mutation)))
     )
-    res = RestartHandlerLimit(
-        200, cur_solution=dummy, cur_objective=rcpsp_model.evaluate(dummy)
-    )
+    res = RestartHandlerLimit(200)
     objectives = ["makespan", "mean_resource_reserve"]
     objective_weights = [-1, 100]
     params_objective_function = ParamsObjectiveFunction(
@@ -340,9 +330,7 @@ def test_local_search_postpro_multiobj_multimode(random_seed):
     mixed_mutation = BasicPortfolioMutation(
         list_mutation, np.ones((len(list_mutation)))
     )
-    res = RestartHandlerLimit(
-        500, cur_solution=dummy, cur_objective=rcpsp_model.evaluate(dummy)
-    )
+    res = RestartHandlerLimit(500)
     objectives = ["makespan", "mean_resource_reserve"]
     objective_weights = [-1, 100]
     params_objective_function = ParamsObjectiveFunction(

--- a/tests/rcpsp/solver/test_rcpsp_local_search.py
+++ b/tests/rcpsp/solver/test_rcpsp_local_search.py
@@ -82,7 +82,6 @@ def test_local_search_sm(random_seed):
         mode_mutation=ModeMutation.MUTATE,
         params_objective_function=params_objective_function,
         store_solution=False,
-        nb_solutions=10,
     )
 
     sol = sa.solve(dummy, nb_iteration_max=500, pickle_result=False).get_best_solution()
@@ -135,7 +134,6 @@ def test_local_search_mm(random_seed):
         mode_mutation=ModeMutation.MUTATE,
         params_objective_function=params_objective_function,
         store_solution=False,
-        nb_solutions=10,
     )
 
     sol = sa.solve(dummy, nb_iteration_max=300, pickle_result=False).get_best_solution()
@@ -185,7 +183,6 @@ def test_local_search_sm_multiobj(random_seed):
         params_objective_function=params_objective_function,
         mode_mutation=ModeMutation.MUTATE,
         store_solution=True,
-        nb_solutions=100,
     )
     pareto_store = sa.solve(
         dummy, nb_iteration_max=100, pickle_result=False, update_iteration_pareto=100
@@ -227,7 +224,6 @@ def test_local_search_sm_postpro_multiobj(random_seed):
         mode_mutation=ModeMutation.MUTATE,
         params_objective_function=params_objective_function,
         store_solution=True,
-        nb_solutions=100,
     )
     store = sa.solve(dummy, nb_iteration_max=100, pickle_result=False)
     pareto_store = result_storage_to_pareto_front(
@@ -291,7 +287,6 @@ def test_local_search_mm_multiobj(random_seed):
         params_objective_function=params_objective_function,
         mode_mutation=ModeMutation.MUTATE,
         store_solution=True,
-        nb_solutions=100,
     )
     pareto_store = sa.solve(
         dummy,
@@ -364,7 +359,6 @@ def test_local_search_postpro_multiobj_multimode(random_seed):
         mode_mutation=ModeMutation.MUTATE,
         params_objective_function=params_objective_function,
         store_solution=True,
-        nb_solutions=100,
     )
     result_sa = sa.solve(dummy, nb_iteration_max=100, pickle_result=False)
     result_sa.list_solution_fits = [

--- a/tests/tsp/test_tsp_ls.py
+++ b/tests/tsp/test_tsp_ls.py
@@ -35,7 +35,7 @@ def test_sa_2opt():
     params_objective_function = get_default_objective_setup(problem=model)
     solution = model.get_dummy_solution()
     _, list_mutation = get_available_mutations(model, solution)
-    res = RestartHandlerLimit(3000, solution, model.evaluate(solution))
+    res = RestartHandlerLimit(3000)
     list_mutation = [
         mutate[0].build(model, solution, attribute="permutation", **mutate[1])
         for mutate in list_mutation
@@ -66,7 +66,7 @@ def test_sa_partial_shuffle():
     params_objective_function = get_default_objective_setup(problem=model)
     solution = model.get_dummy_solution()
     _, list_mutation = get_available_mutations(model, solution)
-    res = RestartHandlerLimit(3000, solution, model.evaluate(solution))
+    res = RestartHandlerLimit(3000)
     list_mutation = [
         mutate[0].build(model, solution, attribute="permutation", **mutate[1])
         for mutate in list_mutation
@@ -96,7 +96,7 @@ def test_sa_swap():
     params_objective_function = get_default_objective_setup(problem=model)
     solution = model.get_dummy_solution()
     _, list_mutation = get_available_mutations(model, solution)
-    res = RestartHandlerLimit(3000, solution, model.evaluate(solution)["length"])
+    res = RestartHandlerLimit(3000)
     list_mutation = [
         mutate[0].build(model, solution, attribute="permutation", **mutate[1])
         for mutate in list_mutation
@@ -127,7 +127,7 @@ def test_sa_twoopttbasic():
     params_objective_function = get_default_objective_setup(problem=model)
     solution = model.get_dummy_solution()
     _, list_mutation = get_available_mutations(model, solution)
-    res = RestartHandlerLimit(3000, solution, model.evaluate(solution))
+    res = RestartHandlerLimit(3000)
     list_mutation = [
         mutate[0].build(model, solution, attribute="permutation", **mutate[1])
         for mutate in list_mutation
@@ -158,7 +158,7 @@ def test_hc():
     params_objective_function = get_default_objective_setup(problem=model)
     solution = model.get_dummy_solution()
     _, list_mutation = get_available_mutations(model, solution)
-    res = RestartHandlerLimit(100, solution, model.evaluate(solution))
+    res = RestartHandlerLimit(100)
     list_mutation = [
         mutate[0].build(model, solution, **mutate[1])
         for mutate in list_mutation


### PR DESCRIPTION
- Remove unused `nb_solutions` attribute from local search solvers
- Remove `current_solution` and `current_objective` from `RestartHandlerLimit.__init__()`: 
  objective was already overwritten during local search algo's `solve()` and generally badly initialized in examples (using `model.evaluate()` which gives a dictionary instead of a fitness value).
- Make local search solvers and genetic algorithms derive from SolverDO.