### PR TITLE
Add SolverDO.__init__() and ._init_model()

### DIFF
--- a/discrete_optimization/coloring/coloring_solvers.py
+++ b/discrete_optimization/coloring/coloring_solvers.py
@@ -108,19 +108,19 @@ def look_for_solver_class(
 
 
 def solve(
-    method: Type[SolverColoring], coloring_model: ColoringProblem, **kwargs: Any
+    method: Type[SolverColoring], problem: ColoringProblem, **kwargs: Any
 ) -> ResultStorage:
     """Solve a coloring instance with a given class of solver.
 
     Args:
         method: class of the solver to use
-        coloring_model: coloring problem instance
+        problem: coloring problem instance
         **args: specific options of the solver
 
     Returns: a ResultsStorage objecting obtained by the solver.
 
     """
-    solver_ = method(coloring_model, **kwargs)
+    solver_ = method(problem, **kwargs)
     try:
         solver_.init_model(**kwargs)
     except AttributeError:
@@ -129,19 +129,19 @@ def solve(
 
 
 def return_solver(
-    method: Type[SolverColoring], coloring_model: ColoringProblem, **kwargs: Any
+    method: Type[SolverColoring], problem: ColoringProblem, **kwargs: Any
 ) -> SolverColoring:
     """Return the solver initialized with the coloring problem instance
 
     Args:
         method: class of the solver to use
-        coloring_model: coloring problem instance
+        problem: coloring problem instance
         **args: specific options of the solver
 
     Returns (SolverDO) : a solver object.
 
     """
-    solver_ = method(coloring_model, **kwargs)
+    solver_ = method(problem, **kwargs)
     try:
         solver_.init_model(**kwargs)
     except AttributeError:

--- a/discrete_optimization/coloring/solvers/coloring_cp_lns_solvers.py
+++ b/discrete_optimization/coloring/solvers/coloring_cp_lns_solvers.py
@@ -55,8 +55,8 @@ class InitialColoring(InitialSolution):
         self.problem = problem
         self.initial_method = initial_method
         (
-            self.aggreg_sol,
-            self.aggreg_dict,
+            self.aggreg_from_sol,
+            self.aggreg_from_dict,
             self.params_objective_function,
         ) = build_aggreg_function_and_params_objective(
             problem=self.problem, params_objective_function=params_objective_function
@@ -69,7 +69,7 @@ class InitialColoring(InitialSolution):
         """
         if self.initial_method == InitialColoringMethod.DUMMY:
             sol = self.problem.get_dummy_solution()
-            fit = self.aggreg_sol(sol)
+            fit = self.aggreg_from_sol(sol)
             return ResultStorage(
                 list_solution_fits=[(sol, fit)],
                 best_solution=sol,
@@ -77,7 +77,7 @@ class InitialColoring(InitialSolution):
             )
         else:
             solver = GreedyColoring(
-                coloring_model=self.problem,
+                problem=self.problem,
                 params_objective_function=self.params_objective_function,
             )
             return solver.solve(strategy=NXGreedyColoringMethod.largest_first)
@@ -190,7 +190,7 @@ class PostProcessSolutionColoring(PostProcessSolution):
         self.params_objective_function = params_objective_function
         (
             self.aggreg_from_sol,
-            self.aggreg_dict,
+            self.aggreg_from_dict,
             self.params_objective_function,
         ) = build_aggreg_function_and_params_objective(
             problem=self.problem,

--- a/discrete_optimization/coloring/solvers/coloring_lp_lns_solvers.py
+++ b/discrete_optimization/coloring/solvers/coloring_lp_lns_solvers.py
@@ -53,8 +53,8 @@ class InitialColoring(InitialSolution):
         self.problem = problem
         self.initial_method = initial_method
         (
-            self.aggreg_sol,
-            self.aggreg_dict,
+            self.aggreg_from_sol,
+            self.aggreg_from_dict,
             self.params_objective_function,
         ) = build_aggreg_function_and_params_objective(
             problem=self.problem, params_objective_function=params_objective_function
@@ -63,7 +63,7 @@ class InitialColoring(InitialSolution):
     def get_starting_solution(self) -> ResultStorage:
         if self.initial_method == InitialColoringMethod.DUMMY:
             sol = self.problem.get_dummy_solution()
-            fit = self.aggreg_sol(sol)
+            fit = self.aggreg_from_sol(sol)
             return ResultStorage(
                 list_solution_fits=[(sol, fit)],
                 best_solution=sol,
@@ -71,7 +71,7 @@ class InitialColoring(InitialSolution):
             )
         else:
             solver = GreedyColoring(
-                coloring_model=self.problem,
+                problem=self.problem,
                 params_objective_function=self.params_objective_function,
             )
             return solver.solve()

--- a/discrete_optimization/coloring/solvers/coloring_solver.py
+++ b/discrete_optimization/coloring/solvers/coloring_solver.py
@@ -2,15 +2,9 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Any
-
 from discrete_optimization.coloring.coloring_model import ColoringProblem
 from discrete_optimization.generic_tools.do_solver import SolverDO
 
 
 class SolverColoring(SolverDO):
-    def __init__(self, coloring_model: ColoringProblem, **kwargs: Any):
-        self.coloring_model = coloring_model
-
-    def init_model(self, **kwargs: Any) -> None:
-        pass
+    problem: ColoringProblem

--- a/discrete_optimization/coloring/solvers/coloring_solver_with_starting_solution.py
+++ b/discrete_optimization/coloring/solvers/coloring_solver_with_starting_solution.py
@@ -35,7 +35,7 @@ class SolverColoringWithStartingSolution(SolverColoring):
         if greedy_start:
             logger.info("Computing greedy solution")
             greedy_solver = GreedyColoring(
-                self.coloring_model,
+                self.problem,
                 params_objective_function=params_objective_function,
             )
             result_store = greedy_solver.solve(
@@ -53,5 +53,5 @@ class SolverColoringWithStartingSolution(SolverColoring):
                 )
         else:
             logger.info("Get dummy solution")
-            solution = self.coloring_model.get_dummy_solution()
+            solution = self.problem.get_dummy_solution()
         return solution

--- a/discrete_optimization/coloring/solvers/coloring_toulbar_solver.py
+++ b/discrete_optimization/coloring/solvers/coloring_toulbar_solver.py
@@ -2,6 +2,8 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from typing import Any, Dict, List, Optional
 
 from discrete_optimization.coloring.coloring_model import ColoringSolution

--- a/discrete_optimization/facility/facility_solvers.py
+++ b/discrete_optimization/facility/facility_solvers.py
@@ -103,9 +103,9 @@ def look_for_solver_class(
 
 
 def solve(
-    method: Type[SolverFacility], facility_problem: FacilityProblem, **kwargs: Any
+    method: Type[SolverFacility], problem: FacilityProblem, **kwargs: Any
 ) -> ResultStorage:
-    solver = method(facility_problem, **kwargs)
+    solver = method(problem, **kwargs)
     try:
         solver.init_model(**kwargs)
     except:
@@ -114,9 +114,9 @@ def solve(
 
 
 def return_solver(
-    method: Type[SolverFacility], coloring_model: FacilityProblem, **kwargs: Any
+    method: Type[SolverFacility], problem: FacilityProblem, **kwargs: Any
 ) -> SolverFacility:
-    solver = method(coloring_model, **kwargs)
+    solver = method(problem, **kwargs)
     try:
         solver.init_model(**kwargs)
     except:

--- a/discrete_optimization/facility/solvers/facility_lp_lns_solver.py
+++ b/discrete_optimization/facility/solvers/facility_lp_lns_solver.py
@@ -56,8 +56,8 @@ class InitialFacilitySolution(InitialSolution):
         self.problem = problem
         self.initial_method = initial_method
         (
-            self.aggreg_sol,
-            self.aggreg_dict,
+            self.aggreg_from_sol,
+            self.aggreg_from_dict,
             self.params_objective_function,
         ) = build_aggreg_function_and_params_objective(
             problem=self.problem, params_objective_function=params_objective_function
@@ -71,7 +71,7 @@ class InitialFacilitySolution(InitialSolution):
             return greedy_solver.solve()
         else:
             solution = self.problem.get_dummy_solution()
-            fit = self.aggreg_sol(solution)
+            fit = self.aggreg_from_sol(solution)
             return ResultStorage(
                 list_solution_fits=[(solution, fit)],
                 best_solution=solution,

--- a/discrete_optimization/facility/solvers/facility_solver.py
+++ b/discrete_optimization/facility/solvers/facility_solver.py
@@ -2,15 +2,10 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Any
 
 from discrete_optimization.facility.facility_model import FacilityProblem
 from discrete_optimization.generic_tools.do_solver import SolverDO
 
 
 class SolverFacility(SolverDO):
-    def __init__(self, facility_problem: FacilityProblem, **kwargs: Any):
-        self.facility_problem = facility_problem
-
-    def init_model(self, **kwargs: Any) -> None:
-        pass
+    problem: FacilityProblem

--- a/discrete_optimization/facility/solvers/gphh_facility.py
+++ b/discrete_optimization/facility/solvers/gphh_facility.py
@@ -29,11 +29,7 @@ from discrete_optimization.facility.solvers.facility_solver import SolverFacilit
 from discrete_optimization.facility.solvers.greedy_solvers import (
     GreedySolverDistanceBased,
 )
-from discrete_optimization.generic_tools.do_problem import (
-    ParamsObjectiveFunction,
-    Problem,
-    build_aggreg_function_and_params_objective,
-)
+from discrete_optimization.generic_tools.do_problem import ParamsObjectiveFunction
 from discrete_optimization.generic_tools.ghh_tools import argsort, protected_div
 from discrete_optimization.generic_tools.result_storage.result_storage import (
     ResultStorage,
@@ -205,12 +201,14 @@ class GPHH(SolverFacility):
     def __init__(
         self,
         training_domains: List[FacilityProblem],
-        facility_problem: FacilityProblem,
+        problem: FacilityProblem,
         weight: int = 1,
         params_gphh: Optional[ParametersGPHH] = None,
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
     ):
-        SolverFacility.__init__(self, facility_problem=facility_problem)
+        super().__init__(
+            problem=problem, params_objective_function=params_objective_function
+        )
         self.training_domains = training_domains
         if params_gphh is None:
             self.params_gphh = ParametersGPHH.default()
@@ -221,17 +219,7 @@ class GPHH(SolverFacility):
         self.list_feature_names = [value.value for value in list(self.list_feature)]
         self.pset: PrimitiveSet = self.init_primitives(self.params_gphh.set_primitives)
         self.weight = weight
-        (
-            self.aggreg_from_sol,
-            self.aggreg_dict,
-            self.params_objective_function,
-        ) = build_aggreg_function_and_params_objective(
-            problem=self.facility_problem,
-            params_objective_function=params_objective_function,
-        )
-        self.greedy_solver = GreedySolverDistanceBased(
-            facility_problem=self.facility_problem
-        )
+        self.greedy_solver = GreedySolverDistanceBased(problem=self.problem)
 
     def init_model(self, **kwargs: Any) -> None:
         tournament_ratio = self.params_gphh.tournament_ratio
@@ -308,7 +296,7 @@ class GPHH(SolverFacility):
         self.final_pop = pop
         self.func_heuristic = self.toolbox.compile(expr=self.best_heuristic)
         result = self.build_solution(
-            domain=self.facility_problem, func_heuristic=self.func_heuristic
+            domain=self.problem, func_heuristic=self.func_heuristic
         )
         return result
 

--- a/discrete_optimization/facility/solvers/greedy_solvers.py
+++ b/discrete_optimization/facility/solvers/greedy_solvers.py
@@ -12,10 +12,7 @@ from discrete_optimization.facility.facility_model import (
     FacilitySolution,
 )
 from discrete_optimization.facility.solvers.facility_solver import SolverFacility
-from discrete_optimization.generic_tools.do_problem import (
-    ParamsObjectiveFunction,
-    build_aggreg_function_and_params_objective,
-)
+from discrete_optimization.generic_tools.do_problem import ParamsObjectiveFunction
 from discrete_optimization.generic_tools.do_solver import ResultStorage
 
 
@@ -25,27 +22,12 @@ class GreedySolverFacility(SolverFacility):
     pack the facilities one by one until all the customers are served
     """
 
-    def __init__(
-        self,
-        facility_problem: FacilityProblem,
-        params_objective_function: Optional[ParamsObjectiveFunction] = None,
-    ):
-        SolverFacility.__init__(self, facility_problem=facility_problem)
-        (
-            self.aggreg_sol,
-            self.aggreg_dict,
-            self.params_objective_function,
-        ) = build_aggreg_function_and_params_objective(
-            problem=self.facility_problem,
-            params_objective_function=params_objective_function,
-        )
-
     def solve(self, **kwargs: Any) -> ResultStorage:
-        solution = [-1] * self.facility_problem.customer_count
-        capacity_remaining = [f.capacity for f in self.facility_problem.facilities]
+        solution = [-1] * self.problem.customer_count
+        capacity_remaining = [f.capacity for f in self.problem.facilities]
         facility_index = 0
-        for index in range(len(self.facility_problem.customers)):
-            customer = self.facility_problem.customers[index]
+        for index in range(len(self.problem.customers)):
+            customer = self.problem.customers[index]
             if capacity_remaining[facility_index] >= customer.demand:
                 solution[index] = facility_index
                 capacity_remaining[facility_index] -= customer.demand
@@ -54,10 +36,8 @@ class GreedySolverFacility(SolverFacility):
                 assert capacity_remaining[facility_index] >= customer.demand
                 solution[index] = facility_index
                 capacity_remaining[facility_index] -= customer.demand
-        sol = FacilitySolution(
-            problem=self.facility_problem, facility_for_customers=solution
-        )
-        fit = self.aggreg_sol(sol)
+        sol = FacilitySolution(problem=self.problem, facility_for_customers=solution)
+        fit = self.aggreg_from_sol(sol)
         return ResultStorage(
             list_solution_fits=[(sol, fit)],
             best_solution=sol,
@@ -68,28 +48,20 @@ class GreedySolverFacility(SolverFacility):
 class GreedySolverDistanceBased(SolverFacility):
     def __init__(
         self,
-        facility_problem: FacilityProblem,
+        problem: FacilityProblem,
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
     ):
-        SolverFacility.__init__(self, facility_problem=facility_problem)
-        (
-            self.aggreg_sol,
-            self.aggreg_dict,
-            self.params_objective_function,
-        ) = build_aggreg_function_and_params_objective(
-            problem=self.facility_problem,
-            params_objective_function=params_objective_function,
+        super().__init__(
+            problem=problem, params_objective_function=params_objective_function
         )
         self.matrix_cost = np.zeros(
-            (self.facility_problem.customer_count, self.facility_problem.facility_count)
+            (self.problem.customer_count, self.problem.facility_count)
         )
-        for k in range(self.facility_problem.customer_count):
-            for j in range(self.facility_problem.facility_count):
-                self.matrix_cost[
-                    k, j
-                ] = self.facility_problem.evaluate_customer_facility(
-                    facility=self.facility_problem.facilities[j],
-                    customer=self.facility_problem.customers[k],
+        for k in range(self.problem.customer_count):
+            for j in range(self.problem.facility_count):
+                self.matrix_cost[k, j] = self.problem.evaluate_customer_facility(
+                    facility=self.problem.facilities[j],
+                    customer=self.problem.customers[k],
                 )
         self.min_distance: npt.NDArray[np.float_] = np.min(self.matrix_cost, axis=1)
         self.sorted_distance: npt.NDArray[np.int_] = np.argsort(
@@ -99,13 +71,13 @@ class GreedySolverDistanceBased(SolverFacility):
         # sort the customers based on the minimum distance of facility (so the first element is the one which is the furthest to a facility
         self.available_demands = np.array(
             [
-                self.facility_problem.facilities[k].capacity
-                for k in range(self.facility_problem.facility_count)
+                self.problem.facilities[k].capacity
+                for k in range(self.problem.facility_count)
             ]
         )
 
     def solve(self, **kwargs: Any) -> ResultStorage:
-        solution = [-1] * self.facility_problem.customer_count
+        solution = [-1] * self.problem.customer_count
         capacity_remaining = np.copy(self.available_demands)
         for customer in self.sorted_customers:
             prior_customers = kwargs.get("prio", {}).get(
@@ -115,19 +87,12 @@ class GreedySolverDistanceBased(SolverFacility):
                 prior_customers = self.sorted_distance[customer, :]
             for f in prior_customers:
                 f = int(f)
-                if (
-                    capacity_remaining[f]
-                    >= self.facility_problem.customers[customer].demand
-                ):
+                if capacity_remaining[f] >= self.problem.customers[customer].demand:
                     solution[customer] = f
-                    capacity_remaining[f] -= self.facility_problem.customers[
-                        customer
-                    ].demand
+                    capacity_remaining[f] -= self.problem.customers[customer].demand
                     break
-        sol = FacilitySolution(
-            problem=self.facility_problem, facility_for_customers=solution
-        )
-        fit = self.aggreg_sol(sol)
+        sol = FacilitySolution(problem=self.problem, facility_for_customers=solution)
+        fit = self.aggreg_from_sol(sol)
         return ResultStorage(
             list_solution_fits=[(sol, fit)],
             best_solution=sol,

--- a/discrete_optimization/generic_rcpsp_tools/generic_rcpsp_solver.py
+++ b/discrete_optimization/generic_rcpsp_tools/generic_rcpsp_solver.py
@@ -9,8 +9,4 @@ from discrete_optimization.generic_tools.do_solver import SolverDO
 
 
 class SolverGenericRCPSP(SolverDO):
-    def __init__(self, rcpsp_model: ANY_RCPSP, **kwargs: Any):
-        self.rcpsp_model = rcpsp_model
-
-    def init_model(self, **kwargs: Any) -> None:
-        pass
+    problem: ANY_RCPSP

--- a/discrete_optimization/generic_rcpsp_tools/gphh_solver.py
+++ b/discrete_optimization/generic_rcpsp_tools/gphh_solver.py
@@ -20,7 +20,6 @@ from discrete_optimization.generic_rcpsp_tools.typing import ANY_RCPSP
 from discrete_optimization.generic_tools.do_problem import (
     ParamsObjectiveFunction,
     Problem,
-    build_aggreg_function_and_params_objective,
 )
 from discrete_optimization.generic_tools.result_storage.result_storage import (
     ResultStorage,
@@ -489,12 +488,14 @@ class GPHH(SolverGenericRCPSP):
     def __init__(
         self,
         training_domains: List[Problem],
-        rcpsp_model: Problem,
+        problem: Problem,
         weight: int = 1,
         params_gphh: ParametersGPHH = None,
         params_objective_function: ParamsObjectiveFunction = None,
     ):
-        SolverGenericRCPSP.__init__(self, rcpsp_model=rcpsp_model)
+        super().__init__(
+            problem=problem, params_objective_function=params_objective_function
+        )
         self.training_domains = training_domains
         self.params_gphh = params_gphh
         if self.params_gphh is None:
@@ -505,7 +506,7 @@ class GPHH(SolverGenericRCPSP):
         self.pset = self.init_primitives(self.params_gphh.set_primitves)
         self.weight = weight
         self.evaluation_method = self.params_gphh.evaluation
-        model = self.rcpsp_model
+        model = self.problem
         try:
             if model.graph.full_successors is None:
                 model.graph.full_predecessors = model.graph.ancestors_map()
@@ -514,14 +515,6 @@ class GPHH(SolverGenericRCPSP):
             pass
         self.initialize_cpm_data_for_training()
         self.graphs = {}
-        (
-            self.aggreg_from_sol,
-            self.aggreg_dict,
-            self.params_objective_function,
-        ) = build_aggreg_function_and_params_objective(
-            problem=self.rcpsp_model,
-            params_objective_function=params_objective_function,
-        )
         self.toolbox = None
 
     def init_model(self):
@@ -609,7 +602,7 @@ class GPHH(SolverGenericRCPSP):
         self.final_pop = pop
         self.func_heuristic = self.toolbox.compile(expr=self.best_heuristic)
         solution = self.build_solution(
-            domain=self.rcpsp_model, func_heuristic=self.func_heuristic
+            domain=self.problem, func_heuristic=self.func_heuristic
         )
         return ResultStorage(
             list_solution_fits=[(solution, self.aggreg_from_sol(solution))],

--- a/discrete_optimization/generic_rcpsp_tools/neighbor_tools_rcpsp.py
+++ b/discrete_optimization/generic_rcpsp_tools/neighbor_tools_rcpsp.py
@@ -655,7 +655,7 @@ def constraints_start_on_end(
         data[st] = tasks_ending
     selected = listed
     selected_task = random.sample(
-        cp_solver.rcpsp_model.tasks_list, k=int(frac * cp_solver.rcpsp_model.nb_tasks)
+        cp_solver.problem.tasks_list, k=int(frac * cp_solver.problem.nb_tasks)
     )
     s = []
     cnt = 0
@@ -702,7 +702,7 @@ def constraints_start_on_end_preemptive(
         data[st] = tasks_ending
     selected = listed
     selected_task = random.sample(
-        cp_solver.rcpsp_model.tasks_list, k=int(frac * cp_solver.rcpsp_model.nb_tasks)
+        cp_solver.problem.tasks_list, k=int(frac * cp_solver.problem.nb_tasks)
     )
     s = []
     cnt = 0

--- a/discrete_optimization/generic_rcpsp_tools/postpro_local_search.py
+++ b/discrete_optimization/generic_rcpsp_tools/postpro_local_search.py
@@ -32,7 +32,7 @@ class PostProLocalSearch(PostProcessSolution):
         self.params_objective_function = params_objective_function
         (
             self.aggreg_from_sol,
-            self.aggreg_dict,
+            self.aggreg_from_dict,
             self.params_objective_function,
         ) = build_aggreg_function_and_params_objective(
             problem=self.problem,
@@ -41,7 +41,7 @@ class PostProLocalSearch(PostProcessSolution):
         self.dict_params = kwargs
 
     def build_other_solution(self, result_storage: ResultStorage) -> ResultStorage:
-        solver = LS_RCPSP_Solver(rcpsp_model=self.problem, ls_solver=LS_SOLVER.SA)
+        solver = LS_RCPSP_Solver(problem=self.problem, ls_solver=LS_SOLVER.SA)
         s = result_storage.get_best_solution().copy()
         if isinstance(s, MS_RCPSPSolution_Preemptive):
             s = schedule_solution_preemptive_to_variant(s)

--- a/discrete_optimization/generic_tools/do_solver.py
+++ b/discrete_optimization/generic_tools/do_solver.py
@@ -8,6 +8,11 @@ from abc import abstractmethod
 from typing import Any, List, Optional
 
 from discrete_optimization.generic_tools.callbacks.callback import Callback
+from discrete_optimization.generic_tools.do_problem import (
+    ParamsObjectiveFunction,
+    Problem,
+    build_aggreg_function_and_params_objective,
+)
 from discrete_optimization.generic_tools.result_storage.result_storage import (
     ResultStorage,
 )
@@ -15,6 +20,24 @@ from discrete_optimization.generic_tools.result_storage.result_storage import (
 
 class SolverDO:
     """Base class for a discrete-optimization solver."""
+
+    problem: Problem
+
+    def __init__(
+        self,
+        problem: Problem,
+        params_objective_function: Optional[ParamsObjectiveFunction] = None,
+        **kwargs: Any
+    ):
+        self.problem = problem
+        (
+            self.aggreg_from_sol,
+            self.aggreg_from_dict,
+            self.params_objective_function,
+        ) = build_aggreg_function_and_params_objective(
+            problem=self.problem,
+            params_objective_function=params_objective_function,
+        )
 
     @abstractmethod
     def solve(
@@ -33,3 +56,11 @@ class SolverDO:
         to a discrete-optimization problem
         """
         ...
+
+    def init_model(self, **kwargs: Any) -> None:
+        """Initialize intern model used to solve.
+
+        Can initialize a ortools, milp, gurobi, ... model.
+
+        """
+        pass

--- a/discrete_optimization/generic_tools/ea/alternating_ga.py
+++ b/discrete_optimization/generic_tools/ea/alternating_ga.py
@@ -7,8 +7,8 @@ from typing import Any, Dict, List, Optional, Union
 from discrete_optimization.generic_tools.do_mutation import Mutation
 from discrete_optimization.generic_tools.do_problem import (
     ObjectiveHandling,
+    ParamsObjectiveFunction,
     Problem,
-    build_aggreg_function_and_params_objective,
 )
 from discrete_optimization.generic_tools.do_solver import SolverDO
 from discrete_optimization.generic_tools.ea.ga import (
@@ -53,8 +53,11 @@ class AlternatingGa(SolverDO):
         crossover_rate: Optional[float] = None,
         tournament_size: Optional[float] = None,
         deap_verbose: bool = False,
+        params_objective_function: Optional[ParamsObjectiveFunction] = None,
     ):
-        self.problem = problem
+        super().__init__(
+            problem=problem, params_objective_function=params_objective_function
+        )
         self.encodings = encodings
         self.mutations = mutations
         self.crossovers = crossovers
@@ -69,14 +72,6 @@ class AlternatingGa(SolverDO):
         self.crossover_rate = crossover_rate
         self.tournament_size = tournament_size
         self.deap_verbose = deap_verbose
-
-        (
-            self.aggreg_from_sol,
-            self.aggreg_dict,
-            self.params_objective_function,
-        ) = build_aggreg_function_and_params_objective(
-            problem=self.problem, params_objective_function=None
-        )
 
     def solve(self, **kwargs: Any) -> ResultStorage:
         # Initialise the population (here at random)

--- a/discrete_optimization/generic_tools/ea/ga.py
+++ b/discrete_optimization/generic_tools/ea/ga.py
@@ -14,9 +14,9 @@ from discrete_optimization.generic_tools.do_mutation import Mutation
 from discrete_optimization.generic_tools.do_problem import (
     EncodingRegister,
     ObjectiveHandling,
+    ParamsObjectiveFunction,
     Problem,
     TypeAttribute,
-    build_aggreg_function_and_params_objective,
     lower_bound_vector_encoding_from_dict,
     upper_bound_vector_encoding_from_dict,
 )
@@ -99,8 +99,11 @@ class Ga(SolverDO):
         tournament_size: float = 0.2,  # as a percentage of the population
         deap_verbose: bool = True,
         initial_population: Optional[List[List[Any]]] = None,
+        params_objective_function: Optional[ParamsObjectiveFunction] = None,
     ):
-        self.problem = problem
+        super().__init__(
+            problem=problem, params_objective_function=params_objective_function
+        )
         if not hasattr(self.problem, "evaluate_from_encoding"):
             raise ValueError("self.problem shoud define an evaluate_from_encoding()")
             # self.problem.evaluate_from_encoding: Callable[[List[int], str], Dict[str, float]]
@@ -393,14 +396,6 @@ class Ga(SolverDO):
             self._toolbox.register("select", tools.selWorst)
         elif self._selection_type == DeapSelection.SEL_STOCHASTIC_UNIVERSAL_SAMPLING:
             self._toolbox.register("select", tools.selStochasticUniversalSampling)
-
-        (
-            self.aggreg_from_sol,
-            self.aggreg_dict,
-            self.params_objective_function,
-        ) = build_aggreg_function_and_params_objective(
-            problem=self.problem, params_objective_function=None
-        )
 
     def evaluate_problem(self, int_vector: List[int]) -> Tuple[float]:
         objective_values: Dict[str, float] = self.problem.evaluate_from_encoding(  # type: ignore

--- a/discrete_optimization/generic_tools/ea/nsga.py
+++ b/discrete_optimization/generic_tools/ea/nsga.py
@@ -203,10 +203,13 @@ class Nsga(SolverDO):
             weights=self._objective_weights,
             sense_function=ModeOptim.MAXIMIZATION,
         )
-        self.evaluate_sol: Union[
+        self.aggreg_from_sol: Union[
             Callable[[Solution], float], Callable[[Solution], TupleFitness]
         ]
-        self.evaluate_sol, _ = build_evaluate_function_aggregated(
+        (
+            self.aggreg_from_sol,
+            self.aggreg_from_dict,
+        ) = build_evaluate_function_aggregated(
             problem=problem, params_objective_function=self.params_objective_function
         )
 
@@ -393,7 +396,7 @@ class Nsga(SolverDO):
             s_pure_int = [i for i in s]
             kwargs = {self._encoding_variable_name: s_pure_int, "problem": self.problem}
             problem_sol = self.problem.get_solution_type()(**kwargs)
-            fits = self.evaluate_sol(problem_sol)
+            fits = self.aggreg_from_sol(problem_sol)
             sols.append((problem_sol, fits))
         rs = ResultStorage(
             list_solution_fits=sols,

--- a/discrete_optimization/generic_tools/lns_cp.py
+++ b/discrete_optimization/generic_tools/lns_cp.py
@@ -18,7 +18,6 @@ from discrete_optimization.generic_tools.do_problem import (
     ModeOptim,
     ParamsObjectiveFunction,
     Problem,
-    build_aggreg_function_and_params_objective,
 )
 from discrete_optimization.generic_tools.do_solver import SolverDO
 from discrete_optimization.generic_tools.lns_mip import (
@@ -71,7 +70,9 @@ class LNS_CP(SolverDO):
         post_process_solution: Optional[PostProcessSolution] = None,
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
     ):
-        self.problem = problem
+        super().__init__(
+            problem=problem, params_objective_function=params_objective_function
+        )
         self.cp_solver = cp_solver
         self.initial_solution_provider = initial_solution_provider
         self.constraint_handler = constraint_handler
@@ -80,14 +81,6 @@ class LNS_CP(SolverDO):
             self.post_process_solution = TrivialPostProcessSolution()
         else:
             self.post_process_solution = post_process_solution
-        (
-            self.aggreg_from_sol,
-            self.aggreg_dict,
-            self.params_objective_function,
-        ) = build_aggreg_function_and_params_objective(
-            problem=self.problem,
-            params_objective_function=params_objective_function,
-        )
 
     def solve_lns(
         self,
@@ -256,7 +249,9 @@ class LNS_CPlex(SolverDO):
         post_process_solution: Optional[PostProcessSolution] = None,
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
     ):
-        self.problem = problem
+        super().__init__(
+            problem=problem, params_objective_function=params_objective_function
+        )
         self.cp_solver = cp_solver
         self.initial_solution_provider = initial_solution_provider
         self.constraint_handler = constraint_handler
@@ -265,14 +260,6 @@ class LNS_CPlex(SolverDO):
             self.post_process_solution = TrivialPostProcessSolution()
         else:
             self.post_process_solution = post_process_solution
-        (
-            self.aggreg_from_sol,
-            self.aggreg_dict,
-            self.params_objective_function,
-        ) = build_aggreg_function_and_params_objective(
-            problem=self.problem,
-            params_objective_function=params_objective_function,
-        )
 
     def solve_lns(
         self,

--- a/discrete_optimization/generic_tools/lns_mip.py
+++ b/discrete_optimization/generic_tools/lns_mip.py
@@ -11,7 +11,6 @@ from discrete_optimization.generic_tools.do_problem import (
     ModeOptim,
     ParamsObjectiveFunction,
     Problem,
-    build_aggreg_function_and_params_objective,
 )
 from discrete_optimization.generic_tools.do_solver import SolverDO
 from discrete_optimization.generic_tools.lp_tools import MilpSolver, ParametersMilp
@@ -88,7 +87,9 @@ class LNS_MILP(SolverDO):
         post_process_solution: Optional[PostProcessSolution] = None,
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
     ):
-        self.problem = problem
+        super().__init__(
+            problem=problem, params_objective_function=params_objective_function
+        )
         self.milp_solver = milp_solver
         self.initial_solution_provider = initial_solution_provider
         self.constraint_handler = constraint_handler
@@ -97,15 +98,6 @@ class LNS_MILP(SolverDO):
             self.post_process_solution = TrivialPostProcessSolution()
         else:
             self.post_process_solution = post_process_solution
-
-        (
-            self.aggreg_from_sol,
-            self.aggreg_dict,
-            self.params_objective_function,
-        ) = build_aggreg_function_and_params_objective(
-            problem=self.problem,
-            params_objective_function=params_objective_function,
-        )
 
     def solve_lns(
         self,

--- a/discrete_optimization/generic_tools/result_storage/result_storage.py
+++ b/discrete_optimization/generic_tools/result_storage/result_storage.py
@@ -206,15 +206,15 @@ def from_solutions_to_result_storage(
         params_objective_function = get_default_objective_setup(problem)
     mode_optim = params_objective_function.sense_function
     (
-        aggreg_sol,
-        aggreg_dict,
+        aggreg_from_sol,
+        aggreg_from_dict,
         params_objective_function,
     ) = build_aggreg_function_and_params_objective(
         problem=problem, params_objective_function=params_objective_function
     )
     list_solution_fit: List[Tuple[Solution, fitness_class]] = []
     for s in list_solution:
-        list_solution_fit += [(s, aggreg_sol(s))]
+        list_solution_fit += [(s, aggreg_from_sol(s))]
     return ResultStorage(
         list_solution_fits=list_solution_fit,
         mode_optim=mode_optim,

--- a/discrete_optimization/generic_tools/robustness/robustness_tool.py
+++ b/discrete_optimization/generic_tools/robustness/robustness_tool.py
@@ -190,13 +190,13 @@ def solve_model(
             weights=objective_weights,
             sense_function=ModeOptim.MAXIMIZATION,
         )
-        aggreg_sol: Callable[[Solution], float]
-        aggreg_sol, _, _ = build_aggreg_function_and_params_objective(  # type: ignore
+        aggreg_from_sol: Callable[[Solution], float]
+        aggreg_from_sol, _, _ = build_aggreg_function_and_params_objective(  # type: ignore
             model, params_objective_function
         )
         res = RestartHandlerLimit(200)
         sa = SimulatedAnnealing(
-            evaluator=model,
+            problem=model,
             mutator=mixed_mutation,
             restart_handler=res,
             temperature_handler=TemperatureSchedulingFactor(
@@ -214,13 +214,13 @@ def solve_model(
             weights=objective_weights,
             sense_function=ModeOptim.MAXIMIZATION,
         )
-        aggreg_sol2: Callable[[Solution], TupleFitness]
-        aggreg_sol2, _, _ = build_aggreg_function_and_params_objective(  # type: ignore
+        aggreg_from_sol2: Callable[[Solution], TupleFitness]
+        aggreg_from_sol2, _, _ = build_aggreg_function_and_params_objective(  # type: ignore
             model, params_objective_function
         )
         res = RestartHandlerLimit(200)
         sa_mo = HillClimberPareto(
-            evaluator=model,
+            problem=model,
             mutator=mixed_mutation,
             restart_handler=res,
             params_objective_function=params_objective_function,

--- a/discrete_optimization/knapsack/knapsack_solvers.py
+++ b/discrete_optimization/knapsack/knapsack_solvers.py
@@ -86,8 +86,8 @@ def look_for_solver_class(
 
 
 def solve(
-    method: Type[SolverKnapsack], knapsack_model: KnapsackModel, **args: Any
+    method: Type[SolverKnapsack], problem: KnapsackModel, **args: Any
 ) -> ResultStorage:
-    solver = method(knapsack_model)
+    solver = method(problem)
     solver.init_model(**args)
     return solver.solve(**args)

--- a/discrete_optimization/knapsack/solvers/dyn_prog_knapsack.py
+++ b/discrete_optimization/knapsack/solvers/dyn_prog_knapsack.py
@@ -8,11 +8,7 @@ from typing import Any, Optional
 
 import numpy as np
 
-from discrete_optimization.generic_tools.do_problem import (
-    ParamsObjectiveFunction,
-    build_aggreg_function_and_params_objective,
-)
-from discrete_optimization.generic_tools.do_solver import SolverDO
+from discrete_optimization.generic_tools.do_problem import ParamsObjectiveFunction
 from discrete_optimization.generic_tools.result_storage.result_storage import (
     ResultStorage,
 )
@@ -28,32 +24,26 @@ logger = logging.getLogger(__name__)
 class KnapsackDynProg(SolverKnapsack):
     def __init__(
         self,
-        knapsack_model: KnapsackModel,
+        problem: KnapsackModel,
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
     ):
-        SolverKnapsack.__init__(self, knapsack_model=knapsack_model)
-        self.nb_items = self.knapsack_model.nb_items
-        capacity = int(self.knapsack_model.max_capacity)
-        if capacity != self.knapsack_model.max_capacity:
+        super().__init__(
+            problem=problem, params_objective_function=params_objective_function
+        )
+        self.nb_items = self.problem.nb_items
+        capacity = int(self.problem.max_capacity)
+        if capacity != self.problem.max_capacity:
             logger.warning(
                 "knapsack_model.max_capacity should be an integer for dynamic programming. "
                 "Coercing it to an integer for the solver."
             )
         self.capacity: int = capacity
         self.table = np.zeros((self.nb_items + 1, self.capacity + 1))
-        (
-            self.aggreg_sol,
-            self.aggreg_dict,
-            self.params_objective_function,
-        ) = build_aggreg_function_and_params_objective(
-            problem=self.knapsack_model,
-            params_objective_function=params_objective_function,
-        )
 
     def solve(self, **kwargs: Any) -> ResultStorage:
         start_by_most_promising = kwargs.get("greedy_start", False)
-        max_items = kwargs.get("max_items", self.knapsack_model.nb_items + 1)
-        max_items = min(self.knapsack_model.nb_items + 1, max_items)
+        max_items = kwargs.get("max_items", self.problem.nb_items + 1)
+        max_items = min(self.problem.nb_items + 1, max_items)
         max_time_seconds = kwargs.get("max_time_seconds", None)
         if max_time_seconds is None:
             do_time = False
@@ -63,15 +53,15 @@ class KnapsackDynProg(SolverKnapsack):
             promising = sorted(
                 [
                     l
-                    for l in self.knapsack_model.list_items
-                    if l.weight <= self.knapsack_model.max_capacity
+                    for l in self.problem.list_items
+                    if l.weight <= self.problem.max_capacity
                 ],
                 key=lambda x: x.value / x.weight,
                 reverse=True,
             )
             index_promising = [l.index for l in promising]
         else:
-            index_promising = [l.index for l in self.knapsack_model.list_items]
+            index_promising = [l.index for l in self.problem.list_items]
         if do_time:
             t_start = time.time()
         cur_indexes = (0, 0)
@@ -79,14 +69,12 @@ class KnapsackDynProg(SolverKnapsack):
             if do_time:
                 if time.time() - t_start > max_time_seconds:
                     break
-            index_item = self.knapsack_model.index_to_index_list[
-                index_promising[nb_item - 1]
-            ]
+            index_item = self.problem.index_to_index_list[index_promising[nb_item - 1]]
             for capacity in range(self.capacity + 1):
                 weight = int(
-                    self.knapsack_model.list_items[index_item].weight
+                    self.problem.list_items[index_item].weight
                 )  # weight should be an integer for this algo
-                value = self.knapsack_model.list_items[index_item].value
+                value = self.problem.list_items[index_item].value
                 if weight > capacity:
                     self.table[nb_item, capacity] = self.table[nb_item - 1, capacity]
                     continue
@@ -104,24 +92,23 @@ class KnapsackDynProg(SolverKnapsack):
         while cur_indexes[0] != 0:
             value_left = self.table[cur_indexes[0] - 1, cur_indexes[1]]
             if cur_value != value_left:
-                index_item = self.knapsack_model.index_to_index_list[
+                index_item = self.problem.index_to_index_list[
                     index_promising[cur_indexes[0] - 1]
                 ]
-                taken[self.knapsack_model.list_items[index_item].index] = 1
-                value += self.knapsack_model.list_items[index_item].value
-                weight += int(self.knapsack_model.list_items[index_item].weight)
+                taken[self.problem.list_items[index_item].index] = 1
+                value += self.problem.list_items[index_item].value
+                weight += int(self.problem.list_items[index_item].weight)
                 cur_indexes = (
                     cur_indexes[0] - 1,
-                    cur_indexes[1]
-                    - int(self.knapsack_model.list_items[index_item].weight),
+                    cur_indexes[1] - int(self.problem.list_items[index_item].weight),
                 )
             else:
                 cur_indexes = (cur_indexes[0] - 1, cur_indexes[1])
             cur_value = self.table[cur_indexes[0], cur_indexes[1]]
         sol = KnapsackSolution(
-            problem=self.knapsack_model, value=value, weight=weight, list_taken=taken
+            problem=self.problem, value=value, weight=weight, list_taken=taken
         )
-        fit = self.aggreg_sol(sol)
+        fit = self.aggreg_from_sol(sol)
         return ResultStorage(
             list_solution_fits=[(sol, fit)],
             best_solution=sol,
@@ -130,7 +117,7 @@ class KnapsackDynProg(SolverKnapsack):
 
     def solve_np(self, **kwargs: Any) -> ResultStorage:
         start_by_most_promising = kwargs.get("greedy_start", False)
-        max_items = kwargs.get("max_items", self.knapsack_model.nb_items + 1)
+        max_items = kwargs.get("max_items", self.problem.nb_items + 1)
         max_time_seconds = kwargs.get("max_time_seconds", None)
         if max_time_seconds is None:
             do_time = False
@@ -140,15 +127,15 @@ class KnapsackDynProg(SolverKnapsack):
             promising = sorted(
                 [
                     l
-                    for l in self.knapsack_model.list_items
-                    if l.weight <= self.knapsack_model.max_capacity
+                    for l in self.problem.list_items
+                    if l.weight <= self.problem.max_capacity
                 ],
                 key=lambda x: x.value / x.weight,
                 reverse=True,
             )
             index_promising = [l.index for l in promising]
         else:
-            index_promising = [l.index for l in self.knapsack_model.list_items]
+            index_promising = [l.index for l in self.problem.list_items]
         if do_time:
             t_start = time.time()
         cur_indexes = (0, 0)
@@ -156,11 +143,9 @@ class KnapsackDynProg(SolverKnapsack):
             if do_time:
                 if time.time() - t_start > max_time_seconds:
                     break
-            index_item = self.knapsack_model.index_to_index_list[
-                index_promising[nb_item - 1]
-            ]
-            weight = int(self.knapsack_model.list_items[index_item].weight)
-            value = self.knapsack_model.list_items[index_item].value
+            index_item = self.problem.index_to_index_list[index_promising[nb_item - 1]]
+            weight = int(self.problem.list_items[index_item].weight)
+            value = self.problem.list_items[index_item].value
             vec_1 = self.table[nb_item - 1, :]
             ind = [max(capacity - weight, 0) for capacity in range(self.capacity + 1)]
             vec_2 = vec_1[ind] + value * (ind != 0)
@@ -174,24 +159,23 @@ class KnapsackDynProg(SolverKnapsack):
         while cur_indexes[0] != 0:
             value_left = self.table[cur_indexes[0] - 1, cur_indexes[1]]
             if cur_value != value_left:
-                index_item = self.knapsack_model.index_to_index_list[
+                index_item = self.problem.index_to_index_list[
                     index_promising[cur_indexes[0] - 1]
                 ]
-                taken[self.knapsack_model.list_items[index_item].index] = 1
-                value += self.knapsack_model.list_items[index_item].value
-                weight += int(self.knapsack_model.list_items[index_item].weight)
+                taken[self.problem.list_items[index_item].index] = 1
+                value += self.problem.list_items[index_item].value
+                weight += int(self.problem.list_items[index_item].weight)
                 cur_indexes = (
                     cur_indexes[0] - 1,
-                    cur_indexes[1]
-                    - int(self.knapsack_model.list_items[index_item].weight),
+                    cur_indexes[1] - int(self.problem.list_items[index_item].weight),
                 )
             else:
                 cur_indexes = (cur_indexes[0] - 1, cur_indexes[1])
             cur_value = self.table[cur_indexes[0], cur_indexes[1]]
         sol = KnapsackSolution(
-            problem=self.knapsack_model, value=value, weight=weight, list_taken=taken
+            problem=self.problem, value=value, weight=weight, list_taken=taken
         )
-        fit = self.aggreg_sol(sol)
+        fit = self.aggreg_from_sol(sol)
         return ResultStorage(
             list_solution_fits=[(sol, fit)],
             best_solution=sol,

--- a/discrete_optimization/knapsack/solvers/greedy_solvers.py
+++ b/discrete_optimization/knapsack/solvers/greedy_solvers.py
@@ -4,11 +4,7 @@
 
 from typing import Any, Callable, List, Optional
 
-from discrete_optimization.generic_tools.do_problem import (
-    ParamsObjectiveFunction,
-    build_aggreg_function_and_params_objective,
-)
-from discrete_optimization.generic_tools.do_solver import ResultStorage, SolverDO
+from discrete_optimization.generic_tools.do_solver import ResultStorage
 from discrete_optimization.knapsack.knapsack_model import (
     Item,
     KnapsackModel,
@@ -76,24 +72,9 @@ def best_of_greedy(knapsack_model: KnapsackModel) -> KnapsackSolution:
 
 
 class GreedyBest(SolverKnapsack):
-    def __init__(
-        self,
-        knapsack_model: KnapsackModel,
-        params_objective_function: Optional[ParamsObjectiveFunction] = None,
-    ):
-        SolverKnapsack.__init__(self, knapsack_model=knapsack_model)
-        (
-            self.aggreg_sol,
-            self.aggreg_dict,
-            self.params_objective_function,
-        ) = build_aggreg_function_and_params_objective(
-            problem=self.knapsack_model,
-            params_objective_function=params_objective_function,
-        )
-
     def solve(self, **kwargs: Any) -> ResultStorage:
-        res = best_of_greedy(self.knapsack_model)
-        fit = self.aggreg_sol(res)
+        res = best_of_greedy(self.problem)
+        fit = self.aggreg_from_sol(res)
         return ResultStorage(
             list_solution_fits=[(res, fit)],
             best_solution=res,
@@ -102,29 +83,14 @@ class GreedyBest(SolverKnapsack):
 
 
 class GreedyDummy(SolverKnapsack):
-    def __init__(
-        self,
-        knapsack_model: KnapsackModel,
-        params_objective_function: Optional[ParamsObjectiveFunction] = None,
-    ):
-        SolverKnapsack.__init__(self, knapsack_model=knapsack_model)
-        (
-            self.aggreg_sol,
-            self.aggreg_dict,
-            self.params_objective_function,
-        ) = build_aggreg_function_and_params_objective(
-            problem=self.knapsack_model,
-            params_objective_function=params_objective_function,
-        )
-
     def solve(self, **kwargs: Any) -> ResultStorage:
         sol = KnapsackSolution(
-            problem=self.knapsack_model,
+            problem=self.problem,
             value=0,
             weight=0,
-            list_taken=[0] * self.knapsack_model.nb_items,
+            list_taken=[0] * self.problem.nb_items,
         )
-        fit = self.aggreg_sol(sol)
+        fit = self.aggreg_from_sol(sol)
         return ResultStorage(
             list_solution_fits=[(sol, fit)],
             best_solution=sol,

--- a/discrete_optimization/knapsack/solvers/knapsack_lns_solver.py
+++ b/discrete_optimization/knapsack/solvers/knapsack_lns_solver.py
@@ -41,8 +41,8 @@ class InitialKnapsackSolution(InitialSolution):
         self.problem = problem
         self.initial_method = initial_method
         (
-            self.aggreg_sol,
-            self.aggreg_dict,
+            self.aggreg_from_sol,
+            self.aggreg_from_dict,
             self.params_objective_function,
         ) = build_aggreg_function_and_params_objective(
             problem=self.problem, params_objective_function=params_objective_function
@@ -56,7 +56,7 @@ class InitialKnapsackSolution(InitialSolution):
             return greedy_solver.solve()
         else:
             solution = self.problem.get_dummy_solution()
-            fit = self.aggreg_sol(solution)
+            fit = self.aggreg_from_sol(solution)
             return ResultStorage(
                 list_solution_fits=[(solution, fit)],
                 best_solution=solution,

--- a/discrete_optimization/knapsack/solvers/knapsack_solver.py
+++ b/discrete_optimization/knapsack/solvers/knapsack_solver.py
@@ -2,15 +2,10 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Any
 
 from discrete_optimization.generic_tools.do_solver import SolverDO
 from discrete_optimization.knapsack.knapsack_model import KnapsackModel
 
 
 class SolverKnapsack(SolverDO):
-    def __init__(self, knapsack_model: KnapsackModel, **kwargs: Any):
-        self.knapsack_model = knapsack_model
-
-    def init_model(self, **kwargs: Any) -> None:
-        pass
+    problem: KnapsackModel

--- a/discrete_optimization/rcpsp/rcpsp_solvers.py
+++ b/discrete_optimization/rcpsp/rcpsp_solvers.py
@@ -250,32 +250,32 @@ def look_for_solver_class(
 
 def solve(
     method: Union[Type[SolverRCPSP], Type[SolverGenericRCPSP]],
-    rcpsp_model: ANY_CLASSICAL_RCPSP,
+    problem: ANY_CLASSICAL_RCPSP,
     **kwargs: Any,
 ) -> ResultStorage:
-    solver = return_solver(method=method, rcpsp_model=rcpsp_model, **kwargs)
+    solver = return_solver(method=method, problem=problem, **kwargs)
     return solver.solve(**kwargs)
 
 
 def solve_return_solver(
     method: Union[Type[SolverRCPSP], Type[SolverGenericRCPSP]],
-    rcpsp_model: ANY_CLASSICAL_RCPSP,
+    problem: ANY_CLASSICAL_RCPSP,
     **kwargs: Any,
 ) -> Tuple[ResultStorage, Union[SolverRCPSP, SolverGenericRCPSP]]:
-    solver = return_solver(method=method, rcpsp_model=rcpsp_model, **kwargs)
+    solver = return_solver(method=method, problem=problem, **kwargs)
     return solver.solve(**kwargs), solver
 
 
 def return_solver(
     method: Union[Type[SolverRCPSP], Type[SolverGenericRCPSP]],
-    rcpsp_model: ANY_CLASSICAL_RCPSP,
+    problem: ANY_CLASSICAL_RCPSP,
     **kwargs: Any,
 ) -> Union[SolverRCPSP, SolverGenericRCPSP]:
     solver: Union[SolverRCPSP, SolverGenericRCPSP]
     if method == GPHH:
-        solver = GPHH(training_domains=[rcpsp_model], rcpsp_model=rcpsp_model, **kwargs)
+        solver = GPHH(training_domains=[problem], problem=problem, **kwargs)
     else:
-        solver = method(rcpsp_model=rcpsp_model, **kwargs)
+        solver = method(problem=problem, **kwargs)
     try:
         solver.init_model(**kwargs)
     except:

--- a/discrete_optimization/rcpsp/solver/cp_lns_methods_preemptive.py
+++ b/discrete_optimization/rcpsp/solver/cp_lns_methods_preemptive.py
@@ -80,7 +80,7 @@ class PostProLeftShift(PostProcessSolution):
         self.params_objective_function = params_objective_function
         (
             self.aggreg_from_sol,
-            self.aggreg_dict,
+            self.aggreg_from_dict,
             self.params_objective_function,
         ) = build_aggreg_function_and_params_objective(
             problem=self.problem,
@@ -116,7 +116,7 @@ class PostProLeftShift(PostProcessSolution):
         fit = self.aggreg_from_sol(new_solution)
         result_storage.add_solution(new_solution, fit)
         if self.do_ls:
-            solver = LS_RCPSP_Solver(rcpsp_model=self.problem, ls_solver=LS_SOLVER.SA)
+            solver = LS_RCPSP_Solver(problem=self.problem, ls_solver=LS_SOLVER.SA)
             s = result_storage.get_best_solution().copy()
             if self.problem != s.problem:
                 s.change_problem(self.problem)
@@ -1007,7 +1007,7 @@ class PostProcessSolutionNonFeasible(PostProcessSolution):
                 ]
         if self.do_ls:
             solver = LS_RCPSP_Solver(
-                rcpsp_model=self.problem_calendar, ls_solver=LS_SOLVER.SA
+                problem=self.problem_calendar, ls_solver=LS_SOLVER.SA
             )
             satisfiable = [
                 (s, f) for s, f in result_storage.list_solution_fits if s.satisfy

--- a/discrete_optimization/rcpsp/solver/cpsat_solver.py
+++ b/discrete_optimization/rcpsp/solver/cpsat_solver.py
@@ -20,11 +20,7 @@ from ortools.sat.python.cp_model import (
 )
 
 from discrete_optimization.generic_tools.cp_tools import ParametersCP, StatusSolver
-from discrete_optimization.generic_tools.do_problem import (
-    ParamsObjectiveFunction,
-    build_aggreg_function_and_params_objective,
-)
-from discrete_optimization.generic_tools.do_solver import SolverDO
+from discrete_optimization.generic_tools.do_problem import ParamsObjectiveFunction
 from discrete_optimization.generic_tools.result_storage.result_storage import (
     ResultStorage,
     from_solutions_to_result_storage,
@@ -35,24 +31,22 @@ from discrete_optimization.rcpsp.rcpsp_utils import (
     get_end_bounds_from_additional_constraint,
     get_start_bounds_from_additional_constraint,
 )
+from discrete_optimization.rcpsp.solver.rcpsp_solver import SolverRCPSP
 from discrete_optimization.rcpsp.special_constraints import PairModeConstraint
 
 logger = logging.getLogger(__name__)
 
 
-class CPSatRCPSPSolver(SolverDO):
+class CPSatRCPSPSolver(SolverRCPSP):
+    problem: RCPSPModel
+
     def __init__(
         self,
         problem: RCPSPModel,
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
     ):
-        self.problem = problem
-        (
-            self.aggreg_sol,
-            self.aggreg_from_dict_values,
-            self.params_objective_function,
-        ) = build_aggreg_function_and_params_objective(
-            self.problem, params_objective_function=params_objective_function
+        super().__init__(
+            problem=problem, params_objective_function=params_objective_function
         )
         self.cp_model: Optional[CpModel] = None
         self.cp_solver: Optional[CpSolver] = None

--- a/discrete_optimization/rcpsp/solver/rcpsp_ga_solver.py
+++ b/discrete_optimization/rcpsp/solver/rcpsp_ga_solver.py
@@ -2,10 +2,6 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from discrete_optimization.generic_tools.do_problem import (
-    ParamsObjectiveFunction,
-    build_aggreg_function_and_params_objective,
-)
 from discrete_optimization.generic_tools.ea.alternating_ga import AlternatingGa
 from discrete_optimization.generic_tools.ea.ga import Ga
 from discrete_optimization.generic_tools.ea.ga_tools import (
@@ -17,24 +13,11 @@ from discrete_optimization.rcpsp.solver.rcpsp_solver import SolverRCPSP
 
 
 class GA_RCPSP_Solver(SolverRCPSP):
-    def __init__(
-        self,
-        rcpsp_model: RCPSPModel,
-        params_objective_function: ParamsObjectiveFunction = None,
-        **kwargs
-    ):
-        SolverRCPSP.__init__(self, rcpsp_model=rcpsp_model)
-        (
-            self.aggreg_sol,
-            self.aggreg_from_dict_values,
-            self.params_objective_function,
-        ) = build_aggreg_function_and_params_objective(
-            self.rcpsp_model, params_objective_function=params_objective_function
-        )
+    problem: RCPSPModel
 
     def solve(self, parameters_ga: ParametersGa = ParametersGa.default_rcpsp(), **args):
         ga_solver = Ga(
-            problem=self.rcpsp_model,
+            problem=self.problem,
             encoding=parameters_ga.encoding,
             objective_handling=parameters_ga.objective_handling,
             objectives=parameters_ga.objectives,
@@ -53,26 +36,13 @@ class GA_RCPSP_Solver(SolverRCPSP):
 
 
 class GA_MRCPSP_Solver(SolverRCPSP):
-    def __init__(
-        self,
-        rcpsp_model: RCPSPModel,
-        params_objective_function: ParamsObjectiveFunction = None,
-        **kwargs
-    ):
-        SolverRCPSP.__init__(self, rcpsp_model=rcpsp_model)
-        (
-            self.aggreg_sol,
-            self.aggreg_from_dict_values,
-            self.params_objective_function,
-        ) = build_aggreg_function_and_params_objective(
-            self.rcpsp_model, params_objective_function=params_objective_function
-        )
+    problem: RCPSPModel
 
     def solve(
         self, parameters_ga: ParametersAltGa = ParametersAltGa.default_mrcpsp(), **args
     ):
         ga_solver = AlternatingGa(
-            problem=self.rcpsp_model,
+            problem=self.problem,
             encodings=parameters_ga.encodings,
             objective_handling=parameters_ga.objective_handling,
             objectives=parameters_ga.objectives,

--- a/discrete_optimization/rcpsp/solver/rcpsp_solver.py
+++ b/discrete_optimization/rcpsp/solver/rcpsp_solver.py
@@ -2,7 +2,7 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Any, Union
+from typing import Union
 
 from discrete_optimization.generic_tools.do_solver import SolverDO
 from discrete_optimization.rcpsp.rcpsp_model import RCPSPModel
@@ -10,10 +10,4 @@ from discrete_optimization.rcpsp.rcpsp_model_preemptive import RCPSPModelPreempt
 
 
 class SolverRCPSP(SolverDO):
-    def __init__(
-        self, rcpsp_model: Union[RCPSPModel, RCPSPModelPreemptive], **kwargs: Any
-    ):
-        self.rcpsp_model = rcpsp_model
-
-    def init_model(self, **kwargs: Any) -> None:
-        pass
+    problem: Union[RCPSPModel, RCPSPModelPreemptive]

--- a/discrete_optimization/rcpsp_multiskill/rcpsp_multiskill_mslib_parser.py
+++ b/discrete_optimization/rcpsp_multiskill/rcpsp_multiskill_mslib_parser.py
@@ -191,7 +191,7 @@ if __name__ == "__main__":
     )
 
     logging.basicConfig(level=logging.DEBUG)
-    solver = LS_RCPSP_Solver(rcpsp_model=model)
+    solver = LS_RCPSP_Solver(problem=model)
     result = solver.solve(nb_iteration_max=5000)
     sol, fit = result.get_best_solution_fit()
     plot_resource_individual_gantt(rcpsp_model=model, rcpsp_sol=sol)

--- a/discrete_optimization/rcpsp_multiskill/rcpsp_multiskill_solvers.py
+++ b/discrete_optimization/rcpsp_multiskill/rcpsp_multiskill_solvers.py
@@ -163,11 +163,11 @@ def look_for_solver_class(class_domain):
     return available
 
 
-def solve(method, rcpsp_model: MS_RCPSPModel, **args) -> ResultStorage:
+def solve(method, problem: MS_RCPSPModel, **args) -> ResultStorage:
     if method == GPHH:
-        solver = GPHH([rcpsp_model], rcpsp_model, **args)
+        solver = GPHH([problem], problem, **args)
     else:
-        solver = method(rcpsp_model, **args)
+        solver = method(problem, **args)
     try:
         solver.init_model(**args)
     except:
@@ -175,11 +175,11 @@ def solve(method, rcpsp_model: MS_RCPSPModel, **args) -> ResultStorage:
     return solver.solve(**args)
 
 
-def return_solver(method, rcpsp_model: MS_RCPSPModel, **args) -> ResultStorage:
+def return_solver(method, problem: MS_RCPSPModel, **args) -> ResultStorage:
     if method == GPHH:
-        solver = GPHH([rcpsp_model], rcpsp_model, **args)
+        solver = GPHH([problem], problem, **args)
     else:
-        solver = method(rcpsp_model, **args)
+        solver = method(problem, **args)
     try:
         solver.init_model(**args)
     except:

--- a/discrete_optimization/rcpsp_multiskill/solvers/lns_post_process_rcpsp.py
+++ b/discrete_optimization/rcpsp_multiskill/solvers/lns_post_process_rcpsp.py
@@ -34,7 +34,7 @@ class PostProMSRCPSP(PostProcessSolution):
         self.params_objective_function = params_objective_function
         (
             self.aggreg_from_sol,
-            self.aggreg_dict,
+            self.aggreg_from_dict,
             self.params_objective_function,
         ) = build_aggreg_function_and_params_objective(
             problem=self.problem,
@@ -87,7 +87,7 @@ class PostProMSRCPSPPreemptive(PostProcessSolution):
         self.params_objective_function = params_objective_function
         (
             self.aggreg_from_sol,
-            self.aggreg_dict,
+            self.aggreg_from_dict,
             self.params_objective_function,
         ) = build_aggreg_function_and_params_objective(
             problem=self.problem,

--- a/discrete_optimization/rcpsp_multiskill/solvers/ms_rcpsp_ga_solver.py
+++ b/discrete_optimization/rcpsp_multiskill/solvers/ms_rcpsp_ga_solver.py
@@ -2,10 +2,6 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from discrete_optimization.generic_tools.do_problem import (
-    ParamsObjectiveFunction,
-    build_aggreg_function_and_params_objective,
-)
 from discrete_optimization.generic_tools.do_solver import SolverDO
 from discrete_optimization.generic_tools.ea.alternating_ga import AlternatingGa
 from discrete_optimization.generic_tools.ea.ga_tools import ParametersAltGa
@@ -13,26 +9,13 @@ from discrete_optimization.rcpsp.rcpsp_model import RCPSPModel
 
 
 class GA_MSRCPSP_Solver(SolverDO):
-    def __init__(
-        self,
-        rcpsp_model: RCPSPModel,
-        params_objective_function: ParamsObjectiveFunction = None,
-        **kwargs
-    ):
-        self.rcpsp_model = rcpsp_model
-        (
-            self.aggreg_sol,
-            self.aggreg_from_dict_values,
-            self.params_objective_function,
-        ) = build_aggreg_function_and_params_objective(
-            self.rcpsp_model, params_objective_function=params_objective_function
-        )
+    problem: RCPSPModel
 
     def solve(
         self, parameters_ga: ParametersAltGa = ParametersAltGa.default_msrcpsp(), **args
     ):
         ga_solver = AlternatingGa(
-            problem=self.rcpsp_model,
+            problem=self.problem,
             encodings=parameters_ga.encodings,
             objective_handling=parameters_ga.objective_handling,
             objectives=parameters_ga.objectives,

--- a/discrete_optimization/rcpsp_multiskill/solvers/solver_rcpsp_based.py
+++ b/discrete_optimization/rcpsp_multiskill/solvers/solver_rcpsp_based.py
@@ -4,10 +4,7 @@
 
 from typing import Union
 
-from discrete_optimization.generic_tools.do_problem import (
-    ParamsObjectiveFunction,
-    build_aggreg_function_and_params_objective,
-)
+from discrete_optimization.generic_tools.do_problem import ParamsObjectiveFunction
 from discrete_optimization.generic_tools.do_solver import SolverDO
 from discrete_optimization.generic_tools.result_storage.result_storage import (
     ResultStorage,
@@ -22,44 +19,41 @@ from discrete_optimization.rcpsp_multiskill.rcpsp_multiskill import (
 
 
 class Solver_RCPSP_Based(SolverDO):
+    problem: Union[MS_RCPSPModel, MS_RCPSPModel_Variant]
+
     def __init__(
         self,
-        model: Union[MS_RCPSPModel, MS_RCPSPModel_Variant],
+        problem: Union[MS_RCPSPModel, MS_RCPSPModel_Variant],
         method,
         params_objective_function: ParamsObjectiveFunction = None,
         **args
     ):
-        self.model = model
-        self.model_rcpsp = model.build_multimode_rcpsp_calendar_representative()
+        super().__init__(
+            problem=problem, params_objective_function=params_objective_function
+        )
+        self.problem_rcpsp = problem.build_multimode_rcpsp_calendar_representative()
         self.method = method
         self.args_solve = args
-        (
-            self.aggreg_from_sol,
-            self.aggreg_dict,
-            self.params_objective_function,
-        ) = build_aggreg_function_and_params_objective(
-            problem=self.model, params_objective_function=params_objective_function
-        )
         self.args_solve["params_objective_function"] = self.params_objective_function
 
     def solve(self, **kwargs):
         res_storage = solve(
-            method=self.method, rcpsp_model=self.model_rcpsp, **self.args_solve
+            method=self.method, problem=self.problem_rcpsp, **self.args_solve
         )
         list_solution_fits = []
         for s, fit in res_storage.list_solution_fits:
             sol: RCPSPSolution = s
             mode = sol.rcpsp_modes
             modes = {i + 2: mode[i] for i in range(len(mode))}
-            modes[self.model.source_task] = 1
-            modes[self.model.sink_task] = 1
+            modes[self.problem.source_task] = 1
+            modes[self.problem.sink_task] = 1
             ms_rcpsp_solution = MS_RCPSPSolution_Variant(
-                problem=self.model,
+                problem=self.problem,
                 priority_list_task=sol.rcpsp_permutation,
                 modes_vector=sol.rcpsp_modes,
                 priority_worker_per_task=[
-                    [w for w in self.model.employees]
-                    for i in range(self.model.n_jobs_non_dummy)
+                    [w for w in self.problem.employees]
+                    for i in range(self.problem.n_jobs_non_dummy)
                 ],
             )
             list_solution_fits += [

--- a/discrete_optimization/tsp/solver/tsp_solver.py
+++ b/discrete_optimization/tsp/solver/tsp_solver.py
@@ -2,15 +2,9 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Any
-
 from discrete_optimization.generic_tools.do_solver import SolverDO
 from discrete_optimization.tsp.tsp_model import TSPModel
 
 
 class SolverTSP(SolverDO):
-    def __init__(self, tsp_model: TSPModel, **kwargs: Any):
-        self.tsp_model = tsp_model
-
-    def init_model(self, **kwargs: Any) -> None:
-        pass
+    problem: TSPModel

--- a/discrete_optimization/tsp/tsp_solvers.py
+++ b/discrete_optimization/tsp/tsp_solvers.py
@@ -68,10 +68,8 @@ def look_for_solver_class(class_domain: Type["TSPModel"]) -> List[Type[SolverTSP
     return available
 
 
-def solve(
-    method: Type[SolverTSP], tsp_problem: TSPModel, **kwargs: Any
-) -> ResultStorage:
-    solver = method(tsp_model=tsp_problem, **kwargs)
+def solve(method: Type[SolverTSP], problem: TSPModel, **kwargs: Any) -> ResultStorage:
+    solver = method(problem=problem, **kwargs)
     try:
         solver.init_model(**kwargs)
     except AttributeError:
@@ -80,9 +78,9 @@ def solve(
 
 
 def return_solver(
-    method: Type[SolverTSP], tsp_problem: TSPModel, **kwargs: Any
+    method: Type[SolverTSP], problem: TSPModel, **kwargs: Any
 ) -> SolverTSP:
-    solver = method(tsp_problem, **kwargs)
+    solver = method(problem, **kwargs)
     try:
         solver.init_model(**kwargs)
     except:

--- a/discrete_optimization/vrp/solver/greedy_vrp.py
+++ b/discrete_optimization/vrp/solver/greedy_vrp.py
@@ -2,35 +2,17 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Any, Optional
+from typing import Any
 
-from discrete_optimization.generic_tools.do_problem import (
-    ParamsObjectiveFunction,
-    build_aggreg_function_and_params_objective,
-)
 from discrete_optimization.generic_tools.do_solver import ResultStorage
 from discrete_optimization.vrp.solver.vrp_solver import SolverVrp
 from discrete_optimization.vrp.vrp_model import VrpProblem, trivial_solution
 
 
 class GreedyVRPSolver(SolverVrp):
-    def __init__(
-        self,
-        vrp_model: VrpProblem,
-        params_objective_function: Optional[ParamsObjectiveFunction] = None,
-    ):
-        SolverVrp.__init__(self, vrp_model=vrp_model)
-        (
-            self.aggreg_sol,
-            self.aggreg_dict,
-            self.params_objective_function,
-        ) = build_aggreg_function_and_params_objective(
-            problem=self.vrp_model, params_objective_function=params_objective_function
-        )
-
     def solve(self, **kwargs: Any) -> ResultStorage:
-        sol, _ = trivial_solution(self.vrp_model)
-        fit = self.aggreg_sol(sol)
+        sol, _ = trivial_solution(self.problem)
+        fit = self.aggreg_from_sol(sol)
         return ResultStorage(
             list_solution_fits=[(sol, fit)],
             mode_optim=self.params_objective_function.sense_function,

--- a/discrete_optimization/vrp/solver/lp_vrp_iterative.py
+++ b/discrete_optimization/vrp/solver/lp_vrp_iterative.py
@@ -2,6 +2,8 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import logging
 import random
 from copy import deepcopy

--- a/discrete_optimization/vrp/solver/lp_vrp_iterative_pymip.py
+++ b/discrete_optimization/vrp/solver/lp_vrp_iterative_pymip.py
@@ -2,6 +2,8 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 import logging
 import random
 from typing import Any, Dict, List, Optional, Set, Tuple, Union

--- a/discrete_optimization/vrp/solver/vrp_solver.py
+++ b/discrete_optimization/vrp/solver/vrp_solver.py
@@ -2,31 +2,10 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Any, Optional
 
-from discrete_optimization.generic_tools.do_problem import (
-    ParamsObjectiveFunction,
-    build_aggreg_function_and_params_objective,
-)
 from discrete_optimization.generic_tools.do_solver import SolverDO
 from discrete_optimization.vrp.vrp_model import VrpProblem
 
 
 class SolverVrp(SolverDO):
-    def __init__(
-        self,
-        vrp_model: VrpProblem,
-        params_objective_function: Optional[ParamsObjectiveFunction] = None,
-        **kwargs: Any
-    ):
-        self.vrp_model = vrp_model
-        (
-            self.aggreg_sol,
-            self.aggreg_from_dict_values,
-            self.params_objective_function,
-        ) = build_aggreg_function_and_params_objective(
-            self.vrp_model, params_objective_function=params_objective_function
-        )
-
-    def init_model(self, **kwargs: Any) -> None:
-        pass
+    problem: VrpProblem

--- a/discrete_optimization/vrp/vrp_solvers.py
+++ b/discrete_optimization/vrp/vrp_solvers.py
@@ -42,10 +42,8 @@ def look_for_solver_class(class_domain: Type[VrpProblem]) -> List[Type[SolverVrp
     return available
 
 
-def solve(
-    method: Type[SolverVrp], vrp_problem: VrpProblem, **kwargs: Any
-) -> ResultStorage:
-    solver = method(vrp_problem, **kwargs)
+def solve(method: Type[SolverVrp], problem: VrpProblem, **kwargs: Any) -> ResultStorage:
+    solver = method(problem, **kwargs)
     try:
         solver.init_model(**kwargs)
     except:
@@ -54,9 +52,9 @@ def solve(
 
 
 def return_solver(
-    method: Type[SolverVrp], vrp_problem: VrpProblem, **kwargs: Any
+    method: Type[SolverVrp], problem: VrpProblem, **kwargs: Any
 ) -> SolverVrp:
-    solver = method(vrp_problem, **kwargs)
+    solver = method(problem, **kwargs)
     try:
         solver.init_model(**kwargs)
     except:

--- a/examples/coloring/coloring_run_all_solvers.py
+++ b/examples/coloring/coloring_run_all_solvers.py
@@ -30,7 +30,7 @@ def run_solvers():
         if s == ColoringLP:
             # you need a gurobi licence to test this solver.
             continue
-        results = solve(method=s, coloring_model=coloring_model, **solvers_map[s][1])
+        results = solve(method=s, problem=coloring_model, **solvers_map[s][1])
         sol, fit = results.get_best_solution_fit()
         plot_coloring_solution(sol, name_figure=f"{s.__name__} nb_colors={fit}")
         logging.info(f"solver = {s.__name__} sol={sol}, nb_colors={fit}")

--- a/examples/knapsack/knapsack_cpmyp.py
+++ b/examples/knapsack/knapsack_cpmyp.py
@@ -24,13 +24,9 @@ def run():
     logging.basicConfig(level=logging.DEBUG)
     file = [f for f in get_data_available() if "ks_60_0" in f][0]
     knapsack_model = parse_file(file)
-    # solver_lp = LPKnapsack(knapsack_model=knapsack_model, milp_solver_name=MilpSolverName.CBC)
-    # solver_lp.init_model()
-    # res = solver_lp.solve(parameters_milp=ParametersMilp.default())
-    # sol_lp = res.get_best_solution()
     a = SolverLookup.base_solvers()
     print(SolverLookup.base_solvers())
-    solver = CPMPYKnapsackSolver(knapsack_model=knapsack_model)
+    solver = CPMPYKnapsackSolver(problem=knapsack_model)
     solver.init_model()
     parameters_cp = ParametersCP.default()
     parameters_cp.time_limit = 20

--- a/examples/knapsack/knapsack_decomposition_solver.py
+++ b/examples/knapsack/knapsack_decomposition_solver.py
@@ -27,7 +27,7 @@ def run_decomposed_knapsack_asp():
     file = [f for f in get_data_available() if "ks_1000_0" in f][0]
     knapsack_model = parse_file(file)
     solver = KnapsackDecomposedSolver(
-        knapsack_model=knapsack_model, params_objective_function=None
+        problem=knapsack_model, params_objective_function=None
     )
     result_store = solver.solve(
         initial_solver=GreedyBest,
@@ -45,7 +45,7 @@ def run_decomposed_knapsack_greedy():
     file = [f for f in get_data_available() if "ks_10000_0" in f][0]
     knapsack_model = parse_file(file)
     solver = KnapsackDecomposedSolver(
-        knapsack_model=knapsack_model, params_objective_function=None
+        problem=knapsack_model, params_objective_function=None
     )
     result_store = solver.solve(
         initial_solver=GreedyBest,
@@ -63,7 +63,7 @@ def run_decomposed_knapsack_cp():
     file = [f for f in get_data_available() if "ks_1000_0" in f][0]
     knapsack_model = parse_file(file)
     solver = KnapsackDecomposedSolver(
-        knapsack_model=knapsack_model,
+        problem=knapsack_model,
         params_objective_function=None,
     )
     params_cp = ParametersCP.default()

--- a/examples/knapsack/knapsack_multidimensional.py
+++ b/examples/knapsack/knapsack_multidimensional.py
@@ -54,7 +54,7 @@ def run_cp_multidimensional():
     one_file = get_data_available()[10]
     knapsack_model: KnapsackModel = parse_file(one_file)
     multidimensional_knapsack = from_kp_to_multi(knapsack_model)
-    cp_solver = CPMultidimensionalSolver(knapsack_model=multidimensional_knapsack)
+    cp_solver = CPMultidimensionalSolver(problem=multidimensional_knapsack)
     cp_solver.init_model(output_type=True)
     params_cp = ParametersCP.default()
     params_cp.time_limit = 5
@@ -73,7 +73,7 @@ def run_ls(multiscenario_model):
     )
     res = RestartHandlerLimit(3000)
     sa = SimulatedAnnealing(
-        evaluator=multiscenario_model,
+        problem=multiscenario_model,
         mutator=mixed_mutation,
         restart_handler=res,
         temperature_handler=TemperatureSchedulingFactor(1000, res, 0.99),
@@ -98,7 +98,7 @@ def run_cp_multidimensional_multiscenario():
             base_method_aggregating=BaseMethodAggregating.MEAN
         ),
     )
-    solver = CPMultidimensionalMultiScenarioSolver(knapsack_model=multiscenario_model)
+    solver = CPMultidimensionalMultiScenarioSolver(problem=multiscenario_model)
     solver.init_model(output_type=True)
 
     dummy_solution = multiscenario_model.get_dummy_solution()

--- a/examples/knapsack/multiscenario_knap.py
+++ b/examples/knapsack/multiscenario_knap.py
@@ -60,7 +60,7 @@ def initialize_multiscenario():
     )
     res = RestartHandlerLimit(3000)
     sa = SimulatedAnnealing(
-        evaluator=multiscenario_model,
+        problem=multiscenario_model,
         mutator=mixed_mutation,
         restart_handler=res,
         temperature_handler=TemperatureSchedulingFactor(1000, res, 0.99),

--- a/examples/knapsack/solvers_run.py
+++ b/examples/knapsack/solvers_run.py
@@ -38,7 +38,7 @@ def main_run():
         if s == LPKnapsackGurobi:
             # skip Except if you have a licence
             continue
-        results = solve(method=s, knapsack_model=knapsack_model, **solvers_map[s][1])
+        results = solve(method=s, problem=knapsack_model, **solvers_map[s][1])
         s, f = results.get_best_solution_fit()
         logging.info(f"sol={s}")
         logging.info(f"fitness={f}")

--- a/examples/pickup_vrp/cp_solver_gpdp_example.py
+++ b/examples/pickup_vrp/cp_solver_gpdp_example.py
@@ -1675,7 +1675,7 @@ def run_tsp():
     weight = np.ones(len(list_mutation))
     mutate_portfolio = BasicPortfolioMutation(list_mutation, weight)
     sa = SimulatedAnnealing(
-        evaluator=tsp_model,
+        problem=tsp_model,
         mutator=mutate_portfolio,
         restart_handler=res,
         temperature_handler=TemperatureSchedulingFactor(

--- a/examples/rcpsp/rcpsp_lp_cplex_solver.py
+++ b/examples/rcpsp/rcpsp_lp_cplex_solver.py
@@ -23,7 +23,7 @@ def run_rcpsp_sm_lp_cplex():
     files_available = get_data_available()
     file = [f for f in files_available if "j1201_1.sm" in f][0]
     rcpsp_problem: RCPSPModel = parse_file(file)
-    solver = LP_RCPSP_CPLEX(rcpsp_model=rcpsp_problem)
+    solver = LP_RCPSP_CPLEX(problem=rcpsp_problem)
     solver.init_model(greedy_start=True)
     parameters_milp = ParametersMilp.default()
     parameters_milp.time_limit = 10000

--- a/examples/rcpsp/robustness_experiments.py
+++ b/examples/rcpsp/robustness_experiments.py
@@ -146,7 +146,7 @@ def run_cp_multiscenario():
     )
     res = RestartHandlerLimit(500)
     simulated_annealing = SimulatedAnnealing(
-        evaluator=model_aggreg_mean,
+        problem=model_aggreg_mean,
         mutator=mixed_mutation,
         mode_mutation=ModeMutation.MUTATE,
         restart_handler=res,
@@ -164,7 +164,7 @@ def run_cp_multiscenario():
         annealing += [model.evaluate(s)["makespan"]]
 
     solver = CP_MULTISCENARIO(
-        list_rcpsp_model=list_rcpsp_model, cp_solver_name=CPSolverName.CHUFFED
+        list_problem=list_rcpsp_model, cp_solver_name=CPSolverName.CHUFFED
     )
     solver.init_model(
         output_type=True, relax_ordering=False, nb_incoherence_limit=2, max_time=300
@@ -209,7 +209,7 @@ def local_search_postpro_multiobj_multimode(postpro=True):
             sense_function=ModeOptim.MAXIMIZATION,
         )
         sa = SimulatedAnnealing(
-            evaluator=rcpsp_model,
+            problem=rcpsp_model,
             mutator=mixed_mutation,
             restart_handler=res,
             temperature_handler=TemperatureSchedulingFactor(
@@ -228,7 +228,7 @@ def local_search_postpro_multiobj_multimode(postpro=True):
             sense_function=ModeOptim.MAXIMIZATION,
         )
         sa = HillClimberPareto(
-            evaluator=rcpsp_model,
+            problem=rcpsp_model,
             mutator=mixed_mutation,
             restart_handler=res,
             params_objective_function=params_objective_function,
@@ -259,7 +259,7 @@ def local_search_postpro_multiobj_multimode(postpro=True):
     all_results = []
     results = np.zeros((len(solutions_pareto), len(many_random_instance), 3))
 
-    executor = Executor(rcpsp_model=rcpsp_model)
+    executor = Executor(problem=rcpsp_model)
     for index_instance in range(len(many_random_instance)):
         print("Evaluating in instance #", index_instance)
         instance = many_random_instance[index_instance]
@@ -341,7 +341,7 @@ def solve_model(model, postpro=True, nb_iteration=500):
             sense_function=ModeOptim.MAXIMIZATION,
         )
         sa = SimulatedAnnealing(
-            evaluator=model,
+            problem=model,
             mutator=mixed_mutation,
             restart_handler=res,
             temperature_handler=TemperatureSchedulingFactor(
@@ -360,7 +360,7 @@ def solve_model(model, postpro=True, nb_iteration=500):
             sense_function=ModeOptim.MAXIMIZATION,
         )
         sa = HillClimberPareto(
-            evaluator=model,
+            problem=model,
             mutator=mixed_mutation,
             restart_handler=res,
             params_objective_function=params_objective_function,

--- a/examples/rcpsp_multiskill/mslib/mslib_parse_and_solve.py
+++ b/examples/rcpsp_multiskill/mslib/mslib_parse_and_solve.py
@@ -25,7 +25,7 @@ def example_parsing_and_local_search():
     logger.info("file = ", file)
     model = parse_file_mslib(file).to_variant_model()
     logging.basicConfig(level=logging.DEBUG)
-    solver = LS_RCPSP_Solver(rcpsp_model=model)
+    solver = LS_RCPSP_Solver(problem=model)
     result = solver.solve(nb_iteration_max=5000)
     sol, fit = result.get_best_solution_fit()
     plot_resource_individual_gantt(rcpsp_model=model, rcpsp_sol=sol)

--- a/examples/rcpsp_multiskill/solvers/rcpsp_multiskills_runs.py
+++ b/examples/rcpsp_multiskill/solvers/rcpsp_multiskills_runs.py
@@ -72,7 +72,7 @@ def run_lp_debug():
         horizon=100,
         horizon_multiplier=1,
     )
-    lp_model = LP_Solver_MRSCPSP(rcpsp_model=model, lp_solver=MilpSolverName.CBC)
+    lp_model = LP_Solver_MRSCPSP(problem=model, lp_solver=MilpSolverName.CBC)
     lp_model.init_model()
     result = lp_model.solve(parameters_milp=ParametersMilp.default())
 
@@ -145,7 +145,7 @@ def run_lp_debug_bis():
         horizon=100,
         horizon_multiplier=1,
     )
-    lp_model = LP_Solver_MRSCPSP(rcpsp_model=model, lp_solver=MilpSolverName.CBC)
+    lp_model = LP_Solver_MRSCPSP(problem=model, lp_solver=MilpSolverName.CBC)
     lp_model.init_model()
     result = lp_model.solve(parameters_milp=ParametersMilp.default())
     best_solution = result.get_best_solution()

--- a/examples/vrp/vrp_solver_example.py
+++ b/examples/vrp/vrp_solver_example.py
@@ -21,7 +21,7 @@ def run_ortools_vrp_solver():
     vrp_model = parse_file(file_path)
     print("Nb vehicle : ", vrp_model.vehicle_count)
     print("Capacities : ", vrp_model.vehicle_capacities)
-    solver = VrpORToolsSolver(vrp_model=vrp_model)
+    solver = VrpORToolsSolver(problem=vrp_model)
     solver.init_model(
         first_solution_strategy=FirstSolutionStrategy.SAVINGS,
         local_search_metaheuristic=LocalSearchMetaheuristic.GUIDED_LOCAL_SEARCH,
@@ -40,7 +40,7 @@ def run_lp_vrp_solver():
     vrp_model = parse_file(file_path)
     print("Nb vehicle : ", vrp_model.vehicle_count)
     print("Capacities : ", vrp_model.vehicle_capacities)
-    solver = VRPIterativeLP(vrp_model=vrp_model)
+    solver = VRPIterativeLP(problem=vrp_model)
     solver.init_model()
     res = solver.solve(limit_time_s=20)
     sol, fit = res.get_best_solution_fit()
@@ -54,7 +54,7 @@ def run_greedy_vrp_solver():
     file_path = [f for f in get_data_available() if "vrp_31_9_1" in f][0]
     print(file_path)
     vrp_model = parse_file(file_path)
-    greedy_solver = GreedyVRPSolver(vrp_model=vrp_model, params_objective_function=None)
+    greedy_solver = GreedyVRPSolver(problem=vrp_model, params_objective_function=None)
     res = greedy_solver.solve(limit_time_s=20)
     sol, fit = res.get_best_solution_fit()
     print(vrp_model.evaluate(sol))

--- a/notebooks/Knapsack tutorial.ipynb
+++ b/notebooks/Knapsack tutorial.ipynb
@@ -279,7 +279,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "greedy_solver = GreedyBest(knapsack_model=model)"
+    "greedy_solver = GreedyBest(problem=model)"
    ]
   },
   {
@@ -389,7 +389,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lp_solver_cbc = LPKnapsack(knapsack_model=model, milp_solver_name=MilpSolverName.CBC)"
+    "lp_solver_cbc = LPKnapsack(problem=model, milp_solver_name=MilpSolverName.CBC)"
    ]
   },
   {
@@ -438,7 +438,7 @@
    "id": "d207ac79",
    "metadata": {},
    "source": [
-    "lp_solver_gurobi = LPKnapsack(knapsack_model=model, milp_solver_name=MilpSolverName.GRB)\n",
+    "lp_solver_gurobi = LPKnapsack(problem=model, milp_solver_name=MilpSolverName.GRB)\n",
     "params_milp = ParametersMilp(\n",
     "    time_limit=100,\n",
     "    pool_solutions=10000,\n",
@@ -481,7 +481,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cp_solver = CPKnapsackMZN2(knapsack_model=model, cp_solver_name=CPSolverName.CHUFFED)\n",
+    "cp_solver = CPKnapsackMZN2(problem=model, cp_solver_name=CPSolverName.CHUFFED)\n",
     "parameters_cp = ParametersCP.default()\n",
     "parameters_cp.time_limit = 50\n",
     "results_cp = cp_solver.solve(parameters_cp=parameters_cp)"

--- a/notebooks/RCPSP tutorials/RCPSP-1 Introduction.ipynb
+++ b/notebooks/RCPSP tutorials/RCPSP-1 Introduction.ipynb
@@ -324,7 +324,7 @@
    "source": [
     "from discrete_optimization.rcpsp.solver.cpm import CPM\n",
     "\n",
-    "solver = CPM(rcpsp_model=rcpsp_model)\n",
+    "solver = CPM(problem=rcpsp_model)\n",
     "critical_path = solver.run_classic_cpm()\n",
     "edges = [(pi, pi1) for pi, pi1 in zip(critical_path[:-1], critical_path[1:])]\n",
     "print(solver.map_node[rcpsp_model.sink_task])"

--- a/notebooks/RCPSP tutorials/RCPSP-2 Heuristics Solving.ipynb
+++ b/notebooks/RCPSP tutorials/RCPSP-2 Heuristics Solving.ipynb
@@ -86,7 +86,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "solver = PileSolverRCPSP(rcpsp_model=rcpsp_problem)\n",
+    "solver = PileSolverRCPSP(problem=rcpsp_problem)\n",
     "result_storage = solver.solve(greedy_choice=GreedyChoice.MOST_SUCCESSORS)"
    ]
   },
@@ -156,7 +156,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "solver = CPM(rcpsp_model=rcpsp_problem)\n",
+    "solver = CPM(problem=rcpsp_problem)\n",
     "critical_path = solver.run_classic_cpm()\n",
     "sol = solver.solve().get_best_solution()\n",
     "sol.get_start_time(rcpsp_problem.sink_task)"

--- a/notebooks/RCPSP tutorials/RCPSP-3 Local search.ipynb
+++ b/notebooks/RCPSP tutorials/RCPSP-3 Local search.ipynb
@@ -102,7 +102,7 @@
     "The API of the HillClimber object is the following.\n",
     "```\n",
     "HillClimber(\n",
-    "    evaluator: discrete_optimization.generic_tools.do_problem.Problem,\n",
+    "    problem: discrete_optimization.generic_tools.do_problem.Problem,\n",
     "    mutator: discrete_optimization.generic_tools.do_mutation.Mutation,\n",
     "    restart_handler: discrete_optimization.generic_tools.ls.local_search.RestartHandler,\n",
     "    mode_mutation: discrete_optimization.generic_tools.ls.local_search.ModeMutation,\n",
@@ -174,7 +174,7 @@
    "outputs": [],
    "source": [
     "solver = HillClimber(\n",
-    "    evaluator=rcpsp_problem,\n",
+    "    problem=rcpsp_problem,\n",
     "    mode_mutation=ModeMutation.MUTATE_AND_EVALUATE,\n",
     "    mutator=mixed_mutation,\n",
     "    restart_handler=RestartHandler(),\n",
@@ -306,8 +306,6 @@
     "# Come back to best solution every 300 iteration without improvement.\n",
     "restart_handler = RestartHandlerLimit(\n",
     "    nb_iteration_no_improvement=300,\n",
-    "    cur_solution=dummy,\n",
-    "    cur_objective=-rcpsp_problem.evaluate(dummy)[\"makespan\"],\n",
     ")\n",
     "# Multiply current temperature by a coefficient at every iteration. There might be better cooling schedule\n",
     "# in the litterature.\n",
@@ -332,7 +330,7 @@
    "outputs": [],
    "source": [
     "solver = SimulatedAnnealing(\n",
-    "    evaluator=rcpsp_problem,\n",
+    "    problem=rcpsp_problem,\n",
     "    mutator=mixed_mutation,\n",
     "    temperature_handler=temperature_scheduling,\n",
     "    restart_handler=restart_handler,\n",
@@ -379,7 +377,7 @@
    "id": "dacf1cfd",
    "metadata": {},
    "source": [
-    "Since RCPSP is a widely developed use case in `discrete-optimisation` we developed a wrapper around Hill climbing and simulated annealing to ease theur use : "
+    "Since RCPSP is a widely developed use case in `discrete-optimisation` we developed a wrapper around Hill climbing and simulated annealing to ease their use : "
    ]
   },
   {
@@ -389,7 +387,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from discrete_optimization.rcpsp.solver.ls_solver import LS_SOLVER, LS_RCPSP_Solver"
+    "from discrete_optimization.generic_rcpsp_tools.ls_solver import (\n",
+    "    LS_SOLVER,\n",
+    "    LS_RCPSP_Solver,\n",
+    ")"
    ]
   },
   {
@@ -399,7 +400,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "solver = LS_RCPSP_Solver(ls_solver=LS_SOLVER.HC, model=rcpsp_problem)\n",
+    "solver = LS_RCPSP_Solver(ls_solver=LS_SOLVER.HC, problem=rcpsp_problem)\n",
     "res = solver.solve(nb_iteration_max=10000, max_time_seconds=20)"
    ]
   },
@@ -431,10 +432,10 @@
    "source": [
     "from discrete_optimization.rcpsp.solver.rcpsp_pile import GreedyChoice, PileSolverRCPSP\n",
     "\n",
-    "solver = PileSolverRCPSP(rcpsp_model=rcpsp_problem)\n",
+    "solver = PileSolverRCPSP(problem=rcpsp_problem)\n",
     "res_greedy = solver.solve(greedy_choice=GreedyChoice.MOST_SUCCESSORS)\n",
     "print(\"res greedy : \", res_greedy.get_best_solution_fit())\n",
-    "solver = LS_RCPSP_Solver(ls_solver=LS_SOLVER.SA, model=rcpsp_problem)\n",
+    "solver = LS_RCPSP_Solver(ls_solver=LS_SOLVER.SA, problem=rcpsp_problem)\n",
     "res = solver.solve(\n",
     "    nb_iteration_max=30000,\n",
     "    max_time_seconds=20,\n",

--- a/notebooks/RCPSP tutorials/RCPSP-4 Linear programming.ipynb
+++ b/notebooks/RCPSP tutorials/RCPSP-4 Linear programming.ipynb
@@ -108,7 +108,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "solver = LP_RCPSP(rcpsp_model=rcpsp_problem)\n",
+    "solver = LP_RCPSP(problem=rcpsp_problem)\n",
     "parameters_milp = ParametersMilp.default()\n",
     "solver.init_model(greedy_start=True)\n",
     "results = solver.solve(parameters_milp=parameters_milp)"

--- a/notebooks/RCPSP tutorials/RCPSP-5 Constraint Programming.ipynb
+++ b/notebooks/RCPSP tutorials/RCPSP-5 Constraint Programming.ipynb
@@ -101,7 +101,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "solver = CP_RCPSP_MZN(rcpsp_model=rcpsp_problem, cp_solver_name=CPSolverName.CHUFFED)\n",
+    "solver = CP_RCPSP_MZN(problem=rcpsp_problem, cp_solver_name=CPSolverName.CHUFFED)\n",
     "solver.init_model()\n",
     "parameters_cp = ParametersCP.default()\n",
     "parameters_cp.time_limit = 20\n",

--- a/notebooks/RCPSP tutorials/RCPSP-6 Large Neighbourhood Search .ipynb
+++ b/notebooks/RCPSP tutorials/RCPSP-6 Large Neighbourhood Search .ipynb
@@ -73,7 +73,7 @@
     "    ParametersCP,\n",
     ")\n",
     "\n",
-    "solver = CP_RCPSP_MZN(rcpsp_model=rcpsp_problem, cp_solver_name=CPSolverName.CHUFFED)\n",
+    "solver = CP_RCPSP_MZN(problem=rcpsp_problem, cp_solver_name=CPSolverName.CHUFFED)\n",
     "params_cp = ParametersCP.default()\n",
     "params_cp.time_limit = 20\n",
     "solver.init_model(output_type=True)\n",
@@ -175,11 +175,6 @@
    "source": [
     "from discrete_optimization.generic_rcpsp_tools.large_neighborhood_search_scheduling import (\n",
     "    LargeNeighborhoodSearchScheduling,\n",
-    ")\n",
-    "from discrete_optimization.generic_rcpsp_tools.neighbor_builder import (\n",
-    "    ObjectiveSubproblem,\n",
-    "    ParamsConstraintBuilder,\n",
-    "    mix_lot,\n",
     ")"
    ]
   },
@@ -190,7 +185,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lns_solver = LargeNeighborhoodSearchScheduling(rcpsp_problem=rcpsp_problem)"
+    "lns_solver = LargeNeighborhoodSearchScheduling(problem=rcpsp_problem)"
    ]
   },
   {
@@ -237,7 +232,7 @@
     "    params_list=[\n",
     "        ParamsConstraintBuilder(\n",
     "            minus_delta_primary=60,\n",
-    "            plus_delta_primary=60,\n",
+    "            plus_delta_primary=60,152f1299af4f3f60662a07d1591f3938d973a6c4\n",
     "            minus_delta_secondary=20,\n",
     "            plus_delta_secondary=20,\n",
     "            constraint_max_time_to_current_solution=True,\n",
@@ -267,7 +262,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "solver = CP_RCPSP_MZN(rcpsp_model=rcpsp_problem, cp_solver_name=CPSolverName.CHUFFED)\n",
+    "solver = CP_RCPSP_MZN(problem=rcpsp_problem, cp_solver_name=CPSolverName.CHUFFED)\n",
     "solver.init_model(\n",
     "    output_type=True, ignore_sec_objective=False, add_objective_makespan=False\n",
     ")\n",
@@ -276,7 +271,7 @@
     "    solution=from_solutions_to_result_storage([some_solution], problem=rcpsp_problem)\n",
     ")\n",
     "lns_solver = LargeNeighborhoodSearchScheduling(\n",
-    "    rcpsp_problem=rcpsp_problem,\n",
+    "    problem=rcpsp_problem,\n",
     "    cp_solver=solver,\n",
     "    constraint_handler=constraint_handler,\n",
     "    initial_solution_provider=initial_solution_provider,\n",

--- a/tests/coloring/test_coloring.py
+++ b/tests/coloring/test_coloring.py
@@ -75,7 +75,7 @@ def test_solvers():
         if s == ColoringLP and not gurobi_available:
             # you need a gurobi licence to test this solver.
             continue
-        results = solve(method=s, coloring_model=coloring_model, **solvers_map[s][1])
+        results = solve(method=s, problem=coloring_model, **solvers_map[s][1])
         sol, fit = results.get_best_solution_fit()
 
 
@@ -96,7 +96,7 @@ def test_solvers_subset():
         if s == ColoringLP and not gurobi_available:
             # you need a gurobi licence to test this solver.
             continue
-        results = solve(method=s, coloring_model=coloring_model, **solvers_map[s][1])
+        results = solve(method=s, problem=coloring_model, **solvers_map[s][1])
         sol, fit = results.get_best_solution_fit()
         print(f"Solver {s}, fitness = {fit}")
         print(f"Evaluation : {coloring_model.evaluate(sol)}")

--- a/tests/generic_tools/callbacks/test_sa_with_callbacks.py
+++ b/tests/generic_tools/callbacks/test_sa_with_callbacks.py
@@ -91,7 +91,7 @@ def test_sa_with_callbacks(caplog):
         backuper,
     ]
     sa = SimulatedAnnealing(
-        evaluator=rcpsp_model,
+        problem=rcpsp_model,
         mutator=mixed_mutation,
         restart_handler=restart_handler,
         temperature_handler=temperature_handler,

--- a/tests/knapsack/test_knapsack_cpmyp.py
+++ b/tests/knapsack/test_knapsack_cpmyp.py
@@ -14,7 +14,7 @@ from discrete_optimization.knapsack.solvers.knapsack_cpmpy import CPMPYKnapsackS
 def test_knapsack_cpmyp():
     file = [f for f in get_data_available() if "ks_30_0" in f][0]
     knapsack_model = parse_file(file)
-    solver = CPMPYKnapsackSolver(knapsack_model=knapsack_model)
+    solver = CPMPYKnapsackSolver(problem=knapsack_model)
     solver.init_model()
     parameters_cp = ParametersCP.default()
     parameters_cp.time_limit = 20

--- a/tests/knapsack/test_knapsack_decomposition_solver.py
+++ b/tests/knapsack/test_knapsack_decomposition_solver.py
@@ -26,7 +26,7 @@ def test_decomposed_knapsack_asp():
     file = [f for f in get_data_available() if "ks_1000_0" in f][0]
     knapsack_model = parse_file(file)
     solver = KnapsackDecomposedSolver(
-        knapsack_model=knapsack_model, params_objective_function=None
+        problem=knapsack_model, params_objective_function=None
     )
     result_store = solver.solve(
         root_solver=KnapsackASPSolver,
@@ -43,7 +43,7 @@ def test_decomposed_knapsack_greedy():
     file = [f for f in get_data_available() if "ks_1000_0" in f][0]
     knapsack_model = parse_file(file)
     solver = KnapsackDecomposedSolver(
-        knapsack_model=knapsack_model, params_objective_function=None
+        problem=knapsack_model, params_objective_function=None
     )
     result_store = solver.solve(
         root_solver=GreedyBest,
@@ -60,7 +60,7 @@ def test_decomposed_knapsack_cp():
     file = [f for f in get_data_available() if "ks_1000_0" in f][0]
     knapsack_model = parse_file(file)
     solver = KnapsackDecomposedSolver(
-        knapsack_model=knapsack_model,
+        problem=knapsack_model,
         params_objective_function=None,
     )
     params_cp = ParametersCP.default()

--- a/tests/knapsack/test_knapsack_gphh.py
+++ b/tests/knapsack/test_knapsack_gphh.py
@@ -29,7 +29,7 @@ def test_run_one_example():
     params_gphh.max_tree_depth = 5
     gphh_solver = GPHH(
         training_domains=trainings,
-        domain_model=multidimensional_knapsack,
+        problem=multidimensional_knapsack,
         params_gphh=params_gphh,
     )
     gphh_solver.init_model()

--- a/tests/knapsack/test_knapsack_ls_solver.py
+++ b/tests/knapsack/test_knapsack_ls_solver.py
@@ -43,7 +43,7 @@ def test_sa_knapsack():
     )
     res = RestartHandlerLimit(3000)
     sa = SimulatedAnnealing(
-        evaluator=model,
+        problem=model,
         mutator=mixed_mutation,
         restart_handler=res,
         temperature_handler=TemperatureSchedulingFactor(1000, res, 0.99),
@@ -73,7 +73,7 @@ def test_hc_knapsack_multiobj():
     res = RestartHandlerLimit(3000)
     params_objective_function = get_default_objective_setup(model)
     sa = HillClimberPareto(
-        evaluator=model,
+        problem=model,
         mutator=mixed_mutation,
         restart_handler=res,
         mode_mutation=ModeMutation.MUTATE,

--- a/tests/knapsack/test_knapsack_solvers.py
+++ b/tests/knapsack/test_knapsack_solvers.py
@@ -48,6 +48,6 @@ def test_solvers():
         if s == LPKnapsackGurobi:
             continue
         logging.info(f"Solver {s}")
-        results = solve(method=s, knapsack_model=knapsack_model, **solvers_map[s][1])
+        results = solve(method=s, problem=knapsack_model, **solvers_map[s][1])
         s, f = results.get_best_solution_fit()
         logging.info(f"fitness={f}")

--- a/tests/rcpsp/solver/test_rcpsp_cp.py
+++ b/tests/rcpsp/solver/test_rcpsp_cp.py
@@ -158,9 +158,9 @@ def test_cp_sm_robust():
     worst, average, many_random_instance = create_models(
         rcpsp_model, range_around_mean=5
     )
-    solver_worst = CP_RCPSP_MZN(rcpsp_model=worst)
-    solver_average = CP_RCPSP_MZN(rcpsp_model=average)
-    solver_original = CP_RCPSP_MZN(rcpsp_model=rcpsp_model)
+    solver_worst = CP_RCPSP_MZN(problem=worst)
+    solver_average = CP_RCPSP_MZN(problem=average)
+    solver_original = CP_RCPSP_MZN(problem=rcpsp_model)
     parameters_cp = ParametersCP.default()
     parameters_cp.time_limit = 5
     sol_original, fit_original = solver_original.solve(

--- a/tests/rcpsp/solver/test_rcpsp_cp_lns.py
+++ b/tests/rcpsp/solver/test_rcpsp_cp_lns.py
@@ -32,9 +32,7 @@ def test_lns_sm():
     files_available = get_data_available()
     file = [f for f in files_available if "j1201_1.sm" in f][0]
     rcpsp_problem: RCPSPModel = parse_file(file)
-    solver = CP_RCPSP_MZN(
-        rcpsp_model=rcpsp_problem, cp_solver_name=CPSolverName.CHUFFED
-    )
+    solver = CP_RCPSP_MZN(problem=rcpsp_problem, cp_solver_name=CPSolverName.CHUFFED)
     solver.init_model(output_type=True)
     parameters_cp = ParametersCP.default()
     parameters_cp.time_limit = 5
@@ -80,9 +78,7 @@ def test_lns_mm():
     rcpsp_problem: RCPSPModel = parse_file(file)
     if rcpsp_problem.is_rcpsp_multimode():
         rcpsp_problem.set_fixed_modes([1 for i in range(rcpsp_problem.n_jobs)])
-    solver = CP_MRCPSP_MZN(
-        rcpsp_model=rcpsp_problem, cp_solver_name=CPSolverName.CHUFFED
-    )
+    solver = CP_MRCPSP_MZN(problem=rcpsp_problem, cp_solver_name=CPSolverName.CHUFFED)
     solver.init_model()
     parameters_cp = ParametersCP.default()
     parameters_cp.time_limit = 5
@@ -125,7 +121,7 @@ def test_lns_solver():
     parameters_cp = ParametersCP.default()
     parameters_cp.time_limit = 20
     lns_solver = LNS_CP_RCPSP_SOLVER(
-        rcpsp_model=rcpsp_problem, option_neighbor=OptionNeighbor.MIX_ALL
+        problem=rcpsp_problem, option_neighbor=OptionNeighbor.MIX_ALL
     )
     result_store = lns_solver.solve(
         parameters_cp=parameters_cp,

--- a/tests/rcpsp/solver/test_rcpsp_cpm.py
+++ b/tests/rcpsp/solver/test_rcpsp_cpm.py
@@ -35,7 +35,7 @@ def test_cpm_sm():
     solution_cp, fit_cp = result_storage.get_best_solution_fit()
     assert fit_dummy <= fit_cp
 
-    cpm = CPM(rcpsp_model=rcpsp_problem)
+    cpm = CPM(problem=rcpsp_problem)
     cpath = cpm.run_classic_cpm()
     order = cpm.return_order_cpm()
     permutation_sgs = [o - 2 for o in order]
@@ -182,7 +182,7 @@ def test_cpm_sm():
                         modified_model.successors[e0].remove(e1)
             gg = modified_model.compute_graph()
             has_loop = gg.check_loop()
-        cpm = CPM(rcpsp_model=modified_model)
+        cpm = CPM(problem=modified_model)
         cpath = cpm.run_classic_cpm()
         order = sorted(
             cpm.map_node,
@@ -222,7 +222,7 @@ def test_cpm_partial():
     files_available = get_data_available()
     file = [f for f in files_available if "j1201_1.sm" in f][0]
     rcpsp_problem = parse_file(file)
-    cpm = CPM(rcpsp_model=rcpsp_problem)
+    cpm = CPM(problem=rcpsp_problem)
     sol = cpm.solve()
     cpm.map_node[rcpsp_problem.sink_task]
     best_sol: RCPSPSolution = sol.get_best_solution_fit()[0]

--- a/tests/rcpsp/solver/test_rcpsp_local_search.py
+++ b/tests/rcpsp/solver/test_rcpsp_local_search.py
@@ -73,7 +73,7 @@ def test_local_search_sm(random_seed):
         sense_function=ModeOptim.MAXIMIZATION,
     )
     sa = SimulatedAnnealing(
-        evaluator=rcpsp_model,
+        problem=rcpsp_model,
         mutator=mixed_mutation,
         restart_handler=res,
         temperature_handler=TemperatureSchedulingFactor(1, res, 0.9999),
@@ -123,7 +123,7 @@ def test_local_search_mm(random_seed):
         sense_function=ModeOptim.MAXIMIZATION,
     )
     sa = SimulatedAnnealing(
-        evaluator=rcpsp_model,
+        problem=rcpsp_model,
         mutator=mixed_mutation,
         restart_handler=res,
         temperature_handler=TemperatureSchedulingFactor(1, res, 0.9999),
@@ -171,7 +171,7 @@ def test_local_search_sm_multiobj(random_seed):
         sense_function=ModeOptim.MAXIMIZATION,
     )
     sa = HillClimberPareto(
-        evaluator=rcpsp_model,
+        problem=rcpsp_model,
         mutator=mixed_mutation,
         restart_handler=res,
         params_objective_function=params_objective_function,
@@ -207,7 +207,7 @@ def test_local_search_sm_postpro_multiobj(random_seed):
         sense_function=ModeOptim.MAXIMIZATION,
     )
     sa = SimulatedAnnealing(
-        evaluator=rcpsp_model,
+        problem=rcpsp_model,
         mutator=mixed_mutation,
         restart_handler=res,
         temperature_handler=TemperatureSchedulingFactor(2, res, 0.9999),
@@ -269,7 +269,7 @@ def test_local_search_mm_multiobj(random_seed):
         sense_function=ModeOptim.MAXIMIZATION,
     )
     sa = HillClimberPareto(
-        evaluator=rcpsp_model,
+        problem=rcpsp_model,
         mutator=mixed_mutation,
         restart_handler=res,
         params_objective_function=params_objective_function,
@@ -337,7 +337,7 @@ def test_local_search_postpro_multiobj_multimode(random_seed):
         sense_function=ModeOptim.MAXIMIZATION,
     )
     sa = SimulatedAnnealing(
-        evaluator=rcpsp_model,
+        problem=rcpsp_model,
         mutator=mixed_mutation,
         restart_handler=res,
         temperature_handler=TemperatureSchedulingFactor(10, res, 0.99999),

--- a/tests/rcpsp/solver/test_rcpsp_lp.py
+++ b/tests/rcpsp/solver/test_rcpsp_lp.py
@@ -19,7 +19,7 @@ def test_rcpsp_sm_lp_cbc():
     files_available = get_data_available()
     file = [f for f in files_available if "j301_1.sm" in f][0]
     rcpsp_problem = parse_file(file)
-    solver = LP_RCPSP(rcpsp_model=rcpsp_problem, lp_solver=MilpSolverName.CBC)
+    solver = LP_RCPSP(problem=rcpsp_problem, lp_solver=MilpSolverName.CBC)
     solver.init_model()
     results_storage: ResultStorage = solver.solve(
         parameters_milp=ParametersMilp.default()
@@ -40,7 +40,7 @@ def test_rcpsp_mm_lp_cbc():
     file = [f for f in files_available if "j1010_1.mm" in f][0]
     rcpsp_problem = parse_file(file)
     rcpsp_problem.set_fixed_modes([1 for i in range(rcpsp_problem.n_jobs)])
-    solver = LP_MRCPSP(rcpsp_model=rcpsp_problem, lp_solver=MilpSolverName.CBC)
+    solver = LP_MRCPSP(problem=rcpsp_problem, lp_solver=MilpSolverName.CBC)
     solver.init_model(greedy_start=False)
     results_storage: ResultStorage = solver.solve(
         parameters_milp=ParametersMilp.default()
@@ -68,7 +68,7 @@ def test_rcpsp_sm_lp_cbc_partial():
     }
     partial_solution = PartialSolution(task_mode=None, start_times=some_constraints)
     partial_solution_for_lp = partial_solution
-    solver = LP_MRCPSP(rcpsp_model=rcpsp_problem, lp_solver=MilpSolverName.CBC)
+    solver = LP_MRCPSP(problem=rcpsp_problem, lp_solver=MilpSolverName.CBC)
     solver.init_model(partial_solution=partial_solution_for_lp, greedy_start=False)
     params_milp = ParametersMilp.default()
     params_milp.time_limit = 20

--- a/tests/rcpsp/solver/test_rcpsp_lp_lns.py
+++ b/tests/rcpsp/solver/test_rcpsp_lp_lns.py
@@ -31,7 +31,7 @@ def test_lns_sm():
     files_available = get_data_available()
     file = [f for f in files_available if "j301_1.sm" in f][0]
     rcpsp_problem = parse_file(file)
-    solver = LP_RCPSP(rcpsp_model=rcpsp_problem, lp_solver=MilpSolverName.CBC)
+    solver = LP_RCPSP(problem=rcpsp_problem, lp_solver=MilpSolverName.CBC)
     solver.init_model(greedy_start=False)
     parameters_milp = ParametersMilp(
         time_limit=10,
@@ -85,7 +85,7 @@ def test_lns_mm():
         sense_function=ModeOptim.MAXIMIZATION,
     )
     solver = LP_MRCPSP(
-        rcpsp_model=rcpsp_problem,
+        problem=rcpsp_problem,
         lp_solver=MilpSolverName.CBC,
         params_objective_function=params_objective_function,
     )

--- a/tests/rcpsp/solver/test_rcpsp_pile.py
+++ b/tests/rcpsp/solver/test_rcpsp_pile.py
@@ -23,7 +23,7 @@ def test_pile_sm():
     files = [f for f in files if "j1201_1.sm" in f]
     file_path = files[0]
     rcpsp_model = parse_file(file_path)
-    solver = PileSolverRCPSP(rcpsp_model=rcpsp_model)
+    solver = PileSolverRCPSP(problem=rcpsp_model)
     for k in range(10):
         result_storage = solver.solve(greedy_choice=GreedyChoice.SAMPLE_MOST_SUCCESSORS)
         sol, fit = result_storage.get_best_solution_fit()
@@ -41,7 +41,7 @@ def test_pile_multimode():
     files = [f for f in files if "j1010_1.mm" in f]
     file_path = files[0]
     rcpsp_model = parse_file(file_path)
-    solver = PileSolverRCPSP(rcpsp_model=rcpsp_model)
+    solver = PileSolverRCPSP(problem=rcpsp_model)
     for k in range(10):
         result_storage = solver.solve(greedy_choice=GreedyChoice.SAMPLE_MOST_SUCCESSORS)
         sol, fit = result_storage.get_best_solution_fit()
@@ -68,8 +68,8 @@ def test_pile_robust():
     worst = uncertain.create_rcpsp_model(
         MethodRobustification(MethodBaseRobustification.WORST_CASE, percentile=0)
     )
-    solver = PileSolverRCPSP(rcpsp_model=worst)
-    solver_original = PileSolverRCPSP(rcpsp_model=rcpsp_model)
+    solver = PileSolverRCPSP(problem=worst)
+    solver_original = PileSolverRCPSP(problem=rcpsp_model)
     sol_origin, fit_origin = solver_original.solve(
         greedy_choice=GreedyChoice.MOST_SUCCESSORS
     ).get_best_solution_fit()

--- a/tests/rcpsp/test_rcpsp_preemptive.py
+++ b/tests/rcpsp/test_rcpsp_preemptive.py
@@ -162,7 +162,7 @@ def test_run_preemptive(rcpsp_problem):
 def test_preemptive_cp_alamano():
     rcpsp_problem = create_alamano_preemptive_model()
     solver = CP_RCPSP_MZN_PREEMPTIVE(
-        rcpsp_model=rcpsp_problem, cp_solver_name=CPSolverName.CHUFFED
+        problem=rcpsp_problem, cp_solver_name=CPSolverName.CHUFFED
     )
     solver.init_model(
         output_type=True,
@@ -187,7 +187,7 @@ def test_preemptive_cp_alamano():
 def test_preemptive_multimode_cp_alamano():
     rcpsp_problem = create_alamano_preemptive_model()
     solver = CP_MRCPSP_MZN_PREEMPTIVE(
-        rcpsp_model=rcpsp_problem, cp_solver_name=CPSolverName.CHUFFED
+        problem=rcpsp_problem, cp_solver_name=CPSolverName.CHUFFED
     )
     solver.init_model(
         output_type=True,
@@ -211,7 +211,7 @@ def test_preemptive_multimode_cp_alamano():
 def test_preemptive_cp_psplib():
     rcpsp_problem = load_psplib_preemptive_model_2("j601_5.sm")
     solver = CP_RCPSP_MZN_PREEMPTIVE(
-        rcpsp_model=rcpsp_problem, cp_solver_name=CPSolverName.CHUFFED
+        problem=rcpsp_problem, cp_solver_name=CPSolverName.CHUFFED
     )
     solver.init_model(
         output_type=True,
@@ -234,7 +234,7 @@ def test_preemptive_cp_psplib():
 def test_preemptive_multimode_cp_psplib():
     rcpsp_problem = load_psplib_preemptive_model_2("j1010_5.mm")
     solver = CP_MRCPSP_MZN_PREEMPTIVE(
-        rcpsp_model=rcpsp_problem, cp_solver_name=CPSolverName.CHUFFED
+        problem=rcpsp_problem, cp_solver_name=CPSolverName.CHUFFED
     )
     solver.init_model(
         output_type=True,

--- a/tests/rcpsp_multiskill/test_rcpsp_ms_cp.py
+++ b/tests/rcpsp_multiskill/test_rcpsp_ms_cp.py
@@ -193,7 +193,7 @@ def test_cp_toy_model():
     model_msrcpsp = create_toy_v2()
 
     cp_model = CP_MS_MRCPSP_MZN(
-        rcpsp_model=model_msrcpsp, cp_solver_name=CPSolverName.GECODE
+        problem=model_msrcpsp, cp_solver_name=CPSolverName.GECODE
     )
     cp_model.init_model(
         add_calendar_constraint_unit=False,
@@ -214,7 +214,7 @@ def test_cp_imopse():
     file = [f for f in get_data_available() if "100_5_20_9_D3.def" in f][0]
     model_msrcpsp, new_tame_to_original_task_id = parse_file(file, max_horizon=1000)
     cp_model = CP_MS_MRCPSP_MZN(
-        rcpsp_model=model_msrcpsp,
+        problem=model_msrcpsp,
         one_ressource_per_task=True,
         cp_solver_name=CPSolverName.CHUFFED,
     )
@@ -257,7 +257,7 @@ def test_lns_small_neighbor():
     makespan = model_msrcpsp.evaluate(solution)["makespan"]
     model_msrcpsp.horizon = makespan + 5
     lns_cp = LNS_CP_MS_RCPSP_SOLVER(
-        rcpsp_model=model_msrcpsp,
+        problem=model_msrcpsp,
         option_neighbor=OptionNeighbor.MIX_FAST,
         one_ressource_per_task=True,
     )
@@ -293,7 +293,7 @@ def test_lns():
     model_msrcpsp.horizon = makespan + 5
     model_rcpsp = model_msrcpsp.build_multimode_rcpsp_calendar_representative()
     lns_cp = LNS_CP_MS_RCPSP_SOLVER(
-        rcpsp_model=model_msrcpsp,
+        problem=model_msrcpsp,
         option_neighbor=OptionNeighbor.MIX_ALL,
         one_ressource_per_task=True,
         fake_tasks=True,

--- a/tests/rcpsp_multiskill/test_rcpsp_ms_lp.py
+++ b/tests/rcpsp_multiskill/test_rcpsp_ms_lp.py
@@ -57,7 +57,7 @@ def test_lp():
         horizon=100,
         horizon_multiplier=1,
     )
-    lp_solver = LP_Solver_MRSCPSP(rcpsp_model=model, lp_solver=MilpSolverName.CBC)
+    lp_solver = LP_Solver_MRSCPSP(problem=model, lp_solver=MilpSolverName.CBC)
     lp_solver.init_model()
     sol = lp_solver.solve(parameters_milp=ParametersMilp.default()).get_best_solution()
     assert model.satisfy(sol)
@@ -131,7 +131,7 @@ def test_lp_bis():
         horizon=100,
         horizon_multiplier=1,
     )
-    lp_solver = LP_Solver_MRSCPSP(rcpsp_model=model, lp_solver=MilpSolverName.CBC)
+    lp_solver = LP_Solver_MRSCPSP(problem=model, lp_solver=MilpSolverName.CBC)
     lp_solver.init_model()
     result = lp_solver.solve(parameters_milp=ParametersMilp.default())
     best_solution = result.get_best_solution()

--- a/tests/rcpsp_multiskill/test_rcpsp_ms_lp_lns.py
+++ b/tests/rcpsp_multiskill/test_rcpsp_ms_lp_lns.py
@@ -48,13 +48,13 @@ def test_multiskill_imopse():
     model_rcpsp = model.build_multimode_rcpsp_calendar_representative()
     graph = model_rcpsp.compute_graph()
     cycles = graph.check_loop()
-    solver = PileSolverRCPSP_Calendar(rcpsp_model=model_rcpsp)
+    solver = PileSolverRCPSP_Calendar(problem=model_rcpsp)
     parameters_cp = ParametersCP.default()
     parameters_cp.time_limit = 200
     store_solution = solver.solve(parameters_cp=parameters_cp)
     best_mrcpsp, fit = store_solution.get_best_solution_fit()
     solver = LP_Solver_MRSCPSP(
-        rcpsp_model=model,
+        problem=model,
         lp_solver=MilpSolverName.GRB,
         # CBC is not working well at all. -> so in unit test you should probably skip this test.
         params_objective_function=params_objective_function,

--- a/tests/rcpsp_multiskill/test_rcpsp_ms_ls.py
+++ b/tests/rcpsp_multiskill/test_rcpsp_ms_ls.py
@@ -97,7 +97,7 @@ def create_toy_msrcpsp():
 def test_ls():
     model = create_toy_msrcpsp()
     model = model.to_variant_model()
-    solver = LS_RCPSP_Solver(rcpsp_model=model, ls_solver=LS_SOLVER.SA)
+    solver = LS_RCPSP_Solver(problem=model, ls_solver=LS_SOLVER.SA)
     result = solver.solve(nb_iteration_max=1000)
     solution: MS_RCPSPSolution = result.get_best_solution()
     model.evaluate(solution)
@@ -108,7 +108,7 @@ def test_ls_imopse():
     file = [f for f in get_data_available() if "100_5_22_15.def" in f][0]
     model, name_task = parse_file(file, max_horizon=1000)
     model = model.to_variant_model()
-    solver = LS_RCPSP_Solver(rcpsp_model=model, ls_solver=LS_SOLVER.SA)
+    solver = LS_RCPSP_Solver(problem=model, ls_solver=LS_SOLVER.SA)
     result = solver.solve(nb_iteration_max=1)
     solution: MS_RCPSPSolution = result.get_best_solution()
     model.evaluate(solution)

--- a/tests/rcpsp_multiskill/test_rcpsp_ms_partially_preemptive.py
+++ b/tests/rcpsp_multiskill/test_rcpsp_ms_partially_preemptive.py
@@ -109,7 +109,7 @@ def test_partial_preemptive(model):
         rcpsp_model=model, rcpsp_sol=dummy_solution
     )
     plot_ressource_view(rcpsp_model=model, rcpsp_sol=dummy_solution)
-    cp_solver = CP_MS_MRCPSP_MZN_PARTIAL_PREEMPTIVE(rcpsp_model=model)
+    cp_solver = CP_MS_MRCPSP_MZN_PARTIAL_PREEMPTIVE(problem=model)
     cp_solver.init_model(
         max_time=20,
         max_preempted=3,
@@ -130,7 +130,7 @@ def test_partial_preemptive(model):
 
 def test_ls(model):
     model_variant: MS_RCPSPModel_Variant = model.to_variant_model()
-    solver = LS_RCPSP_Solver(rcpsp_model=model_variant, ls_solver=LS_SOLVER.SA)
+    solver = LS_RCPSP_Solver(problem=model_variant, ls_solver=LS_SOLVER.SA)
     result_storage = solver.solve(nb_iteration_max=5000)
     rcpsp_sol = result_storage.get_last_best_solution()[0]
     assert model.satisfy(rcpsp_sol)

--- a/tests/rcpsp_multiskill/test_rcpsp_ms_rcpsp_based_solver.py
+++ b/tests/rcpsp_multiskill/test_rcpsp_ms_rcpsp_based_solver.py
@@ -99,7 +99,7 @@ def test_rcpsp_based():
         if solvers[k][j][0] == method
     ][0]
     params["lp_solver"] = MilpSolverName.CBC
-    solver = Solver_RCPSP_Based(model=model, method=method, **params)
+    solver = Solver_RCPSP_Based(problem=model, method=method, **params)
     result = solver.solve()
     solution: MS_RCPSPSolution = result.get_best_solution()
     model.evaluate(solution)

--- a/tests/rcpsp_multiskill/test_rcpsp_ms_to_rcpsp.py
+++ b/tests/rcpsp_multiskill/test_rcpsp_ms_to_rcpsp.py
@@ -58,7 +58,7 @@ def test_solve_rcpsp_imopse1(random_seed):
     params_cp.time_limit_iter0 = 100
     params_cp.free_search = False
     lns_solver = LNS_CP_RCPSP_SOLVER(
-        rcpsp_model=rcpsp_model, option_neighbor=OptionNeighbor.MIX_FAST
+        problem=rcpsp_model, option_neighbor=OptionNeighbor.MIX_FAST
     )
     result_storage = lns_solver.solve(
         parameters_cp=params_cp,
@@ -86,7 +86,7 @@ def test_solve_rcpsp_imopse2(random_seed):
     params_cp.time_limit = 200
     params_cp.time_limit_iter0 = 300
 
-    solver = CP_MRCPSP_MZN(rcpsp_model=rcpsp_model, cp_solver_name=CPSolverName.CHUFFED)
+    solver = CP_MRCPSP_MZN(problem=rcpsp_model, cp_solver_name=CPSolverName.CHUFFED)
     solver.init_model(output_type=True)
     params_cp = ParametersCP.default()
     params_cp.time_limit = 100

--- a/tests/tsp/test_tsp_ls.py
+++ b/tests/tsp/test_tsp_ls.py
@@ -44,7 +44,7 @@ def test_sa_2opt():
     weight = np.ones(len(list_mutation))
     mutate_portfolio = BasicPortfolioMutation(list_mutation, weight)
     sa = SimulatedAnnealing(
-        evaluator=model,
+        problem=model,
         mutator=mutate_portfolio,
         restart_handler=res,
         temperature_handler=TemperatureSchedulingFactor(
@@ -75,7 +75,7 @@ def test_sa_partial_shuffle():
     weight = np.ones(len(list_mutation))
     mutate_portfolio = BasicPortfolioMutation(list_mutation, weight)
     sa = SimulatedAnnealing(
-        evaluator=model,
+        problem=model,
         mutator=mutate_portfolio,
         restart_handler=res,
         temperature_handler=TemperatureSchedulingFactor(
@@ -105,7 +105,7 @@ def test_sa_swap():
     weight = np.ones(len(list_mutation))
     mutate_portfolio = BasicPortfolioMutation(list_mutation, weight)
     sa = SimulatedAnnealing(
-        evaluator=model,
+        problem=model,
         mutator=mutate_portfolio,
         restart_handler=res,
         temperature_handler=TemperatureSchedulingFactor(
@@ -136,7 +136,7 @@ def test_sa_twoopttbasic():
     weight = np.ones(len(list_mutation))
     mutate_portfolio = BasicPortfolioMutation(list_mutation, weight)
     sa = SimulatedAnnealing(
-        evaluator=model,
+        problem=model,
         mutator=mutate_portfolio,
         restart_handler=res,
         temperature_handler=TemperatureSchedulingFactor(
@@ -167,7 +167,7 @@ def test_hc():
     weight = np.ones(len(list_mutation))
     mutate_portfolio = BasicPortfolioMutation(list_mutation, weight)
     sa = HillClimber(
-        evaluator=model,
+        problem=model,
         mutator=mutate_portfolio,
         restart_handler=res,
         mode_mutation=ModeMutation.MUTATE_AND_EVALUATE,

--- a/tests/vrp/test_vrp_solver.py
+++ b/tests/vrp/test_vrp_solver.py
@@ -13,7 +13,7 @@ def test_ortools_vrp_solver():
     logging.basicConfig(level=logging.ERROR)
     file_path = [f for f in get_data_available() if "vrp_31_9_1" in f][0]
     vrp_model = parse_file(file_path)
-    solver = VrpORToolsSolver(vrp_model=vrp_model)
+    solver = VrpORToolsSolver(problem=vrp_model)
     solver.init_model(
         first_solution_strategy=FirstSolutionStrategy.SAVINGS,
         local_search_metaheuristic=LocalSearchMetaheuristic.GUIDED_LOCAL_SEARCH,
@@ -27,7 +27,7 @@ def test_greedy_vrp_solver():
     logging.basicConfig(level=logging.ERROR)
     file_path = [f for f in get_data_available() if "vrp_31_9_1" in f][0]
     vrp_model = parse_file(file_path)
-    greedy_solver = GreedyVRPSolver(vrp_model=vrp_model, params_objective_function=None)
+    greedy_solver = GreedyVRPSolver(problem=vrp_model, params_objective_function=None)
     res = greedy_solver.solve(limit_time_s=20)
     sol, fit = res.get_best_solution_fit()
     assert vrp_model.satisfy(sol)


### PR DESCRIPTION
It allows to put some boilerplate code in one place:
- set self.problem (and all attributes in child solvers are renamed into problem: rcps_model, coloring_model, ...)
- generate self.aggreg_from_sol, self.aggreg_from_dict, and self.params_objective_function (we unify also their names)

We add init_model() because functions in coloring.coloring_solvers, facility.facility_solvers, ... assume its existence to solve a problem from a solver class.

In a next step, these modules could also be made generic and put in common.