### PR TITLE
Refactor ortools cp-sat based solvers

### DIFF
--- a/discrete_optimization/generic_tools/callbacks/early_stoppers.py
+++ b/discrete_optimization/generic_tools/callbacks/early_stoppers.py
@@ -44,7 +44,7 @@ class TimerStopper(Callback):
             current_time = datetime.utcnow()
             difference = current_time - self.initial_training_time
             difference_seconds = difference.total_seconds()
-
+            logger.debug(f"{difference_seconds} seconds elapsed since solve start.")
             if difference_seconds >= self.total_seconds:
                 logger.info(f"{self.__class__.__name__} callback met its criteria")
                 return True

--- a/discrete_optimization/generic_tools/ortools_cpsat_tools.py
+++ b/discrete_optimization/generic_tools/ortools_cpsat_tools.py
@@ -1,0 +1,148 @@
+#  Copyright (c) 2024 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+import logging
+from abc import abstractmethod
+from typing import Any, List, Optional
+
+from ortools.sat.python.cp_model import (
+    FEASIBLE,
+    INFEASIBLE,
+    OPTIMAL,
+    UNKNOWN,
+    CpModel,
+    CpSolver,
+    CpSolverSolutionCallback,
+)
+
+from discrete_optimization.generic_tools.callbacks.callback import (
+    Callback,
+    CallbackList,
+)
+from discrete_optimization.generic_tools.cp_tools import (
+    CPSolver,
+    ParametersCP,
+    StatusSolver,
+)
+from discrete_optimization.generic_tools.do_problem import Solution
+from discrete_optimization.generic_tools.exceptions import SolveEarlyStop
+from discrete_optimization.generic_tools.result_storage.result_storage import (
+    ResultStorage,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class OrtoolsCPSatSolver(CPSolver):
+    """Generic ortools cp-sat solver."""
+
+    cp_model: Optional[CpModel]
+
+    @abstractmethod
+    def retrieve_solution(self, cpsolvercb: CpSolverSolutionCallback) -> Solution:
+        """Construct a do solution from the cpsat solver internal solution.
+
+        It will be called each time the cpsat solver find a new solution.
+        At that point, value of internal variables are accessible via `cpsolvercb.Value(VARIABLE_NAME)`.
+
+        Args:
+            cpsolvercb: the ortools callback called when the cpsat solver finds a new solution.
+
+        Returns:
+            the intermediate solution, at do format.
+
+        """
+        ...
+
+    def solve(
+        self,
+        callbacks: Optional[List[Callback]] = None,
+        parameters_cp: Optional[ParametersCP] = None,
+        **kwargs: Any,
+    ) -> ResultStorage:
+        """Solve the problem with a CPSat solver drom ortools library.
+
+        Args:
+            callbacks: list of callbacks used to hook into the various stage of the solve
+            parameters_cp: parameters specific to cp solvers.
+                We use here only `parameters_cp.time_limit` and `parameters_cp.nb_process`.
+            **kwargs: keyword arguments passed to `self.init_model()`
+
+        Returns:
+
+        A dedicated ortools callback is used to:
+        - update a resultstorage each time a new solution is found by the cpsat solver.
+        - call the user (do) callbacks at each new solution, with the possibility of early stopping if the callback return True.
+
+        This ortools callback use the method `self.retrieve_solution()` to reconstruct a do Solution from the cpsat solve internal state.
+
+        """
+        callbacks_list = CallbackList(callbacks=callbacks)
+        callbacks_list.on_solve_start(solver=self)
+        if self.cp_model is None:
+            self.init_model(**kwargs)
+        if parameters_cp is None:
+            parameters_cp = ParametersCP.default()
+        solver = CpSolver()
+        solver.parameters.max_time_in_seconds = parameters_cp.time_limit
+        solver.parameters.num_workers = parameters_cp.nb_process
+        ortools_callback = OrtoolsCallback(do_solver=self, callback=callbacks_list)
+        try:
+            status = solver.Solve(self.cp_model, ortools_callback)
+            self.status_solver = cpstatus_to_dostatus(status_from_cpsat=status)
+        except SolveEarlyStop as e:
+            logger.info(e)
+            if ortools_callback.nb_solutions > 0:
+                status = StatusSolver.SATISFIED
+            else:
+                status = StatusSolver.UNSATISFIABLE
+            self.status_solver = cpstatus_to_dostatus(status_from_cpsat=status)
+        res = ortools_callback.res
+        callbacks_list.on_solve_end(res=res, solver=self)
+        return res
+
+
+class OrtoolsCallback(CpSolverSolutionCallback):
+    def __init__(self, do_solver: OrtoolsCPSatSolver, callback: Callback):
+        super().__init__()
+        self.do_solver = do_solver
+        self.callback = callback
+        self.res = ResultStorage(
+            [],
+            mode_optim=self.do_solver.params_objective_function.sense_function,
+            limit_store=False,
+        )
+        self.nb_solutions = 0
+
+    def on_solution_callback(self) -> None:
+        self.store_current_solution()
+        self.nb_solutions += 1
+        # end of step callback: stopping?
+        stopping = self.callback.on_step_end(
+            step=self.nb_solutions, res=self.res, solver=self.do_solver
+        )
+        if stopping:
+            raise SolveEarlyStop(
+                f"{self.do_solver.__class__.__name__}.solve() stopped by user callback."
+            )
+
+    def store_current_solution(self):
+        sol = self.do_solver.retrieve_solution(cpsolvercb=self)
+        fit = self.do_solver.aggreg_from_sol(sol)
+        self.res.add_solution(solution=sol, fitness=fit)
+
+
+def cpstatus_to_dostatus(status_from_cpsat) -> StatusSolver:
+    """
+
+    :param status_from_cpsat: either [UNKNOWN,INFEASIBLE,OPTIMAL,FEASIBLE] from ortools.cp api.
+    :return: Status
+    """
+    if status_from_cpsat == UNKNOWN:
+        return StatusSolver.UNKNOWN
+    if status_from_cpsat == INFEASIBLE:
+        return StatusSolver.UNSATISFIABLE
+    if status_from_cpsat == OPTIMAL:
+        return StatusSolver.OPTIMAL
+    if status_from_cpsat == FEASIBLE:
+        return StatusSolver.SATISFIED

--- a/discrete_optimization/knapsack/solvers/knapsack_cpsat_solver.py
+++ b/discrete_optimization/knapsack/solvers/knapsack_cpsat_solver.py
@@ -1,0 +1,97 @@
+#  Copyright (c) 2024 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+import logging
+from typing import Any, Dict, List, Optional
+
+from ortools.sat.python.cp_model import (
+    CpModel,
+    CpSolver,
+    IntVar,
+    VarArrayAndObjectiveSolutionPrinter,
+)
+
+from discrete_optimization.generic_tools.cp_tools import CPSolver, ParametersCP
+from discrete_optimization.generic_tools.do_problem import (
+    ParamsObjectiveFunction,
+    build_aggreg_function_and_params_objective,
+)
+from discrete_optimization.generic_tools.result_storage.result_storage import (
+    ResultStorage,
+)
+from discrete_optimization.knapsack.knapsack_model import (
+    KnapsackModel,
+    KnapsackSolution,
+)
+from discrete_optimization.knapsack.solvers.knapsack_solver import SolverKnapsack
+from discrete_optimization.rcpsp.solver.cpsat_solver import cpstatus_to_dostatus
+
+logger = logging.getLogger(__name__)
+
+
+class CPSatKnapsackSolver(CPSolver, SolverKnapsack):
+    def __init__(
+        self,
+        problem: KnapsackModel,
+        params_objective_function: Optional[ParamsObjectiveFunction] = None,
+    ):
+        self.problem = problem
+        (
+            self.aggreg_sol,
+            self.aggreg_dict,
+            self.params_objective_function,
+        ) = build_aggreg_function_and_params_objective(
+            problem=self.problem, params_objective_function=params_objective_function
+        )
+        self.model: Optional[CpModel] = None
+        self.variables: Dict[str, List[IntVar]] = {}
+
+    def init_model(self, **args: Any) -> None:
+        model = CpModel()
+        variables = [
+            model.NewBoolVar(name=f"x_{i}") for i in range(self.problem.nb_items)
+        ]
+        model.Add(
+            sum(
+                [
+                    variables[i] * self.problem.list_items[i].weight
+                    for i in range(self.problem.nb_items)
+                ]
+            )
+            <= self.problem.max_capacity
+        )
+        model.Maximize(
+            sum(
+                [
+                    variables[i] * self.problem.list_items[i].value
+                    for i in range(self.problem.nb_items)
+                ]
+            )
+        )
+        self.model = model
+        self.variables["taken"] = variables
+
+    def retrieve_solution(self, solver: CpSolver) -> ResultStorage:
+        taken = [int(solver.Value(var)) for var in self.variables["taken"]]
+        sol = KnapsackSolution(problem=self.problem, list_taken=taken)
+        fit = self.aggreg_sol(sol)
+        return ResultStorage(
+            [(sol, fit)], mode_optim=self.params_objective_function.sense_function
+        )
+
+    def solve(
+        self, parameters_cp: Optional[ParametersCP] = None, **args: Any
+    ) -> ResultStorage:
+        if self.model is None:
+            self.init_model(**args)
+        solver = CpSolver()
+        solver.parameters.max_time_in_seconds = parameters_cp.time_limit
+        solver.parameters.num_workers = parameters_cp.nb_process
+        callback = VarArrayAndObjectiveSolutionPrinter(variables=[])
+        status = solver.Solve(self.model, callback)
+        self.status_solver = cpstatus_to_dostatus(status_from_cpsat=status)
+        logger.info(
+            f"Solver finished, status={solver.StatusName(status)}, objective = {solver.ObjectiveValue()},"
+            f"best obj bound = {solver.BestObjectiveBound()}"
+        )
+        return self.retrieve_solution(solver=solver)

--- a/discrete_optimization/knapsack/solvers/knapsack_cpsat_solver.py
+++ b/discrete_optimization/knapsack/solvers/knapsack_cpsat_solver.py
@@ -4,49 +4,32 @@
 import logging
 from typing import Any, Dict, List, Optional
 
-from ortools.sat.python.cp_model import (
-    CpModel,
-    CpSolver,
-    IntVar,
-    VarArrayAndObjectiveSolutionPrinter,
-)
+from ortools.sat.python.cp_model import CpModel, CpSolverSolutionCallback, IntVar
 
-from discrete_optimization.generic_tools.cp_tools import CPSolver, ParametersCP
-from discrete_optimization.generic_tools.do_problem import (
-    ParamsObjectiveFunction,
-    build_aggreg_function_and_params_objective,
-)
-from discrete_optimization.generic_tools.result_storage.result_storage import (
-    ResultStorage,
-)
+from discrete_optimization.generic_tools.do_problem import ParamsObjectiveFunction
+from discrete_optimization.generic_tools.ortools_cpsat_tools import OrtoolsCPSatSolver
 from discrete_optimization.knapsack.knapsack_model import (
     KnapsackModel,
     KnapsackSolution,
 )
 from discrete_optimization.knapsack.solvers.knapsack_solver import SolverKnapsack
-from discrete_optimization.rcpsp.solver.cpsat_solver import cpstatus_to_dostatus
 
 logger = logging.getLogger(__name__)
 
 
-class CPSatKnapsackSolver(CPSolver, SolverKnapsack):
+class CPSatKnapsackSolver(OrtoolsCPSatSolver, SolverKnapsack):
     def __init__(
         self,
         problem: KnapsackModel,
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
     ):
-        self.problem = problem
-        (
-            self.aggreg_sol,
-            self.aggreg_dict,
-            self.params_objective_function,
-        ) = build_aggreg_function_and_params_objective(
-            problem=self.problem, params_objective_function=params_objective_function
+        super().__init__(
+            problem=problem, params_objective_function=params_objective_function
         )
-        self.model: Optional[CpModel] = None
         self.variables: Dict[str, List[IntVar]] = {}
 
     def init_model(self, **args: Any) -> None:
+        """Init CP model."""
         model = CpModel()
         variables = [
             model.NewBoolVar(name=f"x_{i}") for i in range(self.problem.nb_items)
@@ -68,30 +51,23 @@ class CPSatKnapsackSolver(CPSolver, SolverKnapsack):
                 ]
             )
         )
