### PR TITLE
Add callbacks in `SolverDO.solve()`

### DIFF
--- a/discrete_optimization/generic_rcpsp_tools/ls_solver.py
+++ b/discrete_optimization/generic_rcpsp_tools/ls_solver.py
@@ -119,7 +119,5 @@ class LS_RCPSP_Solver(SolverGenericRCPSP):
         result_sa = ls.solve(
             dummy,
             nb_iteration_max=kwargs.get("nb_iteration_max", 2000),
-            max_time_seconds=kwargs.get("max_time_seconds", None),
-            pickle_result=False,
         )
         return result_sa

--- a/discrete_optimization/generic_tools/callbacks/__init__.py
+++ b/discrete_optimization/generic_tools/callbacks/__init__.py
@@ -1,0 +1,3 @@
+#  Copyright (c) 2024 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.

--- a/discrete_optimization/generic_tools/callbacks/backup.py
+++ b/discrete_optimization/generic_tools/callbacks/backup.py
@@ -1,0 +1,29 @@
+#  Copyright (c) 2024 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+
+import logging
+import pickle
+from datetime import datetime
+from typing import Optional
+
+from discrete_optimization.generic_tools.callbacks.callback import Callback
+from discrete_optimization.generic_tools.do_solver import SolverDO
+from discrete_optimization.generic_tools.result_storage.result_storage import (
+    ResultStorage,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class PickleBestSolutionBackup(Callback):
+    def __init__(self, save_nb_steps: int, backup_path: str = "debug.pkl"):
+        self.backup_path = backup_path
+        self.save_nb_steps = save_nb_steps
+
+    def on_step_end(
+        self, step: int, res: ResultStorage, solver: SolverDO
+    ) -> Optional[bool]:
+        if step % self.save_nb_steps == 0:
+            logger.debug(f"Pickling best solution")
+            pickle.dump(res.best_solution, open(self.backup_path, "wb"))

--- a/discrete_optimization/generic_tools/callbacks/callback.py
+++ b/discrete_optimization/generic_tools/callbacks/callback.py
@@ -1,0 +1,117 @@
+#  Copyright (c) 2024 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations  # making annotations strings
+
+from typing import TYPE_CHECKING, Optional
+
+from discrete_optimization.generic_tools.result_storage.result_storage import (
+    ResultStorage,
+)
+
+if TYPE_CHECKING:  # avoid cycling imports due solely to annotations
+    from discrete_optimization.generic_tools.do_solver import SolverDO
+
+
+class Callback:
+    """Base class used to build new callbacks.
+
+    Callbacks can be passed to solvers `solve()` in order to hook into the various stages of the solve.
+
+
+    To create a custom callback, subclass `discrete_optimization.generic_tools.callbacks.Callback` and
+    override the method associated with the stage of interest.
+
+    """
+
+    def set_params(self, params):
+        self.params = params
+
+    def on_step_end(
+        self, step: int, res: ResultStorage, solver: SolverDO
+    ) -> Optional[bool]:
+        """Called at the end of an optimization step.
+
+        Args:
+            step: index of step
+            res: current result storage
+            solver: solvers using the callback
+
+        Returns:
+            If `True`, the optimization process is stopped, else it goes on.
+
+        """
+
+    def on_solve_start(self, solver: SolverDO):
+        """Called at the start of solve.
+
+        Args:
+            solver: solvers using the callback
+
+        """
+
+    def on_solve_end(self, res: ResultStorage, solver: SolverDO):
+        """Called at the end of solve.
+
+        Args:
+            res: current result storage
+            solver: solvers using the callback
+
+        """
+
+
+class CallbackList(Callback):
+    """Container abstracting a list of callbacks."""
+
+    def __init__(
+        self,
+        callbacks=None,
+        **params,
+    ):
+        """Container for `Callback` instances.
+
+        This object wraps a list of `Callback` instances, making it possible
+        to call them all at once via a single endpoint
+        (e.g. `callback_list.on_step_end(...)`).
+
+        Args:
+            callbacks: List of `Callback` instances.
+            **params: If provided, parameters will be passed to each `Callback`
+                via `Callback.set_params`.
+        """
+        if callbacks:
+            if isinstance(callbacks, Callback):
+                self.callbacks = [callbacks]
+            else:
+                self.callbacks = callbacks
+        else:
+            self.callbacks = []
+
+        if params:
+            self.set_params(params)
+
+    def append(self, callback):
+        self.callbacks.append(callback)
+
+    def set_params(self, params):
+        self.params = params
+        for callback in self.callbacks:
+            callback.set_params(params)
+
+    def on_step_end(
+        self, step: int, res: ResultStorage, solver: SolverDO
+    ) -> Optional[bool]:
+        stopping = False
+        for callback in self.callbacks:
+            decision = callback.on_step_end(step=step, res=res, solver=solver)
+            stopping = stopping or decision
+        return stopping
+
+    def on_solve_start(self, solver: SolverDO):
+        for callback in self.callbacks:
+            callback.on_solve_start(solver=solver)
+
+    def on_solve_end(self, res: ResultStorage, solver: SolverDO):
+        for callback in self.callbacks:
+            callback.on_solve_end(res=res, solver=solver)

--- a/discrete_optimization/generic_tools/callbacks/early_stoppers.py
+++ b/discrete_optimization/generic_tools/callbacks/early_stoppers.py
@@ -1,0 +1,49 @@
+#  Copyright (c) 2024 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+
+import logging
+from datetime import datetime
+from typing import Optional
+
+from discrete_optimization.generic_tools.callbacks.callback import Callback
+from discrete_optimization.generic_tools.do_solver import SolverDO
+from discrete_optimization.generic_tools.result_storage.result_storage import (
+    ResultStorage,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TimerStopper(Callback):
+    """
+    Stops the optimization process if a limit training time has been elapsed.
+    This time is checked after each `check_nb_steps` steps.
+    """
+
+    def __init__(self, total_seconds: int, check_nb_steps: int = 1):
+        """
+
+        Args:
+            total_seconds: Total time in seconds allowed to solve
+            check_nb_steps: Number of steps to wait before next time check
+
+        """
+        self.total_seconds = total_seconds
+        self.check_nb_steps = check_nb_steps
+
+    def on_solve_start(self, solver: SolverDO):
+        self.initial_training_time = datetime.utcnow()
+
+    def on_step_end(
+        self, step: int, res: ResultStorage, solver: SolverDO
+    ) -> Optional[bool]:
+        if step % self.check_nb_steps == 0:
+            current_time = datetime.utcnow()
+            difference = current_time - self.initial_training_time
+            difference_seconds = difference.total_seconds()
+
+            if difference_seconds >= self.total_seconds:
+                logger.info(f"{self.__class__.__name__} callback met its criteria")
+                return True
+        return False

--- a/discrete_optimization/generic_tools/callbacks/loggers.py
+++ b/discrete_optimization/generic_tools/callbacks/loggers.py
@@ -1,0 +1,51 @@
+#  Copyright (c) 2024 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+
+import logging
+from datetime import datetime
+from typing import Optional
+
+from discrete_optimization.generic_tools.callbacks.callback import Callback
+from discrete_optimization.generic_tools.do_solver import SolverDO
+from discrete_optimization.generic_tools.result_storage.result_storage import (
+    ResultStorage,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class NbIterationTracker(Callback):
+    """
+    Stops the optimization process if a limit training time has been elapsed.
+    This time is checked after each `check_nb_steps` steps.
+    """
+
+    def __init__(
+        self,
+        step_verbosity_level: int = logging.DEBUG,
+        end_verbosity_level: int = logging.INFO,
+    ):
+        """
+
+        Args:
+            step_verbosity_level:
+            end_verbosity_level:
+        """
+        self.step_verbosity_level = step_verbosity_level
+        self.end_verbosity_level = end_verbosity_level
+        self.nb_iteration = 0
+
+    def on_solve_end(self, res: ResultStorage, solver: SolverDO):
+        logger.log(
+            msg=f"Solve finished after {self.nb_iteration} iterations",
+            level=self.end_verbosity_level,
+        )
+
+    def on_step_end(
+        self, step: int, res: ResultStorage, solver: SolverDO
+    ) -> Optional[bool]:
+        self.nb_iteration += 1
+        logger.log(
+            msg=f"Iteration #{self.nb_iteration}", level=self.step_verbosity_level
+        )

--- a/discrete_optimization/generic_tools/do_solver.py
+++ b/discrete_optimization/generic_tools/do_solver.py
@@ -5,8 +5,9 @@
 #  LICENSE file in the root directory of this source tree.
 
 from abc import abstractmethod
-from typing import Any
+from typing import Any, List, Optional
 
+from discrete_optimization.generic_tools.callbacks.callback import Callback
 from discrete_optimization.generic_tools.result_storage.result_storage import (
     ResultStorage,
 )
@@ -16,11 +17,17 @@ class SolverDO:
     """Base class for a discrete-optimization solver."""
 
     @abstractmethod
-    def solve(self, **kwargs: Any) -> ResultStorage:
+    def solve(
+        self, callbacks: Optional[List[Callback]] = None, **kwargs: Any
+    ) -> ResultStorage:
         """Generic solving function.
 
         Args:
+            callbacks: list of callbacks used to hook into the various stage of the solve
             **kwargs: any argument specific to the solver
+
+        Solvers deriving from SolverDo should use callbacks methods .on_step_end(), ...
+        during solve(). But some solvers are not yet updated and are just ignoring it.
 
         Returns (ResultStorage): a result object containing potentially a pool of solutions
         to a discrete-optimization problem

--- a/discrete_optimization/generic_tools/ls/simulated_annealing.py
+++ b/discrete_optimization/generic_tools/ls/simulated_annealing.py
@@ -85,20 +85,15 @@ class SimulatedAnnealing(SolverDO):
         self,
         initial_variable: Solution,
         nb_iteration_max: int,
-        max_time_seconds: Optional[int] = None,
-        pickle_result: bool = False,
-        pickle_name: str = "debug",
         callbacks: Optional[List[Callback]] = None,
         **kwargs: Any,
     ) -> ResultStorage:
         callbacks_list = CallbackList(callbacks=callbacks)
 
-        init_time = time.time()
         objective = self.aggreg_from_dict_values(
             self.evaluator.evaluate(initial_variable)
         )
         cur_variable = initial_variable.copy()
-        cur_best_variable = initial_variable.copy()
         cur_objective = objective
         cur_best_objective = objective
         if self.store_solution:
@@ -169,7 +164,6 @@ class SimulatedAnnealing(SolverDO):
                 logger.info(f"iter {iteration}")
                 logger.info(f"new obj {objective} better than {cur_best_objective}")
                 cur_best_objective = objective
-                cur_best_variable = cur_variable.copy()
                 if not self.store_solution:
                     store.add_solution(cur_variable.copy(), objective)
             self.temperature_handler.next_temperature()
@@ -190,12 +184,6 @@ class SimulatedAnnealing(SolverDO):
             )
             if stopping:
                 break
-
-            if pickle_result and iteration % 20000 == 0:
-                pickle.dump(cur_best_variable, open(pickle_name + ".pk", "wb"))
-            if max_time_seconds is not None and iteration % 1000 == 0:
-                if time.time() - init_time > max_time_seconds:
-                    break
 
         store.finalize()
         # end of solve callback

--- a/discrete_optimization/generic_tools/robustness/robustness_tool.py
+++ b/discrete_optimization/generic_tools/robustness/robustness_tool.py
@@ -206,7 +206,7 @@ def solve_model(
             params_objective_function=params_objective_function,
             store_solution=True,
         )
-        result_ls = sa.solve(dummy, nb_iteration_max=nb_iteration, pickle_result=False)
+        result_ls = sa.solve(dummy, nb_iteration_max=nb_iteration)
     else:
         params_objective_function = ParamsObjectiveFunction(
             objective_handling=ObjectiveHandling.MULTI_OBJ,
@@ -230,7 +230,6 @@ def solve_model(
         result_ls = sa_mo.solve(
             dummy,
             nb_iteration_max=nb_iteration,
-            pickle_result=False,
             update_iteration_pareto=10000,
         )
     return result_ls

--- a/discrete_optimization/rcpsp/solver/rcpsp_lp_lns_solver.py
+++ b/discrete_optimization/rcpsp/solver/rcpsp_lp_lns_solver.py
@@ -137,9 +137,7 @@ class InitialSolutionRCPSP(InitialSolution):
                 params_objective_function=self.params_objective_function,
                 store_solution=True,
             )
-            store_solution = sa.solve(
-                dummy, nb_iteration_max=10000, pickle_result=False
-            )
+            store_solution = sa.solve(dummy, nb_iteration_max=10000)
         return store_solution
 
 

--- a/examples/knapsack/knapsack_multidimensional.py
+++ b/examples/knapsack/knapsack_multidimensional.py
@@ -82,7 +82,6 @@ def run_ls(multiscenario_model):
     return sa.solve(
         initial_variable=solution,
         nb_iteration_max=3000,
-        pickle_result=False,
     )
 
 

--- a/examples/knapsack/multiscenario_knap.py
+++ b/examples/knapsack/multiscenario_knap.py
@@ -69,7 +69,8 @@ def initialize_multiscenario():
 
     logging.basicConfig(level=logging.DEBUG)
     res = sa.solve(
-        initial_variable=solution, nb_iteration_max=5000, pickle_result=False
+        initial_variable=solution,
+        nb_iteration_max=5000,
     )
 
 

--- a/examples/rcpsp/robustness_experiments.py
+++ b/examples/rcpsp/robustness_experiments.py
@@ -219,7 +219,7 @@ def local_search_postpro_multiobj_multimode(postpro=True):
             params_objective_function=params_objective_function,
             store_solution=True,
         )
-        result_ls = sa.solve(dummy, nb_iteration_max=2000, pickle_result=False)
+        result_ls = sa.solve(dummy, nb_iteration_max=2000)
     else:
         params_objective_function = ParamsObjectiveFunction(
             objective_handling=ObjectiveHandling.MULTI_OBJ,
@@ -238,7 +238,6 @@ def local_search_postpro_multiobj_multimode(postpro=True):
         result_ls = sa.solve(
             dummy,
             nb_iteration_max=5000,
-            pickle_result=False,
             update_iteration_pareto=10000,
         )
     result_ls.list_solution_fits = [
@@ -352,7 +351,7 @@ def solve_model(model, postpro=True, nb_iteration=500):
             params_objective_function=params_objective_function,
             store_solution=True,
         )
-        result_ls = sa.solve(dummy, nb_iteration_max=nb_iteration, pickle_result=False)
+        result_ls = sa.solve(dummy, nb_iteration_max=nb_iteration)
     else:
         params_objective_function = ParamsObjectiveFunction(
             objective_handling=ObjectiveHandling.MULTI_OBJ,
@@ -371,7 +370,6 @@ def solve_model(model, postpro=True, nb_iteration=500):
         result_ls = sa.solve(
             dummy,
             nb_iteration_max=nb_iteration,
-            pickle_result=False,
             update_iteration_pareto=10000,
         )
     return result_ls

--- a/tests/generic_tools/callbacks/test_sa_with_callbacks.py
+++ b/tests/generic_tools/callbacks/test_sa_with_callbacks.py
@@ -1,0 +1,112 @@
+#  Copyright (c) 2024 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+
+
+import logging
+import os
+from time import sleep
+
+import numpy as np
+
+from discrete_optimization.generic_tools.callbacks.backup import (
+    PickleBestSolutionBackup,
+)
+from discrete_optimization.generic_tools.callbacks.callback import Callback
+from discrete_optimization.generic_tools.callbacks.early_stoppers import TimerStopper
+from discrete_optimization.generic_tools.callbacks.loggers import NbIterationTracker
+from discrete_optimization.generic_tools.do_problem import (
+    ModeOptim,
+    ObjectiveHandling,
+    ParamsObjectiveFunction,
+)
+from discrete_optimization.generic_tools.ls.local_search import RestartHandlerLimit
+from discrete_optimization.generic_tools.ls.simulated_annealing import (
+    ModeMutation,
+    SimulatedAnnealing,
+    TemperatureSchedulingFactor,
+)
+from discrete_optimization.generic_tools.mutations.mixed_mutation import (
+    BasicPortfolioMutation,
+)
+from discrete_optimization.generic_tools.mutations.mutation_catalog import (
+    PermutationMutationRCPSP,
+    get_available_mutations,
+)
+from discrete_optimization.rcpsp.rcpsp_model import RCPSPModel
+from discrete_optimization.rcpsp.rcpsp_parser import get_data_available, parse_file
+
+
+def test_sa_with_callbacks(caplog):
+    files = get_data_available()
+    files = [f for f in files if "j1010_1.mm" in f]  # Multi mode RCPSP
+    file_path = files[0]
+    rcpsp_model: RCPSPModel = parse_file(file_path)
+    rcpsp_model.set_fixed_modes([1 for i in range(rcpsp_model.n_jobs)])
+
+    dummy = rcpsp_model.get_dummy_solution()
+    _, mutations = get_available_mutations(rcpsp_model, dummy)
+    list_mutation = [
+        mutate[0].build(rcpsp_model, dummy, **mutate[1])
+        for mutate in mutations
+        if mutate[0] == PermutationMutationRCPSP
+    ]
+    mixed_mutation = BasicPortfolioMutation(
+        list_mutation, np.ones((len(list_mutation)))
+    )
+    objectives = ["makespan"]
+    objective_weights = [-1]
+    params_objective_function = ParamsObjectiveFunction(
+        objective_handling=ObjectiveHandling.AGGREGATE,
+        objectives=objectives,
+        weights=objective_weights,
+        sense_function=ModeOptim.MAXIMIZATION,
+    )
+
+    initial_temperature = 0.5
+    coefficient_temperature = 0.9999
+    nb_iteration_max = 1000
+    nb_iteration_no_improvement_max = 50
+
+    restart_handler = RestartHandlerLimit(
+        nb_iteration_no_improvement=nb_iteration_no_improvement_max
+    )
+    temperature_handler = TemperatureSchedulingFactor(
+        temperature=initial_temperature,
+        restart_handler=restart_handler,
+        coefficient=coefficient_temperature,
+    )
+
+    class SleepCallback(Callback):
+        def on_step_end(self, step: int, res, solver):
+            print("zzz")
+            sleep(1)
+
+    nb_iteration_tracker = NbIterationTracker()
+    backuper = PickleBestSolutionBackup(save_nb_steps=2)
+    callbacks = [
+        SleepCallback(),
+        TimerStopper(total_seconds=3, check_nb_steps=5),
+        nb_iteration_tracker,
+        backuper,
+    ]
+    sa = SimulatedAnnealing(
+        evaluator=rcpsp_model,
+        mutator=mixed_mutation,
+        restart_handler=restart_handler,
+        temperature_handler=temperature_handler,
+        mode_mutation=ModeMutation.MUTATE,
+        params_objective_function=params_objective_function,
+        store_solution=False,
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        sa.solve(
+            dummy,
+            nb_iteration_max=nb_iteration_max,
+            callbacks=callbacks,
+        ).get_best_solution_fit()
+
+    assert nb_iteration_tracker.nb_iteration == 5
+    assert os.path.isfile(backuper.backup_path)
+    assert len([line for line in caplog.text.splitlines() if "Pickling" in line]) == 2

--- a/tests/knapsack/test_knapsack_ls_solver.py
+++ b/tests/knapsack/test_knapsack_ls_solver.py
@@ -4,6 +4,7 @@
 
 import numpy as np
 
+from discrete_optimization.generic_tools.callbacks.early_stoppers import TimerStopper
 from discrete_optimization.generic_tools.do_problem import get_default_objective_setup
 from discrete_optimization.generic_tools.ls.hill_climber import HillClimberPareto
 from discrete_optimization.generic_tools.ls.local_search import RestartHandlerLimit
@@ -48,7 +49,11 @@ def test_sa_knapsack():
         temperature_handler=TemperatureSchedulingFactor(1000, res, 0.99),
         mode_mutation=ModeMutation.MUTATE,
     )
-    sa.solve(solution, 1000000, max_time_seconds=20, pickle_result=False)
+    sa.solve(
+        solution,
+        1000000,
+        callbacks=[TimerStopper(total_seconds=20, check_nb_steps=1000)],
+    )
 
 
 def test_hc_knapsack_multiobj():
@@ -78,9 +83,8 @@ def test_hc_knapsack_multiobj():
     result_sa = sa.solve(
         initial_variable=solution,
         nb_iteration_max=50000,
-        max_time_seconds=20,
         update_iteration_pareto=1000,
-        pickle_result=False,
+        callbacks=[TimerStopper(total_seconds=20, check_nb_steps=1000)],
     )
     pareto = result_sa
     pareto.len_pareto_front()

--- a/tests/rcpsp/solver/test_rcpsp_local_search.py
+++ b/tests/rcpsp/solver/test_rcpsp_local_search.py
@@ -82,7 +82,7 @@ def test_local_search_sm(random_seed):
         store_solution=False,
     )
 
-    sol = sa.solve(dummy, nb_iteration_max=500, pickle_result=False).get_best_solution()
+    sol = sa.solve(dummy, nb_iteration_max=500).get_best_solution()
     assert rcpsp_model.satisfy(sol)
     plot_ressource_view(
         rcpsp_model=rcpsp_model,
@@ -132,7 +132,7 @@ def test_local_search_mm(random_seed):
         store_solution=False,
     )
 
-    sol = sa.solve(dummy, nb_iteration_max=300, pickle_result=False).get_best_solution()
+    sol = sa.solve(dummy, nb_iteration_max=300).get_best_solution()
     assert rcpsp_model.satisfy(sol)
     plot_ressource_view(
         rcpsp_model=rcpsp_model,
@@ -178,9 +178,7 @@ def test_local_search_sm_multiobj(random_seed):
         mode_mutation=ModeMutation.MUTATE,
         store_solution=True,
     )
-    pareto_store = sa.solve(
-        dummy, nb_iteration_max=100, pickle_result=False, update_iteration_pareto=100
-    )
+    pareto_store = sa.solve(dummy, nb_iteration_max=100, update_iteration_pareto=100)
     assert isinstance(pareto_store, ParetoFront)
 
 
@@ -217,7 +215,7 @@ def test_local_search_sm_postpro_multiobj(random_seed):
         params_objective_function=params_objective_function,
         store_solution=True,
     )
-    store = sa.solve(dummy, nb_iteration_max=100, pickle_result=False)
+    store = sa.solve(dummy, nb_iteration_max=100)
     pareto_store = result_storage_to_pareto_front(
         result_storage=store, problem=rcpsp_model
     )
@@ -281,7 +279,6 @@ def test_local_search_mm_multiobj(random_seed):
     pareto_store = sa.solve(
         dummy,
         nb_iteration_max=500,
-        pickle_result=False,
         update_iteration_pareto=100,
     )
     assert isinstance(pareto_store, ParetoFront)
@@ -348,7 +345,7 @@ def test_local_search_postpro_multiobj_multimode(random_seed):
         params_objective_function=params_objective_function,
         store_solution=True,
     )
-    result_sa = sa.solve(dummy, nb_iteration_max=100, pickle_result=False)
+    result_sa = sa.solve(dummy, nb_iteration_max=100)
     result_sa.list_solution_fits = [
         l for l in result_sa.list_solution_fits if l[0].rcpsp_schedule_feasible
     ]


### PR DESCRIPTION
We create a Callback class to be used by solver.solve() to hook at some stages.

This will enable
- logging to tools like Tensorboard or Optuna
- timing out solvers
- early stopping
- discarding not promising trials during hyperparameters tuning

Callback has a few methods to overwrite in order to execute some code
- `on_solve_start()`: at the beginning of solve
- `on_solve_end()`: at the end of solve
- `on_step_end()`: at the end of each iteration

We are deeply inspired by work from others:

- keras: https://github.com/keras-team/keras/blob/v3.0.2/keras/callbacks/callback.py
- tensorflow: https://github.com/tensorflow/tensorflow/blob/cafa8f3bd9b5740d1d37db799eec3168edc7e97b/tensorflow/python/training/session_run_hook.py#L94
- or-tools: https://developers.google.com/optimization/reference/python/sat/python/cp_model#cp_model.CpSolverSolutionCallback
- sklearn-genetic-opt: https://github.com/rodrigo-arenas/Sklearn-genetic-opt/blob/0.10.1/sklearn_genetic/callbacks/base.py

In this PR, we only make local search algorithms use them, we will add gradually this possibility to all solvers.
We replace some features (logging, backup, and timer) previously used by local search algos by the use of some basic callbacks that we implement, as shown in test tests/generic_tools/callbacks/test_sa_with_callbacks.py.