### PR TITLE
Adding VRP examples and test + update routing examples

### DIFF
--- a/discrete_optimization/vrp/solver/vrp_solver.py
+++ b/discrete_optimization/vrp/solver/vrp_solver.py
@@ -2,15 +2,31 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Any
+from typing import Any, Optional
 
+from discrete_optimization.generic_tools.do_problem import (
+    ParamsObjectiveFunction,
+    build_aggreg_function_and_params_objective,
+)
 from discrete_optimization.generic_tools.do_solver import SolverDO
 from discrete_optimization.vrp.vrp_model import VrpProblem
 
 
 class SolverVrp(SolverDO):
-    def __init__(self, vrp_model: VrpProblem, **kwargs: Any):
+    def __init__(
+        self,
+        vrp_model: VrpProblem,
+        params_objective_function: Optional[ParamsObjectiveFunction] = None,
+        **kwargs: Any
+    ):
         self.vrp_model = vrp_model
+        (
+            self.aggreg_sol,
+            self.aggreg_from_dict_values,
+            self.params_objective_function,
+        ) = build_aggreg_function_and_params_objective(
+            self.vrp_model, params_objective_function=params_objective_function
+        )
 
     def init_model(self, **kwargs: Any) -> None:
         pass

--- a/discrete_optimization/vrp/vrp_toolbox.py
+++ b/discrete_optimization/vrp/vrp_toolbox.py
@@ -46,6 +46,6 @@ def build_graph(vrp_model: VrpProblem) -> Tuple[nx.Graph, np.ndarray]:
     matrix_adjacency, matrix_distance = prune_search_space(
         vrp_model=vrp_model, n_shortest=vrp_model.customer_count
     )
-    G = nx.from_numpy_matrix(matrix_adjacency, create_using=nx.DiGraph)
+    G = nx.from_numpy_array(matrix_adjacency, create_using=nx.DiGraph)
     G.add_edge(0, 0, weight=0)
     return G, matrix_distance

--- a/examples/pickup_vrp/loading_example.py
+++ b/examples/pickup_vrp/loading_example.py
@@ -19,7 +19,12 @@ from discrete_optimization.pickup_vrp.builders.instance_builders import (
     create_pickup_and_delivery,
     create_selective_tsp,
 )
-from discrete_optimization.pickup_vrp.gpdp import GPDP, ProxyClass, build_pruned_problem
+from discrete_optimization.pickup_vrp.gpdp import (
+    GPDP,
+    GPDPSolution,
+    ProxyClass,
+    build_pruned_problem,
+)
 from discrete_optimization.pickup_vrp.solver.lp_solver import (
     LinearFlowSolver,
     ParametersMilp,
@@ -136,8 +141,8 @@ def run_ortools_solver():
         time_limit=10,
         n_solutions=100,
     )
-    results = solver.solve_intern()
-    plot_ortools_solution(results[0], gpdp)
+    results = solver.solve()
+    plot_ortools_solution(results.get_best_solution(), gpdp)
     plt.show()
     print(results)
 
@@ -165,31 +170,14 @@ def run_ortools_solver_selective():
         time_limit=200,
         n_solutions=10000,
     )
-    results = solver.solve_intern()
-    res_to_plot = min([r for r in results], key=lambda x: x[-1])
+    results = solver.solve()
+    res_to_plot = results.get_best_solution()
     plot_ortools_solution(res_to_plot, gpdp)
     plt.show()
     print(results)
 
 
 def run_ortools_pickup_delivery():
