### PR TITLE
Fix parameter usage in greedy coloring so that the code actually works

### DIFF
--- a/discrete_optimization/coloring/solvers/greedy_coloring.py
+++ b/discrete_optimization/coloring/solvers/greedy_coloring.py
@@ -89,7 +89,7 @@ class GreedyColoring(SolverColoring):
         greedy_strategy: NXGreedyColoringMethod = kwargs.get(
             "strategy", NXGreedyColoringMethod.best
         )
-        strategy_name = greedy_strategy.name
+        strategy_name = greedy_strategy.value
         if strategy_name == "best":
             strategies_to_test = strategies
         else:


### PR DESCRIPTION
- Use .value instead of .name in greedy coloring solver 