-        self.model = model
+        self.cp_model = model
         self.variables["taken"] = variables
 
-    def retrieve_solution(self, solver: CpSolver) -> ResultStorage:
-        taken = [int(solver.Value(var)) for var in self.variables["taken"]]
-        sol = KnapsackSolution(problem=self.problem, list_taken=taken)
-        fit = self.aggreg_sol(sol)
-        return ResultStorage(
-            [(sol, fit)], mode_optim=self.params_objective_function.sense_function
-        )
+    def retrieve_solution(
+        self, cpsolvercb: CpSolverSolutionCallback
+    ) -> KnapsackSolution:
+        """Construct a do solution from the cpsat solver internal solution.
 
-    def solve(
-        self, parameters_cp: Optional[ParametersCP] = None, **args: Any
-    ) -> ResultStorage:
-        if self.model is None:
-            self.init_model(**args)
-        solver = CpSolver()
-        solver.parameters.max_time_in_seconds = parameters_cp.time_limit
-        solver.parameters.num_workers = parameters_cp.nb_process
-        callback = VarArrayAndObjectiveSolutionPrinter(variables=[])
-        status = solver.Solve(self.model, callback)
-        self.status_solver = cpstatus_to_dostatus(status_from_cpsat=status)
-        logger.info(
-            f"Solver finished, status={solver.StatusName(status)}, objective = {solver.ObjectiveValue()},"
-            f"best obj bound = {solver.BestObjectiveBound()}"
-        )
-        return self.retrieve_solution(solver=solver)
+        It will be called each time the cpsat solver find a new solution.
+        At that point, value of internal variables are accessible via `cpsolvercb.Value(VARIABLE_NAME)`.
+
+        Args:
+            cpsolvercb: the ortools callback called when the cpsat solver finds a new solution.
+
+        Returns:
+            the intermediate solution, at do format.
+
+        """
+        taken = [int(cpsolvercb.Value(var)) for var in self.variables["taken"]]
+        return KnapsackSolution(problem=self.problem, list_taken=taken)