-    def check_solution(res, gpdp: GPDP):
-        for p, d in gpdp.list_pickup_deliverable:
-            index_vehicles_p = set(
-                [[i for i in range(len(res)) if pp in res[i]][0] for pp in p]
-            )
-            index_vehicles_d = set(
-                [[i for i in range(len(res)) if dd in res[i]][0] for dd in d]
-            )
-            assert len(index_vehicles_p) == 1
-            assert len(index_vehicles_d) == 1
-            vehicle_p = list(index_vehicles_p)[0]
-            vehicle_d = list(index_vehicles_d)[0]
-            assert vehicle_p == vehicle_d
-            index_p = [res[vehicle_p].index(pp) for pp in p]
-            index_d = [res[vehicle_d].index(dd) for dd in d]
-            assert max(index_p) < min(index_d)
-
     model = create_pickup_and_delivery(
         number_of_vehicles=4,
         number_of_node=100,
@@ -230,9 +218,10 @@ def run_ortools_pickup_delivery():
         n_solutions=10000,
     )
     logging.basicConfig(level=logging.DEBUG)
-    results = solver.solve_intern()
-    res_to_plot = min([r for r in results], key=lambda x: x[-1])
-    check_solution(res_to_plot[0], model)
+    results = solver.solve()
+    res_to_plot = results.get_best_solution()
+    res_to_plot: GPDPSolution
+    res_to_plot.check_pickup_deliverable()
     plot_ortools_solution(res_to_plot, model)
     plt.show()
 

--- a/examples/vrp/vrp_solver_example.py
+++ b/examples/vrp/vrp_solver_example.py
@@ -1,0 +1,65 @@
+import logging
+
+from discrete_optimization.vrp.solver.greedy_vrp import GreedyVRPSolver
+from discrete_optimization.vrp.solver.solver_ortools import (
+    FirstSolutionStrategy,
+    LocalSearchMetaheuristic,
+    VrpORToolsSolver,
+)
+from discrete_optimization.vrp.vrp_parser import (
+    get_data_available,
+    parse_file,
+    parse_input,
+)
+from discrete_optimization.vrp.vrp_solvers import VRPIterativeLP, VRPIterativeLP_Pymip
+
+
+def run_ortools_vrp_solver():
+    logging.basicConfig(level=logging.ERROR)
+    file_path = get_data_available()[0]
+    print(file_path)
+    vrp_model = parse_file(file_path)
+    print("Nb vehicle : ", vrp_model.vehicle_count)
+    print("Capacities : ", vrp_model.vehicle_capacities)
+    solver = VrpORToolsSolver(vrp_model=vrp_model)
+    solver.init_model(
+        first_solution_strategy=FirstSolutionStrategy.SAVINGS,
+        local_search_metaheuristic=LocalSearchMetaheuristic.GUIDED_LOCAL_SEARCH,
+    )
+    res = solver.solve(time_limit_seconds=20)
+    sol, fit = res.get_best_solution_fit()
+    print(vrp_model.evaluate(sol))
+    print(vrp_model.satisfy(sol))
+
+
+def run_lp_vrp_solver():
+    logging.basicConfig(level=logging.ERROR)
+    print(get_data_available())
+    file_path = [f for f in get_data_available() if "vrp_31_9_1" in f][0]
+    print(file_path)
+    vrp_model = parse_file(file_path)
+    print("Nb vehicle : ", vrp_model.vehicle_count)
+    print("Capacities : ", vrp_model.vehicle_capacities)
+    solver = VRPIterativeLP(vrp_model=vrp_model)
+    solver.init_model()
+    res = solver.solve(limit_time_s=20)
+    sol, fit = res.get_best_solution_fit()
+    print(vrp_model.evaluate(sol))
+    print(vrp_model.satisfy(sol))
+
+
+def run_greedy_vrp_solver():
+    logging.basicConfig(level=logging.ERROR)
+    print(get_data_available())
+    file_path = [f for f in get_data_available() if "vrp_31_9_1" in f][0]
+    print(file_path)
+    vrp_model = parse_file(file_path)
+    greedy_solver = GreedyVRPSolver(vrp_model=vrp_model, params_objective_function=None)
+    res = greedy_solver.solve(limit_time_s=20)
+    sol, fit = res.get_best_solution_fit()
+    print(vrp_model.evaluate(sol))
+    print(vrp_model.satisfy(sol))
+
+
+if __name__ == "__main__":
+    run_greedy_vrp_solver()

