### PR TITLE
Handle missing distance value from the dictionnary of distance in GPDP problem

### DIFF
--- a/discrete_optimization/pickup_vrp/gpdp.py
+++ b/discrete_optimization/pickup_vrp/gpdp.py
@@ -99,6 +99,8 @@ class GPDPSolution(Solution):
 
 
 class GPDP(Problem):
+    MAX_VALUE = 10e9
+
     def __init__(
         self,
         number_vehicle: int,
@@ -302,7 +304,7 @@ class GPDP(Problem):
     def compute_distance(self, path: List[Node]) -> float:
         distance = 0.0
         for i in range(len(path) - 1):
-            distance += self.distance_delta[path[i]][path[i + 1]]
+            distance += self.distance_delta[path[i]].get(path[i + 1], GPDP.MAX_VALUE)
         return distance
 
     def evaluate_function_node(self, node_1: Node, node_2: Node) -> float:


### PR DESCRIPTION
- gpdp ortools solver works with complete graph, therefore returns path not necessarly fulfilling the original routing problem. However due to recent callback implementation in ortools solver, we need to tackle the missing distance case to avoid exceptions. Therefore we put high cost to missing transition value