### PR TITLE
Fix corner case of cpsat encoding

### DIFF
--- a/discrete_optimization/rcpsp/solver/cpsat_solver.py
+++ b/discrete_optimization/rcpsp/solver/cpsat_solver.py
@@ -346,6 +346,9 @@ class CPSatRCPSPSolverResource(CPSatRCPSPSolver):
                 for mode in self.problem.mode_details[task]
                 if self.problem.mode_details[task][mode].get(resource, 0) > 0
             ]
+            if len(task_modes_consuming) == 0:
+                # when empty, the constraints don't work !
+                return
             fake_task_res = [
                 (
                     model.NewFixedSizeIntervalVar(
@@ -481,6 +484,9 @@ class CPSatRCPSPSolverCumulativeResource(CPSatRCPSPSolver):
                 for mode in self.problem.mode_details[task]
                 if self.problem.mode_details[task][mode].get(resource, 0) > 0
             ]
+            if len(task_modes_consuming) == 0:
+                # when empty, the constraints don't work !
+                return
             fake_task_res = [
                 (
                     model.NewFixedSizeIntervalVar(


### PR DESCRIPTION
- when no task is consuming a resource, we don't include constraints storing the consumption of this resource, because it leads to failed model. (addMaxEquality most probably or NonOverlap are not compliant with empty list of variables)