--- a/tests/vrp/test_vrp_solver.py
+++ b/tests/vrp/test_vrp_solver.py
@@ -11,7 +11,7 @@ from discrete_optimization.vrp.vrp_parser import get_data_available, parse_file
 
 def test_ortools_vrp_solver():
     logging.basicConfig(level=logging.ERROR)
-    file_path = get_data_available()[0]
+    file_path = [f for f in get_data_available() if "vrp_31_9_1" in f][0]
     vrp_model = parse_file(file_path)
     solver = VrpORToolsSolver(vrp_model=vrp_model)
     solver.init_model(
@@ -25,9 +25,7 @@ def test_ortools_vrp_solver():
 
 def test_greedy_vrp_solver():
     logging.basicConfig(level=logging.ERROR)
-    print(get_data_available())
     file_path = [f for f in get_data_available() if "vrp_31_9_1" in f][0]
-    print(file_path)
     vrp_model = parse_file(file_path)
     greedy_solver = GreedyVRPSolver(vrp_model=vrp_model, params_objective_function=None)
     res = greedy_solver.solve(limit_time_s=20)

--- a/tests/vrp/test_vrp_solver.py
+++ b/tests/vrp/test_vrp_solver.py
@@ -1,0 +1,40 @@
+import logging
+
+from discrete_optimization.vrp.solver.greedy_vrp import GreedyVRPSolver
+from discrete_optimization.vrp.solver.solver_ortools import (
+    FirstSolutionStrategy,
+    LocalSearchMetaheuristic,
+    VrpORToolsSolver,
+)
+from discrete_optimization.vrp.vrp_parser import (
+    get_data_available,
+    parse_file,
+    parse_input,
+)
+from discrete_optimization.vrp.vrp_solvers import VRPIterativeLP, VRPIterativeLP_Pymip
+
+
+def test_ortools_vrp_solver():
+    logging.basicConfig(level=logging.ERROR)
+    file_path = get_data_available()[0]
+    vrp_model = parse_file(file_path)
+    solver = VrpORToolsSolver(vrp_model=vrp_model)
+    solver.init_model(
+        first_solution_strategy=FirstSolutionStrategy.SAVINGS,
+        local_search_metaheuristic=LocalSearchMetaheuristic.GUIDED_LOCAL_SEARCH,
+    )
+    res = solver.solve(time_limit_seconds=20)
+    sol, fit = res.get_best_solution_fit()
+    assert vrp_model.satisfy(sol)
+
+
+def test_greedy_vrp_solver():
+    logging.basicConfig(level=logging.ERROR)
+    print(get_data_available())
+    file_path = [f for f in get_data_available() if "vrp_31_9_1" in f][0]
+    print(file_path)
+    vrp_model = parse_file(file_path)
+    greedy_solver = GreedyVRPSolver(vrp_model=vrp_model, params_objective_function=None)
+    res = greedy_solver.solve(limit_time_s=20)
+    sol, fit = res.get_best_solution_fit()
+    assert vrp_model.satisfy(sol)

--- a/tests/vrp/test_vrp_solver.py
+++ b/tests/vrp/test_vrp_solver.py
@@ -6,12 +6,7 @@ from discrete_optimization.vrp.solver.solver_ortools import (
     LocalSearchMetaheuristic,
     VrpORToolsSolver,
 )
-from discrete_optimization.vrp.vrp_parser import (
-    get_data_available,
-    parse_file,
-    parse_input,
-)
-from discrete_optimization.vrp.vrp_solvers import VRPIterativeLP, VRPIterativeLP_Pymip
+from discrete_optimization.vrp.vrp_parser import get_data_available, parse_file
 
 
 def test_ortools_vrp_solver():


### PR DESCRIPTION
- Some standalone example script for the vrp problem are implemented
- unit test for ortools and greedy vrp solver implemented
- Also took this PR to update the example of the pickup_vrp problems, closely related to classical VRP, so that they run well with latest change in the library.
- fix LP solver for VRP