### PR TITLE
Update ortools solvers

### DIFF
--- a/discrete_optimization/knapsack/solvers/lp_solvers.py
+++ b/discrete_optimization/knapsack/solvers/lp_solvers.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import mip
 from mip import BINARY, MAXIMIZE, xsum
-from ortools.algorithms import pywrapknapsack_solver
+from ortools.algorithms.python import knapsack_solver
 from ortools.linear_solver import pywraplp
 
 from discrete_optimization.generic_tools.do_problem import (
@@ -338,8 +338,8 @@ class KnapsackORTools(SolverKnapsack):
         )
 
     def init_model(self, **kwargs: Any) -> None:
-        solver = pywrapknapsack_solver.KnapsackSolver(
-            pywrapknapsack_solver.KnapsackSolver.KNAPSACK_MULTIDIMENSION_BRANCH_AND_BOUND_SOLVER,
+        solver = knapsack_solver.KnapsackSolver(
+            knapsack_solver.SolverType.KNAPSACK_MULTIDIMENSION_BRANCH_AND_BOUND_SOLVER,
             "KnapsackExample",
         )
         list_item = self.knapsack_model.list_items
@@ -347,7 +347,7 @@ class KnapsackORTools(SolverKnapsack):
         values = [item.value for item in list_item]
         weights = [[item.weight for item in list_item]]
         capacities = [max_capacity]
-        solver.Init(values, weights, capacities)
+        solver.init(values, weights, capacities)
         self.model = solver
 
     def solve(self, **kwargs: Any) -> ResultStorage:
@@ -357,13 +357,13 @@ class KnapsackORTools(SolverKnapsack):
                 raise RuntimeError(
                     "self.model must not be None after self.init_model()."
                 )
-        computed_value = self.model.Solve()
+        computed_value = self.model.solve()
         logger.debug(f"Total value = {computed_value}")
         xs = {}
         weight = 0
         value = 0
         for i in range(self.knapsack_model.nb_items):
-            if self.model.BestSolutionContains(i):
+            if self.model.best_solution_contains(i):
                 weight += self.knapsack_model.list_items[i].weight
                 value += self.knapsack_model.list_items[i].value
                 xs[self.knapsack_model.list_items[i].index] = 1

--- a/discrete_optimization/pickup_vrp/gpdp.py
+++ b/discrete_optimization/pickup_vrp/gpdp.py
@@ -66,6 +66,32 @@ class GPDPSolution(Solution):
             resource_evolution=self.resource_evolution,
         )
 
+    def check_pickup_deliverable(self) -> bool:
+        ok = True
+        for pickup, deliverable in self.problem.list_pickup_deliverable:
+            index_vehicles_pickup = set(
+                [
+                    [v for v, traj in self.trajectories.items() if p in traj][0]
+                    for p in pickup
+                ]
+            )
+            index_vehicles_deliverable = set(
+                [
+                    [v for v, traj in self.trajectories.items() if d in traj][0]
+                    for d in deliverable
+                ]
+            )
+            ok = ok and (
+                len(index_vehicles_pickup) == 1 and len(index_vehicles_deliverable) == 1
+            )
+            vehicle_p = list(index_vehicles_pickup)[0]
+            vehicle_d = list(index_vehicles_deliverable)[0]
+            ok = ok and vehicle_p == vehicle_d
+            index_p = [self.trajectories[vehicle_p].index(p) for p in pickup]
+            index_d = [self.trajectories[vehicle_d].index(d) for d in deliverable]
+            ok = ok and max(index_p) < min(index_d)
+            return ok
+
     def change_problem(self, new_problem: Problem) -> None:
         if not isinstance(new_problem, GPDP):
             raise ValueError("new_problem must be a GPDP for GPDPSolution.")

--- a/discrete_optimization/pickup_vrp/solver/ortools_solver.py
+++ b/discrete_optimization/pickup_vrp/solver/ortools_solver.py
@@ -882,13 +882,13 @@ class RoutingMonitor:
             f"New solution found : --Cur objective : {self.model.CostVar().Max()}"
         )
         logger.debug(status_description[self.model.status()])
