### PR TITLE
Fix update-doc-versions job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -539,6 +539,8 @@ jobs:
         with:
           ref: gh-pages
       - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
       - name: Generate versions.json
         shell: python3 {0}
         run: |
@@ -549,17 +551,15 @@ jobs:
           versions = sorted((item.name for item in cwd.iterdir()
                              if item.is_dir() and not item.name.startswith('.')),
                             reverse=True)
-          target_dir = Path('gh-pages')
-          target_dir.mkdir(parents=True)
-          target_file = target_dir / 'versions.json'
+          target_file = Path('versions.json')
           with target_file.open('w') as f:
               json.dump(versions, f)
       - name: Commit versions.json
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          branch: gh-pages # The branch the action should deploy to.
-          folder: gh-pages # The folder the action should deploy.
-          target-folder: / # The folder the action should deploy to.
-          commit-message: publish documentation
-          clean: false  # do not remove other files (including whole doc versions)
-          single-commit: true
+        shell: bash
+        run: |
+          # Commit versions.json and squash it with previous commit
+          git config user.name "Actions"
+          git config user.email "actions@github.com"
+          git add versions.json
+          git commit --amend --no-edit
+          git push -f origin gh-pages


### PR DESCRIPTION
The job was not working anymore since the squash enabled with single-commit = true option.
This is due to a bug in `JamesIves/github-pages-deploy-action`: https://github.com/JamesIves/github-pages-deploy-action/issues/1388#issuecomment-1886949424
Thus we commit and push manually versions.json to gh-pages.