--- a/examples/knapsack/knapsack_cpsat_solver.py
+++ b/examples/knapsack/knapsack_cpsat_solver.py
@@ -1,0 +1,29 @@
+#  Copyright (c) 2024 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+
+from discrete_optimization.generic_tools.cp_tools import ParametersCP
+from discrete_optimization.knapsack.knapsack_parser import (
+    get_data_available,
+    parse_file,
+)
+from discrete_optimization.knapsack.solvers.knapsack_cpsat_solver import (
+    CPSatKnapsackSolver,
+)
+
+
+def run_cpsat_knapsack():
+    file = [f for f in get_data_available() if "ks_1000_0" in f][0]
+    knapsack_model = parse_file(file)
+    cp_model = CPSatKnapsackSolver(knapsack_model)
+    cp_model.init_model()
+    parameters_cp = ParametersCP.default()
+    parameters_cp.time_limit = 10
+    result_storage = cp_model.solve(parameters_cp=parameters_cp)
+    sol, fit = result_storage.get_best_solution_fit()
+    print("Status solver :", cp_model.get_status_solver())
+    assert knapsack_model.satisfy(sol)
+
+
+if __name__ == "__main__":
+    run_cpsat_knapsack()

--- a/examples/knapsack/knapsack_decomposition_solver.py
+++ b/examples/knapsack/knapsack_decomposition_solver.py
@@ -86,7 +86,7 @@ def run_decomposed_knapsack_cpsat():
     file = [f for f in get_data_available() if "ks_1000_0" in f][0]
     knapsack_model = parse_file(file)
     solver = KnapsackDecomposedSolver(
-        knapsack_model=knapsack_model,
+        problem=knapsack_model,
         params_objective_function=None,
     )
     params_cp = ParametersCP.default()