-        if self.nb_solutions % 100 == 0:
-            self.retrieve_current_solution()
         if self.model.CostVar().Max() < self._best_objective:
             self._best_objective = self.model.CostVar().Max()
             self.retrieve_current_solution()
             self._counter = 0
         else:
+            if self.nb_solutions % 100 == 0:
+                self.retrieve_current_solution()
             self._counter += 1
             if self._counter > self._counter_limit:
                 self.model.solver().FinishCurrentSearch()

--- a/discrete_optimization/pickup_vrp/solver/ortools_solver.py
+++ b/discrete_optimization/pickup_vrp/solver/ortools_solver.py
@@ -136,12 +136,18 @@ https://developers.google.com/optimization/routing/routing_options#first_solutio
 
 
 status_description = {
-    0: "ROUTING_NOT_SOLVED",
-    1: "ROUTING_SUCCESS",
-    2: "ROUTING_FAIL",
-    3: "ROUTING_FAIL_TIMEOUT",
-    4: "ROUTING_INVALID",
+    val: key
+    for key, val in pywrapcp.RoutingModel.__dict__.items()
+    if key.startswith("ROUTING_")
 }
+"""Mapping from status integer to description string.
+
+This maps the integer returned by routing_model.status to the corresponding string.
+
+We use the attributes of RoutingModel to construct the dictionary.
+https://developers.google.com/optimization/routing/routing_options#search_status
+
+"""
 
 
 class ORToolsGPDP(SolverDO):

--- a/discrete_optimization/pickup_vrp/solver/ortools_solver.py
+++ b/discrete_optimization/pickup_vrp/solver/ortools_solver.py
@@ -1029,26 +1029,14 @@ def convert_to_gpdpsolution(
 
 
 def plot_ortools_solution(
-    result: Tuple[
-        Dict[int, List[int]],
-        Dict[Tuple[int, int, NodePosition], Dict[str, Tuple[float, float, float]]],
-        float,
-        float,
-        float,
-    ],
+    sol: GPDPSolution,
     problem: GPDP,
 ) -> Tuple[Figure, Axes]:
     if problem.coordinates_2d is None:
         raise ValueError(
             "problem.coordinates_2d cannot be None when calling plot_ortools_solution."
         )
-    (
-        vehicle_tours,
-        dimension_output,
-        route_distance,
-        objective,
-        cost,
-    ) = result
+    vehicle_tours = sol.trajectories
     fig, ax = plt.subplots(1)
     nb_colors = problem.number_vehicle
     nb_colors_clusters = len(problem.clusters_set)
@@ -1061,32 +1049,17 @@ def plot_ortools_solution(
             colors_nodes(problem.clusters_dict[node]) for node in problem.clusters_dict
         ],
     )
-    for v in range(len(vehicle_tours)):
+    for v, traj in vehicle_tours.items():
         ax.plot(
-            [
-                problem.coordinates_2d[problem.list_nodes[n]][0]
-                for n in vehicle_tours[v]
-            ],
-            [
-                problem.coordinates_2d[problem.list_nodes[n]][1]
-                for n in vehicle_tours[v]
-            ],
+            [problem.coordinates_2d[node][0] for node in traj],
+            [problem.coordinates_2d[node][1] for node in traj],
             label="vehicle n°" + str(v),
         )
         ax.scatter(
-            [
-                problem.coordinates_2d[problem.list_nodes[n]][0]
-                for n in vehicle_tours[v]
-            ],
-            [
-                problem.coordinates_2d[problem.list_nodes[n]][1]
-                for n in vehicle_tours[v]
-            ],
+            [problem.coordinates_2d[node][0] for node in traj],
+            [problem.coordinates_2d[node][1] for node in traj],
             s=10,
-            color=[
-                colors_nodes(problem.clusters_dict[problem.list_nodes[n]])
-                for n in vehicle_tours[v]
-            ],
+            color=[colors_nodes(problem.clusters_dict[node]) for node in traj],
         )
     ax.legend()
     return fig, ax

--- a/discrete_optimization/pickup_vrp/solver/ortools_solver.py
+++ b/discrete_optimization/pickup_vrp/solver/ortools_solver.py
@@ -103,57 +103,36 @@ def apply_cost(
                 )
 
 
