### PR TITLE
Add callbacks to pickup_vrp ortools solver

### DIFF
--- a/discrete_optimization/generic_tools/callbacks/early_stoppers.py
+++ b/discrete_optimization/generic_tools/callbacks/early_stoppers.py
@@ -16,9 +16,11 @@ logger = logging.getLogger(__name__)
 
 
 class TimerStopper(Callback):
-    """
+    """Callback to stop the optimization after a given time.
+
     Stops the optimization process if a limit training time has been elapsed.
     This time is checked after each `check_nb_steps` steps.
+
     """
 
     def __init__(self, total_seconds: int, check_nb_steps: int = 1):
@@ -47,3 +49,23 @@ class TimerStopper(Callback):
                 logger.info(f"{self.__class__.__name__} callback met its criteria")
                 return True
         return False
+
+
+class NbIterationStopper(Callback):
+    """Callback to stop the optimization when a given number of solutions are found."""
+
+    def __init__(self, nb_iteration_max: int):
+        self.nb_iteration_max = nb_iteration_max
+        self.nb_iteration = 0
+
+    def on_step_end(
+        self, step: int, res: ResultStorage, solver: SolverDO
+    ) -> Optional[bool]:
+        self.nb_iteration += 1
+        if self.nb_iteration >= self.nb_iteration_max:
+            logger.info(
+                f"{self.__class__.__name__} callback met its criteria: max number of iterations reached"
+            )
+            return True
+        else:
+            return False

--- a/discrete_optimization/generic_tools/exceptions.py
+++ b/discrete_optimization/generic_tools/exceptions.py
@@ -1,0 +1,13 @@
+#  Copyright (c) 2024 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+
+
+class SolveEarlyStop(Exception):
+    """Exception used to stop some solvers
+
+    See for instance discrete_optimization.pickup_vrp.solver.ortools_solver.ORToolsGPDP.
+
+    """
+
+    ...

--- a/examples/pickup_vrp/loading_example.py
+++ b/examples/pickup_vrp/loading_example.py
@@ -134,12 +134,12 @@ def run_ortools_solver():
         one_visit_per_cluster=False,
         one_visit_per_node=True,
         time_limit=10,
-        n_solutions=100,
     )
-    results = solver.solve_intern()
-    plot_ortools_solution(results[0], gpdp)
+    result_storage = solver.solve()
+    best_sol = result_storage.best_solution
+    assert best_sol.check_pickup_deliverable()
+    plot_ortools_solution(best_sol, gpdp)
     plt.show()
-    print(results)
 
 
 def run_ortools_solver_selective():
@@ -163,13 +163,12 @@ def run_ortools_solver_selective():
         local_search_metaheuristic=LocalSearchMetaheuristic.GUIDED_LOCAL_SEARCH,
         first_solution_strategy=FirstSolutionStrategy.SAVINGS,
         time_limit=200,
-        n_solutions=10000,
     )
-    results = solver.solve_intern()
-    res_to_plot = min([r for r in results], key=lambda x: x[-1])
-    plot_ortools_solution(res_to_plot, gpdp)
+    result_storage = solver.solve()
+    best_sol = result_storage.best_solution
+    assert best_sol.check_pickup_deliverable()
+    plot_ortools_solution(best_sol, gpdp)
     plt.show()
-    print(results)
 
 
 def run_ortools_pickup_delivery():
@@ -227,13 +226,12 @@ def run_ortools_pickup_delivery():
         local_search_metaheuristic=LocalSearchMetaheuristic.GUIDED_LOCAL_SEARCH,
         first_solution_strategy=FirstSolutionStrategy.SAVINGS,
         time_limit=100,
-        n_solutions=10000,
     )
     logging.basicConfig(level=logging.DEBUG)
-    results = solver.solve_intern()
-    res_to_plot = min([r for r in results], key=lambda x: x[-1])
-    check_solution(res_to_plot[0], model)
-    plot_ortools_solution(res_to_plot, model)
+    result_storage = solver.solve()
+    best_sol = result_storage.best_solution
+    assert best_sol.check_pickup_deliverable()
+    plot_ortools_solution(best_sol, model)
     plt.show()
 
 
@@ -254,53 +252,11 @@ def run_ortools_pickup_delivery_cluster():
         local_search_metaheuristic=LocalSearchMetaheuristic.GUIDED_LOCAL_SEARCH,
         first_solution_strategy=FirstSolutionStrategy.PARALLEL_CHEAPEST_INSERTION,
         time_limit=30,
-        n_solutions=10000,
     )
-    results = solver.solve_intern()
-
-    def check_solution(res, gpdp: GPDP):
-        for p, d in gpdp.list_pickup_deliverable_per_cluster:
-            index_vehicles_p = []
-            for pp in p:
-                for node in gpdp.clusters_to_node[pp]:
-                    l = [i for i in range(len(res)) if node in res[i]]
-                    if len(l) > 0:
-                        index_vehicles_p += [l[0]]
-            index_vehicles_p = set(index_vehicles_p)
-            index_vehicles_d = []
-            for dd in d:
-                for node in gpdp.clusters_to_node[dd]:
-                    l = [i for i in range(len(res)) if node in res[i]]
-                    if len(l) > 0:
-                        index_vehicles_d += [l[0]]
-            index_vehicles_d = set(index_vehicles_d)
-            assert len(index_vehicles_p) == 1
-            assert len(index_vehicles_d) == 1
-            vehicle_p = list(index_vehicles_p)[0]
-            vehicle_d = list(index_vehicles_d)[0]
-            assert vehicle_p == vehicle_d
-            index_p = [
-                res[vehicle_p].index(node)
-                for pp in p
-                for node in gpdp.clusters_to_node[pp]
-                if node in res[vehicle_p]
-            ]
-            index_d = [
-                res[vehicle_d].index(node)
-                for dd in d
-                for node in gpdp.clusters_to_node[dd]
-                if node in res[vehicle_d]
-            ]
-            assert max(index_p) < min(index_d)
-
-    t_deb = time.time()
-    check_solution(results[-1][0], gpdp=gpdp)
-    t_end = time.time()
-    print(t_end - t_deb, " seconds check")
-    t_deb = time.time()
-    plot_ortools_solution(results[-1], gpdp)
-    t_end = time.time()
-    print(t_end - t_deb, " seconds plot")
+    result_storage = solver.solve()
+    best_sol = result_storage.best_solution
+    assert best_sol.check_pickup_deliverable()
+    plot_ortools_solution(best_sol, gpdp)
     plt.show()
 
 

--- a/examples/pickup_vrp/time_windows_example.py
+++ b/examples/pickup_vrp/time_windows_example.py
@@ -38,13 +38,11 @@ def run_time_windows():
         local_search_metaheuristic=LocalSearchMetaheuristic.SIMULATED_ANNEALING,
         first_solution_strategy=FirstSolutionStrategy.PATH_CHEAPEST_ARC,
         time_limit=45,
-        n_solutions=200,
     )
-    results = solver.solve_intern()
-    t_deb = time.time()
-    res_to_plot = min([r for r in results], key=lambda x: x[-1])
-    dimension_data = res_to_plot[1]
-    plot_ortools_solution(res_to_plot, gpdp)
+    result_storage = solver.solve()
+    best_sol = result_storage.best_solution
+    assert best_sol.check_pickup_deliverable()
+    plot_ortools_solution(best_sol, gpdp)
     plt.show()
 
 
@@ -67,12 +65,11 @@ def run_pickup():
         local_search_metaheuristic=LocalSearchMetaheuristic.TABU_SEARCH,
         first_solution_strategy=FirstSolutionStrategy.PARALLEL_CHEAPEST_INSERTION,
         time_limit=15,
-        n_solutions=200,
     )
-    results = solver.solve_intern()
-    t_deb = time.time()
-    res_to_plot = min([r for r in results], key=lambda x: x[-1])
-    plot_ortools_solution(res_to_plot, gpdp)
+    result_storage = solver.solve()
+    best_sol = result_storage.best_solution
+    assert best_sol.check_pickup_deliverable()
+    plot_ortools_solution(best_sol, gpdp)
     plt.show()
 
 
@@ -104,11 +101,11 @@ def run_demand():
         first_solution_strategy=FirstSolutionStrategy.PATH_CHEAPEST_ARC,
         time_limit=15,
         parameters_cost=list_parameters_cost,
-        n_solutions=200,
     )
-    results = solver.solve_intern()
-    res_to_plot = min([r for r in results], key=lambda x: x[-1])
-    plot_ortools_solution(res_to_plot, gpdp)
+    result_storage = solver.solve()
+    best_sol = result_storage.best_solution
+    assert best_sol.check_pickup_deliverable()
+    plot_ortools_solution(best_sol, gpdp)
     plt.show()
 
 

--- a/tests/generic_tools/callbacks/test_ortools_with_callbacks.py
+++ b/tests/generic_tools/callbacks/test_ortools_with_callbacks.py
@@ -1,0 +1,102 @@
+#  Copyright (c) 2024 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+
+import random
+from datetime import datetime
+
+import numpy as np
+import pytest
+
+from discrete_optimization.generic_tools.callbacks.early_stoppers import (
+    NbIterationStopper,
+)
+from discrete_optimization.generic_tools.do_problem import (
+    ModeOptim,
+    ObjectiveHandling,
+    ParamsObjectiveFunction,
+)
+from discrete_optimization.pickup_vrp.builders.instance_builders import (
+    GPDP,
+    create_selective_tsp,
+)
+from discrete_optimization.pickup_vrp.gpdp import GPDPSolution
+from discrete_optimization.pickup_vrp.solver.ortools_solver import (
+    FirstSolutionStrategy,
+    LocalSearchMetaheuristic,
+    ORToolsGPDP,
+    ParametersCost,
+)
+
+SEED = 42
+
+
+@pytest.fixture()
+def random_seed():
+    random.seed(SEED)
+    np.random.seed(SEED)
+    return SEED
+
+
+nb_nodes = 1000
+nb_vehicles = 1
+nb_clusters = 100
+
+
+def test_ortools_with_callbacks(random_seed):
+    gpdp: GPDP = create_selective_tsp(
+        nb_nodes=nb_nodes, nb_vehicles=nb_vehicles, nb_clusters=nb_clusters
+    )
+    params_objective_function = ParamsObjectiveFunction(
+        objective_handling=ObjectiveHandling.AGGREGATE,
+        objectives=["distance_max"],
+        weights=[1],
+        sense_function=ModeOptim.MINIMIZATION,
+    )
+    #  hyperparameters
+    first_solution_strategy_name = "LOCAL_CHEAPEST_INSERTION"
+    first_solution_strategy = FirstSolutionStrategy[first_solution_strategy_name]
+    local_search_metaheuristic_name = "SIMULATED_ANNEALING"
+    local_search_metaheuristic = LocalSearchMetaheuristic[
+        local_search_metaheuristic_name
+    ]
+    first_solution_strategy = FirstSolutionStrategy[first_solution_strategy_name]
+    use_lns = False
+    use_cp = True
+    use_cp_sat = True
+
+    #  solver init
+    solver = ORToolsGPDP(
+        problem=gpdp,
+        factor_multiplier_distance=1,
+        factor_multiplier_time=1,
+        params_objective_function=params_objective_function,
+    )
+    solver.init_model(
+        one_visit_per_cluster=True,
+        one_visit_per_node=False,
+        include_time_dimension=True,
+        include_demand=True,
+        include_mandatory=True,
+        include_pickup_and_delivery=False,
+        parameters_cost=[ParametersCost(dimension_name="Distance", global_span=True)],
+        local_search_metaheuristic=LocalSearchMetaheuristic.GUIDED_LOCAL_SEARCH,
+        first_solution_strategy=first_solution_strategy,
+        time_limit=60,
+        use_cp=use_cp,
+        use_lns=use_lns,
+        use_cp_sat=use_cp_sat,
+    )
+
+    # callbacks
+    nb_iteration_stopper = NbIterationStopper(nb_iteration_max=10)
+
+    #  solve
+    start_time = datetime.utcnow()
+    sol, fit = solver.solve(callbacks=[nb_iteration_stopper]).get_best_solution_fit()
+    end_time = datetime.utcnow()
+
+    assert isinstance(fit, float)
+    assert isinstance(sol, GPDPSolution)
+    assert nb_iteration_stopper.nb_iteration == 10
+    assert (end_time - start_time).total_seconds() < 30

--- a/tests/pickup_vrp/builders/test_instance_builders.py
+++ b/tests/pickup_vrp/builders/test_instance_builders.py
@@ -47,8 +47,7 @@ def test_pickup_and_delivery():
         use_lns=True,
         local_search_metaheuristic=LocalSearchMetaheuristic.GUIDED_LOCAL_SEARCH,
         first_solution_strategy=FirstSolutionStrategy.SAVINGS,
-        time_limit=100,
-        n_solutions=10000,
+        time_limit=5,
     )
     result_storage: ResultStorage = solver.solve()
     assert isinstance(result_storage, ResultStorage)
@@ -95,8 +94,7 @@ def test_pickup_and_delivery_equilibrate_new_api():
         },
         local_search_metaheuristic=LocalSearchMetaheuristic.GUIDED_LOCAL_SEARCH,
         first_solution_strategy=FirstSolutionStrategy.AUTOMATIC,
-        time_limit=20,
-        n_solutions=10000,
+        time_limit=5,
     )
     res = solver.solve()
     assert isinstance(res, ResultStorage)
@@ -141,8 +139,7 @@ def test_selective_tsp_new_api():
         parameters_cost=[ParametersCost(dimension_name="Distance", global_span=True)],
         local_search_metaheuristic=LocalSearchMetaheuristic.GUIDED_LOCAL_SEARCH,
         first_solution_strategy=FirstSolutionStrategy.SAVINGS,
-        time_limit=20,
-        n_solutions=10000,
+        time_limit=5,
     )
     res = solver.solve()
     assert isinstance(res, ResultStorage)

--- a/tests/pickup_vrp/solvers/test_ortools_solver.py
+++ b/tests/pickup_vrp/solvers/test_ortools_solver.py
@@ -1,0 +1,108 @@
+#  Copyright (c) 2024 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+
+import logging
+import random
+from datetime import datetime
+
+import numpy as np
+import pytest
+
+from discrete_optimization.generic_tools.callbacks.early_stoppers import TimerStopper
+from discrete_optimization.generic_tools.callbacks.loggers import NbIterationTracker
+from discrete_optimization.generic_tools.do_problem import (
+    ModeOptim,
+    ObjectiveHandling,
+    ParamsObjectiveFunction,
+)
+from discrete_optimization.generic_tools.result_storage.result_storage import (
+    ResultStorage,
+)
+from discrete_optimization.pickup_vrp.builders.instance_builders import (
+    GPDP,
+    create_selective_tsp,
+)
+from discrete_optimization.pickup_vrp.gpdp import GPDPSolution
+from discrete_optimization.pickup_vrp.solver.ortools_solver import (
+    FirstSolutionStrategy,
+    LocalSearchMetaheuristic,
+    ORToolsGPDP,
+    ParametersCost,
+)
+
+SEED = 42
+
+
+@pytest.fixture()
+def random_seed():
+    random.seed(SEED)
+    np.random.seed(SEED)
+    return SEED
+
+
+nb_nodes = 1000
+nb_vehicles = 1
+nb_clusters = 100
+
+
+def test_ortools_with_cb(random_seed):
+    gpdp: GPDP = create_selective_tsp(
+        nb_nodes=nb_nodes, nb_vehicles=nb_vehicles, nb_clusters=nb_clusters
+    )
+    params_objective_function = ParamsObjectiveFunction(
+        objective_handling=ObjectiveHandling.AGGREGATE,
+        objectives=["distance_max"],
+        weights=[1],
+        sense_function=ModeOptim.MINIMIZATION,
+    )
+    #  hyperparameters
+    first_solution_strategy_name = "LOCAL_CHEAPEST_INSERTION"
+    first_solution_strategy = FirstSolutionStrategy[first_solution_strategy_name]
+    local_search_metaheuristic_name = "SIMULATED_ANNEALING"
+    local_search_metaheuristic = LocalSearchMetaheuristic[
+        local_search_metaheuristic_name
+    ]
+    first_solution_strategy = FirstSolutionStrategy[first_solution_strategy_name]
+    use_lns = False
+    use_cp = True
+    use_cp_sat = True
+
+    #  solver init
+    solver = ORToolsGPDP(
+        problem=gpdp,
+        factor_multiplier_distance=1,
+        factor_multiplier_time=1,
+        params_objective_function=params_objective_function,
+    )
+    solver.init_model(
+        one_visit_per_cluster=True,
+        one_visit_per_node=False,
+        include_time_dimension=True,
+        include_demand=True,
+        include_mandatory=True,
+        include_pickup_and_delivery=False,
+        parameters_cost=[ParametersCost(dimension_name="Distance", global_span=True)],
+        local_search_metaheuristic=LocalSearchMetaheuristic.GUIDED_LOCAL_SEARCH,
+        first_solution_strategy=first_solution_strategy,
+        time_limit=5,
+        use_cp=use_cp,
+        use_lns=use_lns,
+        use_cp_sat=use_cp_sat,
+    )
+
+    # callbacks
+    nb_iteration_tracker = NbIterationTracker()
+    timer = TimerStopper(total_seconds=2, check_nb_steps=1)
+
+    start_time = datetime.utcnow()
+    #  solve
+    sol, fit = solver.solve(
+        callbacks=[nb_iteration_tracker, timer]
+    ).get_best_solution_fit()
+    end_time = datetime.utcnow()
+
+    assert isinstance(fit, float)
+    assert isinstance(sol, GPDPSolution)
+    assert nb_iteration_tracker.nb_iteration > 0
+    assert (end_time - start_time).total_seconds() < 5


### PR DESCRIPTION
- We plug the callbacks to ortools solver by making use of `SearchMonitor` object
  NB: the `on_step_end()` is plugged here in the `AtSolution()` ortools hook. Which means an iteration for d-o `Callback` corresponds to finding a feasible solution for ortools routing solver.
- We remove `n_solutions` parameters from `init_solve()` as 
  - it did not work as intended (should have stopped the solve process after finding `n_solutions` solutions);
  - it caused segfault when early stopping with callbacks the solve.
- We implement a `NbIterationStopper` callback which will stops the optimization when a given number of iterations is reached.
  NB: when using it with `ORToolsGPDP`, it will correspond to the number solutions found as we hooked in `AtSolution()`. So this will replace the previous `n_solutions` parameters.
- We add tests for ortools solver using such callbacks