--- a/examples/knapsack/knapsack_decomposition_solver.py
+++ b/examples/knapsack/knapsack_decomposition_solver.py
@@ -17,6 +17,9 @@ from discrete_optimization.knapsack.solvers.cp_solvers import (
 )
 from discrete_optimization.knapsack.solvers.greedy_solvers import GreedyBest
 from discrete_optimization.knapsack.solvers.knapsack_asp_solver import KnapsackASPSolver
+from discrete_optimization.knapsack.solvers.knapsack_cpsat_solver import (
+    CPSatKnapsackSolver,
+)
 from discrete_optimization.knapsack.solvers.knapsack_decomposition import (
     KnapsackDecomposedSolver,
 )
@@ -78,5 +81,26 @@ def run_decomposed_knapsack_cp():
     print(solution, fit)
 
 
+def run_decomposed_knapsack_cpsat():
+    logging.basicConfig(level=logging.INFO)
+    file = [f for f in get_data_available() if "ks_1000_0" in f][0]
+    knapsack_model = parse_file(file)
+    solver = KnapsackDecomposedSolver(
+        knapsack_model=knapsack_model,
+        params_objective_function=None,
+    )
+    params_cp = ParametersCP.default()
+    params_cp.time_limit = 5
+    result_store = solver.solve(
+        root_solver=CPSatKnapsackSolver,
+        parameters_cp=params_cp,
+        nb_iteration=200,
+        proportion_to_remove=0.85,
+    )
+    solution, fit = result_store.get_best_solution_fit()
+    print(solution, fit)
+    assert knapsack_model.satisfy(solution)
+
+
 if __name__ == "__main__":