-local_search_metaheuristic_enum = routing_enums_pb2.LocalSearchMetaheuristic
-metaheuristic_names = [
-    (k, getattr(local_search_metaheuristic_enum, k))
-    for k in local_search_metaheuristic_enum.__dict__.keys()
-    if isinstance(getattr(local_search_metaheuristic_enum, k), int)
-]
-name_metaheuristic_to_value = {x[0]: x[1] for x in metaheuristic_names}
-value_metaheuristic_to_name = {x[1]: x[0] for x in metaheuristic_names}
+LocalSearchMetaheuristic = Enum(
+    value="LocalSearchMetaheuristic",
+    names={
+        name: val.number
+        for name, val in routing_enums_pb2.LocalSearchMetaheuristic.DESCRIPTOR.enum_values_by_name.items()
+    },
+    module=__name__,  # to avoid pickle issues
+)
+"""Enumeration of local search meta-heuristic.
 
-first_solution_strategy_enum = routing_enums_pb2.FirstSolutionStrategy
-first_solution_names = [
-    (k, getattr(first_solution_strategy_enum, k))
-    for k in first_solution_strategy_enum.__dict__.keys()
-    if isinstance(getattr(first_solution_strategy_enum, k), int)
-]
-name_firstsolution_to_value = {x[0]: x[1] for x in first_solution_names}
-value_firstsolution_to_name = {x[1]: x[0] for x in first_solution_names}
+Extracted from ortools Enum-like class.
+https://developers.google.com/optimization/routing/routing_options#local_search_options
+
+"""
 
 
-class MetaheuristicEnum(Enum):
-    UNSET = "UNSET"
-    AUTOMATIC = "AUTOMATIC"
-    GREEDY_DESCENT = "GREEDY_DESCENT"
-    GUIDED_LOCAL_SEARCH = "GUIDED_LOCAL_SEARCH"
-    SIMULATED_ANNEALING = "SIMULATED_ANNEALING"
-    TABU_SEARCH = "TABU_SEARCH"
-    GENERIC_TABU_SEARCH = "GENERIC_TABU_SEARCH"
+FirstSolutionStrategy = Enum(
+    value="FirstSolutionStrategy",
+    names={
+        name: val.number
+        for name, val in routing_enums_pb2.FirstSolutionStrategy.DESCRIPTOR.enum_values_by_name.items()
+    },
+    module=__name__,  # to avoid pickle issues
+)
+"""Enumeration of first solution strategies.
 
+Extracted from ortools Enum-like class.
+https://developers.google.com/optimization/routing/routing_options#first_solution_strategy
 
-class FirstSolutionEnum(Enum):
-    UNSET = "UNSET"
-    AUTOMATIC = "AUTOMATIC"
-    PATH_CHEAPEST_ARC = "PATH_CHEAPEST_ARC"
-    PATH_MOST_CONSTRAINED_ARC = "PATH_MOST_CONSTRAINED_ARC"
-    EVALUATOR_STRATEGY = "EVALUATOR_STRATEGY"
-    SAVINGS = "SAVINGS"
-    SWEEP = "SWEEP"
-    CHRISTOFIDES = "CHRISTOFIDES"
-    ALL_UNPERFORMED = "ALL_UNPERFORMED"
-    BEST_INSERTION = "BEST_INSERTION"
-    PARALLEL_CHEAPEST_INSERTION = "PARALLEL_CHEAPEST_INSERTION"
-    SEQUENTIAL_CHEAPEST_INSERTION = "SEQUENTIAL_CHEAPEST_INSERTION"
-    LOCAL_CHEAPEST_INSERTION = "LOCAL_CHEAPEST_INSERTION"
-    GLOBAL_CHEAPEST_ARC = "GLOBAL_CHEAPEST_ARC"
-    LOCAL_CHEAPEST_ARC = "LOCAL_CHEAPEST_ARC"
-    FIRST_UNBOUND_MIN_VALUE = "FIRST_UNBOUND_MIN_VALUE"
-
-
-# LocalSearchMetaheuristic = Enum([k[0] for k in metaheuristic_names])
-# FirstSolutionStrategy = Enum([k[0] for k in first_solution_names])
-# https://developers.google.com/optimization/routing/routing_options
+"""
 
 
 status_description = {
@@ -787,13 +766,17 @@ class ORToolsGPDP(SolverDO):
     def build_search_parameters(
         self, **kwargs: Any
     ) -> routing_parameters_pb2.RoutingSearchParameters:
-        first_solution_strategy = kwargs.get(
-            "first_solution_strategy", first_solution_strategy_enum.SAVINGS
+        first_solution_strategy: Union[int, FirstSolutionStrategy] = kwargs.get(
+            "first_solution_strategy", FirstSolutionStrategy.SAVINGS
         )
+        if not isinstance(first_solution_strategy, int):
+            first_solution_strategy = int(first_solution_strategy.value)
         local_search_metaheuristic = kwargs.get(
             "local_search_metaheuristic",
-            local_search_metaheuristic_enum.GUIDED_LOCAL_SEARCH,
+            LocalSearchMetaheuristic.GUIDED_LOCAL_SEARCH,
         )
+        if not isinstance(local_search_metaheuristic, int):
+            local_search_metaheuristic = int(local_search_metaheuristic.value)
         one_visit_per_cluster = kwargs.get("one_visit_per_cluster", False)
 
         use_lns = kwargs.get("use_lns", True)

--- a/examples/pickup_vrp/loading_example.py
+++ b/examples/pickup_vrp/loading_example.py
@@ -26,10 +26,10 @@ from discrete_optimization.pickup_vrp.solver.lp_solver import (
     plot_solution,
 )
 from discrete_optimization.pickup_vrp.solver.ortools_solver import (
+    FirstSolutionStrategy,
+    LocalSearchMetaheuristic,
     ORToolsGPDP,
     ParametersCost,
-    first_solution_strategy_enum,
-    local_search_metaheuristic_enum,
     plot_ortools_solution,
 )
 
@@ -160,8 +160,8 @@ def run_ortools_solver_selective():
             for v in range(gpdp.number_vehicle)
         },
         parameters_cost=[ParametersCost(dimension_name="Distance")],
-        local_search_metaheuristic=local_search_metaheuristic_enum.GUIDED_LOCAL_SEARCH,
-        first_solution_strategy=first_solution_strategy_enum.SAVINGS,
+        local_search_metaheuristic=LocalSearchMetaheuristic.GUIDED_LOCAL_SEARCH,
+        first_solution_strategy=FirstSolutionStrategy.SAVINGS,
         time_limit=200,
         n_solutions=10000,
     )