-    run_decomposed_knapsack_asp()
+    run_decomposed_knapsack_cpsat()

--- a/tests/knapsack/test_knapsack_cpsat_solver.py
+++ b/tests/knapsack/test_knapsack_cpsat_solver.py
@@ -1,0 +1,24 @@
+#  Copyright (c) 2024 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+
+from discrete_optimization.generic_tools.cp_tools import ParametersCP
+from discrete_optimization.knapsack.knapsack_parser import (
+    get_data_available,
+    parse_file,
+)
+from discrete_optimization.knapsack.solvers.knapsack_cpsat_solver import (
+    CPSatKnapsackSolver,
+)
+
+
+def test_cp_knapsack():
+    file = [f for f in get_data_available() if "ks_30_0" in f][0]
+    knapsack_model = parse_file(file)
+    cp_model = CPSatKnapsackSolver(knapsack_model)
+    cp_model.init_model()
+    parameters_cp = ParametersCP.default()
+    parameters_cp.time_limit = 10
+    result_storage = cp_model.solve(parameters_cp=parameters_cp)
+    sol, fit = result_storage.get_best_solution_fit()
+    assert knapsack_model.satisfy(sol)

--- a/tests/rcpsp/solver/test_rcpsp_cp.py
+++ b/tests/rcpsp/solver/test_rcpsp_cp.py
@@ -2,7 +2,9 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 import logging
+import random
 
+import numpy as np
 import pytest
 
 from discrete_optimization.generic_tools.callbacks.callback import Callback
@@ -35,6 +37,12 @@ from discrete_optimization.rcpsp.solver.cpsat_solver import (
     CPSatRCPSPSolver,
     CPSatRCPSPSolverCumulativeResource,
 )
+
+
+@pytest.fixture
+def random_seed():
+    random.seed(0)
+    np.random.seed(0)
 
 
 @pytest.mark.parametrize(
@@ -109,7 +117,7 @@ def test_ortools_resource_optim(model):
     assert rcpsp_problem.satisfy(solution)
 
 
-def test_ortools_with_cb(caplog):
+def test_ortools_with_cb(caplog, random_seed):
     model = "j1201_1.sm"
     files_available = get_data_available()
     file = [f for f in files_available if model in f][0]
@@ -132,7 +140,7 @@ def test_ortools_with_cb(caplog):
             logging.debug(sol.rcpsp_schedule)
             logging.debug(sol.rcpsp_modes)
 
-    callbacks = [VariablePrinterCallback(), TimerStopper(3)]
+    callbacks = [VariablePrinterCallback(), TimerStopper(2)]
 
     with caplog.at_level(logging.DEBUG):
         result_storage = solver.solve(callbacks=callbacks, parameters_cp=parameters_cp)


### PR DESCRIPTION
- Add a generic abstract class `OrtoolsCPSatSolver` for such solvers. 
  - A `solve()` is implemented that used an ortools callback for
    - updating a result_storage each time a new solution is found by the cpsat solver.
    - calling the user (do) callbacks at each new solution, with the possibility of early stopping if the callback return True.
  - A method `retrieve_solution()` needs to be implemented to reconstruct a do solution from the current ortools solution found by the cpsat solver. The value of the internal variables are accessible via `cpsolvercb.Value(VARIABLE_NAME)`.

- Update `CPSatRCPSPSolver` to use it.
- Update `CPSatKnapsackSolver` to use it.