@@ -224,8 +224,8 @@ def run_ortools_pickup_delivery():
             v: (len(model.all_nodes) // (4 * model.number_vehicle), None)
             for v in range(model.number_vehicle)
         },
-        local_search_metaheuristic=local_search_metaheuristic_enum.GUIDED_LOCAL_SEARCH,
-        first_solution_strategy=first_solution_strategy_enum.SAVINGS,
+        local_search_metaheuristic=LocalSearchMetaheuristic.GUIDED_LOCAL_SEARCH,
+        first_solution_strategy=FirstSolutionStrategy.SAVINGS,
         time_limit=100,
         n_solutions=10000,
     )
@@ -251,8 +251,8 @@ def run_ortools_pickup_delivery_cluster():
         include_pickup_and_delivery=False,
         include_mandatory=False,
         include_pickup_and_delivery_per_cluster=True,
-        local_search_metaheuristic=local_search_metaheuristic_enum.GUIDED_LOCAL_SEARCH,
-        first_solution_strategy=first_solution_strategy_enum.PARALLEL_CHEAPEST_INSERTION,
+        local_search_metaheuristic=LocalSearchMetaheuristic.GUIDED_LOCAL_SEARCH,
+        first_solution_strategy=FirstSolutionStrategy.PARALLEL_CHEAPEST_INSERTION,
         time_limit=30,
         n_solutions=10000,
     )

--- a/examples/pickup_vrp/time_windows_example.py
+++ b/examples/pickup_vrp/time_windows_example.py
@@ -9,10 +9,10 @@ import matplotlib.pyplot as plt
 from classic_ortools_example import create_matrix_data
 
 from discrete_optimization.pickup_vrp.solver.ortools_solver import (
+    FirstSolutionStrategy,
+    LocalSearchMetaheuristic,
     ORToolsGPDP,
     ParametersCost,
-    first_solution_strategy_enum,
-    local_search_metaheuristic_enum,
     plot_ortools_solution,
 )
 
@@ -35,8 +35,8 @@ def run_time_windows():
         include_mandatory=False,
         include_time_windows=True,
         include_time_windows_cluster=False,
-        local_search_metaheuristic=local_search_metaheuristic_enum.SIMULATED_ANNEALING,
-        first_solution_strategy=first_solution_strategy_enum.PATH_CHEAPEST_ARC,
+        local_search_metaheuristic=LocalSearchMetaheuristic.SIMULATED_ANNEALING,
+        first_solution_strategy=FirstSolutionStrategy.PATH_CHEAPEST_ARC,
         time_limit=45,
         n_solutions=200,
     )
@@ -64,8 +64,8 @@ def run_pickup():
         include_mandatory=False,
         include_time_windows=False,
         include_time_windows_cluster=False,
-        local_search_metaheuristic=local_search_metaheuristic_enum.TABU_SEARCH,
-        first_solution_strategy=first_solution_strategy_enum.PARALLEL_CHEAPEST_INSERTION,
+        local_search_metaheuristic=LocalSearchMetaheuristic.TABU_SEARCH,
+        first_solution_strategy=FirstSolutionStrategy.PARALLEL_CHEAPEST_INSERTION,
         time_limit=15,
         n_solutions=200,
     )
@@ -100,8 +100,8 @@ def run_demand():
         include_mandatory=False,
         include_time_windows=False,
         include_time_windows_cluster=False,
-        local_search_metaheuristic=local_search_metaheuristic_enum.SIMULATED_ANNEALING,
-        first_solution_strategy=first_solution_strategy_enum.PATH_CHEAPEST_ARC,
+        local_search_metaheuristic=LocalSearchMetaheuristic.SIMULATED_ANNEALING,
+        first_solution_strategy=FirstSolutionStrategy.PATH_CHEAPEST_ARC,
         time_limit=15,
         parameters_cost=list_parameters_cost,
         n_solutions=200,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "matplotlib>=3.1",
     "seaborn>=0.10.1",
     "pymzn>=0.18.3",
-    "ortools>=9.5,<9.6",
+    "ortools>=9.8",
     "tqdm>=4.62.3",
     "sortedcontainers>=2.4",
     "deprecation",

--- a/tests/pickup_vrp/builders/test_instance_builders.py
+++ b/tests/pickup_vrp/builders/test_instance_builders.py
@@ -7,7 +7,6 @@ from discrete_optimization.generic_tools.result_storage.result_storage import (
     ResultStorage,
 )
 from discrete_optimization.pickup_vrp.builders.instance_builders import (
-    GPDP,
     create_pickup_and_delivery,
     create_selective_tsp,
 )
@@ -19,24 +18,6 @@ from discrete_optimization.pickup_vrp.solver.ortools_solver import (
     ParametersCost,
     plot_ortools_solution,
 )
-
-
-def check_solution(res, gpdp: GPDP):
-    for p, d in gpdp.list_pickup_deliverable:
-        index_vehicles_p = set(
-            [[i for i in range(len(res)) if pp in res[i]][0] for pp in p]
-        )
-        index_vehicles_d = set(
-            [[i for i in range(len(res)) if dd in res[i]][0] for dd in d]
-        )
-        assert len(index_vehicles_p) == 1
-        assert len(index_vehicles_d) == 1
-        vehicle_p = list(index_vehicles_p)[0]
-        vehicle_d = list(index_vehicles_d)[0]
-        assert vehicle_p == vehicle_d
-        index_p = [res[vehicle_p].index(pp) for pp in p]
-        index_d = [res[vehicle_d].index(dd) for dd in d]
-        assert max(index_p) < min(index_d)
 
 
 def test_pickup_and_delivery():
@@ -69,54 +50,12 @@ def test_pickup_and_delivery():
         time_limit=100,
         n_solutions=10000,
     )
-    results = solver.solve_intern()
-    res_to_plot = min([r for r in results], key=lambda x: x[-1])
-    check_solution(res_to_plot[0], model)
-    plot_ortools_solution(res_to_plot, model)
-
-
-def test_pickup_and_delivery_equilibrate():
-    logging.basicConfig(level=logging.INFO)
-    model = create_pickup_and_delivery(
-        number_of_vehicles=4,
-        number_of_node=75,
-        include_pickup=True,
-        fraction_of_pickup_deliver=0.125,
-        include_cluster=False,
-        pickup_per_cluster=False,
-    )
-    list_params_cost = [
-        ParametersCost(
-            dimension_name="Distance",
-            global_span=True,
-            sum_over_vehicles=False,
-            coefficient_vehicles=10,
-        )
-    ]
-    solver = ORToolsGPDP(problem=model)
-    solver.init_model(
-        one_visit_per_cluster=False,
-        one_visit_per_node=True,
-        include_demand=False,
-        include_pickup_and_delivery=True,
-        parameters_cost=list_params_cost,
-        use_lns=True,
-        include_equilibrate_charge=True,
-        charge_constraint={
-            v: (
-                len(model.all_nodes) // (4 * model.number_vehicle),
-                int(0.5 * len(model.all_nodes)),
-            )
-            for v in range(model.number_vehicle)
-        },
-        local_search_metaheuristic=LocalSearchMetaheuristic.GUIDED_LOCAL_SEARCH,
-        first_solution_strategy=FirstSolutionStrategy.AUTOMATIC,
-        time_limit=1,
-        n_solutions=10000,
-    )
-    results = solver.solve_intern()
-    res_to_plot = min([r for r in results], key=lambda x: x[-1])
-    check_solution(res_to_plot[0], model)
+    result_storage: ResultStorage = solver.solve()
+    assert isinstance(result_storage, ResultStorage)
+    best_sol = result_storage.best_solution
+    assert isinstance(best_sol, GPDPSolution)
+    assert best_sol.check_pickup_deliverable()
+    plot_ortools_solution(best_sol, model)
 
 
 def test_pickup_and_delivery_equilibrate_new_api():
@@ -163,6 +102,7 @@ def test_pickup_and_delivery_equilibrate_new_api():
     assert isinstance(res, ResultStorage)
     sol = res.get_best_solution()
     assert isinstance(sol, GPDPSolution)
+    assert sol.check_pickup_deliverable()
     # check origin + target + times increasing for each trajectory
     for v, trajectory in sol.trajectories.items():
         assert trajectory[0] == model.origin_vehicle[v]
@@ -179,28 +119,6 @@ def test_pickup_and_delivery_equilibrate_new_api():
         nb_nodes_visited == number_of_nodes + 2 * number_of_vehicles
     )  # each node + origin and target of each vehicle
     assert len(sol.times) == nb_nodes_visited
-
-
-def test_selective_tsp():
-    gpdp = create_selective_tsp(nb_nodes=1000, nb_vehicles=1, nb_clusters=100)
-    solver = ORToolsGPDP(
-        problem=gpdp, factor_multiplier_distance=1, factor_multiplier_time=1
-    )
-    solver.init_model(
-        one_visit_per_cluster=True,
-        one_visit_per_node=False,
-        include_time_dimension=True,
-        include_demand=True,
-        include_mandatory=True,
-        include_pickup_and_delivery=False,
-        parameters_cost=[ParametersCost(dimension_name="Distance", global_span=True)],
-        local_search_metaheuristic=LocalSearchMetaheuristic.GUIDED_LOCAL_SEARCH,
-        first_solution_strategy=FirstSolutionStrategy.SAVINGS,
-        time_limit=20,
-        n_solutions=10000,
-    )
-    results = solver.solve_intern()
-    res_to_plot = min([r for r in results], key=lambda x: x[-1])
 
 
 def test_selective_tsp_new_api():

--- a/tests/pickup_vrp/builders/test_instance_builders.py
+++ b/tests/pickup_vrp/builders/test_instance_builders.py
@@ -13,10 +13,10 @@ from discrete_optimization.pickup_vrp.builders.instance_builders import (
 )
 from discrete_optimization.pickup_vrp.gpdp import GPDPSolution
 from discrete_optimization.pickup_vrp.solver.ortools_solver import (
+    FirstSolutionStrategy,
+    LocalSearchMetaheuristic,
     ORToolsGPDP,
     ParametersCost,
-    first_solution_strategy_enum,
-    local_search_metaheuristic_enum,
     plot_ortools_solution,
 )
 
@@ -64,8 +64,8 @@ def test_pickup_and_delivery():
         include_pickup_and_delivery=True,
         parameters_cost=list_params_cost,
         use_lns=True,
-        local_search_metaheuristic=local_search_metaheuristic_enum.GUIDED_LOCAL_SEARCH,
-        first_solution_strategy=first_solution_strategy_enum.SAVINGS,
+        local_search_metaheuristic=LocalSearchMetaheuristic.GUIDED_LOCAL_SEARCH,
+        first_solution_strategy=FirstSolutionStrategy.SAVINGS,
         time_limit=100,
         n_solutions=10000,
     )
@@ -109,8 +109,8 @@ def test_pickup_and_delivery_equilibrate():
             )
             for v in range(model.number_vehicle)
         },
-        local_search_metaheuristic=local_search_metaheuristic_enum.GUIDED_LOCAL_SEARCH,
-        first_solution_strategy=first_solution_strategy_enum.AUTOMATIC,
+        local_search_metaheuristic=LocalSearchMetaheuristic.GUIDED_LOCAL_SEARCH,
+        first_solution_strategy=FirstSolutionStrategy.AUTOMATIC,
         time_limit=1,
         n_solutions=10000,
     )
@@ -154,8 +154,8 @@ def test_pickup_and_delivery_equilibrate_new_api():
             )
             for v in range(model.number_vehicle)
         },
-        local_search_metaheuristic=local_search_metaheuristic_enum.GUIDED_LOCAL_SEARCH,
-        first_solution_strategy=first_solution_strategy_enum.AUTOMATIC,
+        local_search_metaheuristic=LocalSearchMetaheuristic.GUIDED_LOCAL_SEARCH,
+        first_solution_strategy=FirstSolutionStrategy.AUTOMATIC,
         time_limit=20,
         n_solutions=10000,
     )
@@ -194,8 +194,8 @@ def test_selective_tsp():
         include_mandatory=True,
         include_pickup_and_delivery=False,
         parameters_cost=[ParametersCost(dimension_name="Distance", global_span=True)],
-        local_search_metaheuristic=local_search_metaheuristic_enum.GUIDED_LOCAL_SEARCH,
-        first_solution_strategy=first_solution_strategy_enum.SAVINGS,
+        local_search_metaheuristic=LocalSearchMetaheuristic.GUIDED_LOCAL_SEARCH,
+        first_solution_strategy=FirstSolutionStrategy.SAVINGS,
         time_limit=20,
         n_solutions=10000,
     )
@@ -221,8 +221,8 @@ def test_selective_tsp_new_api():
         include_mandatory=True,
         include_pickup_and_delivery=False,
         parameters_cost=[ParametersCost(dimension_name="Distance", global_span=True)],
-        local_search_metaheuristic=local_search_metaheuristic_enum.GUIDED_LOCAL_SEARCH,
-        first_solution_strategy=first_solution_strategy_enum.SAVINGS,
+        local_search_metaheuristic=LocalSearchMetaheuristic.GUIDED_LOCAL_SEARCH,
+        first_solution_strategy=FirstSolutionStrategy.SAVINGS,
         time_limit=20,
         n_solutions=10000,
     )


### PR DESCRIPTION
- upgrade ortools dependency to >=9.8
- upgrade python minimal version to >=3.8 (ortools 9.8 does not exist for python<3.8 and python 3.7 is not maintained anymore)
- update knapsack solver based on ortools to adapt to the api changes
- update pickup_vrp solver based on ortools
  - construct firstsolutionstrategy and localsearchmetaheuristic enum from corresponding ortools pseudo enum
  - construct mapping from integer values to ortools solver status from ortools code
  - adapt tests and plot functions to work directly with ResultStorage and GPDPSolution instead of specific tuple
  - merge solve_intern into solve and construct directly resultstorage on the fly (could be useful to connect logging d-o callbacks or callbacks for hyperparamaters tuning with optuna)
  - fix ResultStorage.add_solution (needed by the previous item)