### PR TITLE
Implement callbacks integration for gurobi solvers

### DIFF
--- a/discrete_optimization/coloring/solvers/coloring_lp_solvers.py
+++ b/discrete_optimization/coloring/solvers/coloring_lp_solvers.py
@@ -6,7 +6,7 @@
 
 import logging
 import sys
-from typing import Any, Dict, Hashable, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Hashable, Optional, Tuple, Union
 
 import mip
 import networkx as nx
@@ -99,13 +99,17 @@ class _BaseColoringLP(MilpSolver, SolverColoring):
         self.sense_optim = self.params_objective_function.sense_function
         self.start_solution: Optional[ColoringSolution] = None
 
-    def retrieve_ith_solution(self, i: int) -> ColoringSolution:
+    def retrieve_current_solution(
+        self,
+        get_var_value_for_current_solution: Callable[[Any], float],
+        get_obj_value_for_current_solution: Callable[[], float],
+    ) -> ColoringSolution:
         colors = [0] * self.number_of_nodes
         for (
             variable_decision_key,
             variable_decision_value,
         ) in self.variable_decision["colors_var"].items():
-            value = self.get_var_value_for_ith_solution(variable_decision_value, i)
+            value = get_var_value_for_current_solution(variable_decision_value)
             if value >= 0.5:
                 node = variable_decision_key[0]
                 color = variable_decision_key[1]

--- a/discrete_optimization/facility/solvers/facility_lp_solver.py
+++ b/discrete_optimization/facility/solvers/facility_lp_solver.py
@@ -5,7 +5,7 @@
 #  LICENSE file in the root directory of this source tree.
 
 import logging
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 import mip
 import numpy as np
@@ -136,14 +136,18 @@ class _LPFacilitySolverBase(MilpSolver, SolverFacility):
         }
         self.description_constraint: Dict[str, Dict[str, str]] = {}
 
-    def retrieve_ith_solution(self, i: int) -> FacilitySolution:
+    def retrieve_current_solution(
+        self,
+        get_var_value_for_current_solution: Callable[[Any], float],
+        get_obj_value_for_current_solution: Callable[[], float],
+    ) -> FacilitySolution:
         facility_for_customer = [0] * self.problem.customer_count
         for (
             variable_decision_key,
             variable_decision_value,
         ) in self.variable_decision["x"].items():
             if not isinstance(variable_decision_value, int):
-                value = self.get_var_value_for_ith_solution(variable_decision_value, i)
+                value = get_var_value_for_current_solution(variable_decision_value)
             else:
                 value = variable_decision_value
             if value >= 0.5:

--- a/discrete_optimization/generic_tools/lp_tools.py
+++ b/discrete_optimization/generic_tools/lp_tools.py
@@ -285,15 +285,6 @@ class GurobiMilpSolver(MilpSolver):
                 "self.model should not be None when calling this method."
             )
         self.model.params.SolutionNumber = i
-        return self.model.getAttr("ObjVal")
-
-    def get_pool_obj_value_for_ith_solution(self, i: int) -> float:
-        """Get pool objective value for i-th solution."""
-        if self.model is None:  # for mypy
-            raise RuntimeError(
-                "self.model should not be None when calling this method."
-            )
-        self.model.params.SolutionNumber = i
         return self.model.getAttr("PoolObjVal")
 
     @property

--- a/discrete_optimization/knapsack/solvers/lp_solvers.py
+++ b/discrete_optimization/knapsack/solvers/lp_solvers.py
@@ -3,7 +3,7 @@
 #  LICENSE file in the root directory of this source tree.
 
 import logging
-from typing import Any, Dict, Optional, Union
+from typing import Any, Callable, Dict, Optional, Union
 
 import mip
 from mip import BINARY, MAXIMIZE, xsum
@@ -57,7 +57,11 @@ class _BaseLPKnapsack(MilpSolver, SolverKnapsack):
         self.description_variable_description: Dict[str, Dict[str, Any]] = {}
         self.description_constraint: Dict[str, Dict[str, str]] = {}
 
-    def retrieve_ith_solution(self, i: int) -> KnapsackSolution:
+    def retrieve_current_solution(
+        self,
+        get_var_value_for_current_solution: Callable[[Any], float],
+        get_obj_value_for_current_solution: Callable[[], float],
+    ) -> KnapsackSolution:
         weight = 0.0
         value_kp = 0.0
         xs = {}
@@ -65,7 +69,7 @@ class _BaseLPKnapsack(MilpSolver, SolverKnapsack):
             variable_decision_key,
             variable_decision_value,
         ) in self.variable_decision["x"].items():
-            value = self.get_var_value_for_ith_solution(variable_decision_value, i)
+            value = get_var_value_for_current_solution(variable_decision_value)
             if value <= 0.1:
                 xs[variable_decision_key] = 0
                 continue

--- a/discrete_optimization/rcpsp/solver/rcpsp_lp_solver_gantt.py
+++ b/discrete_optimization/rcpsp/solver/rcpsp_lp_solver_gantt.py
@@ -4,7 +4,7 @@
 
 import logging
 import random
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
 import networkx as nx
 from mip import BINARY, MINIMIZE, Model, xsum
@@ -12,6 +12,7 @@ from mip import BINARY, MINIMIZE, Model, xsum
 from discrete_optimization.generic_tools.do_problem import (
     ModeOptim,
     ParamsObjectiveFunction,
+    Solution,
 )
 from discrete_optimization.generic_tools.lp_tools import (
     GurobiMilpSolver,
@@ -126,14 +127,16 @@ class _Base_LP_MRCPSP_GANTT(MilpSolver, SolverRCPSP):
         self.params_objective_function.sense_function = self.sense_optim
         self.constraint_additionnal = {}
 
-    def retrieve_ith_solution(
-        self, i: int
+    def retrieve_current_solution(
+        self,
+        get_var_value_for_current_solution: Callable[[Any], float],
+        get_obj_value_for_current_solution: Callable[[], float],
     ) -> Tuple[Dict[Any, Dict[Any, Dict[Any, Any]]], float]:
-        objective = self.get_obj_value_for_ith_solution(i)
+        objective = get_obj_value_for_current_solution()
         resource_id_usage = {
             k: {
                 individual: {
-                    task: self.get_var_value_for_ith_solution(resource_usage, i)
+                    task: get_var_value_for_current_solution(resource_usage)
                     for task, resource_usage in self.ressource_id_usage[k][
                         individual
                     ].items()
@@ -398,14 +401,16 @@ class LP_MRCPSP_GANTT_GUROBI(GurobiMilpSolver, _Base_LP_MRCPSP_GANTT):
             ]
             self.model.update()
 
-    def retrieve_ith_solution(
-        self, i: int
+    def retrieve_current_solution(
+        self,
+        get_var_value_for_current_solution: Callable[[Any], float],
+        get_obj_value_for_current_solution: Callable[[], float],
     ) -> Tuple[Dict[Any, Dict[Any, Dict[Any, Any]]], float]:
-        objective = self.get_pool_obj_value_for_ith_solution(i)
+        objective = get_obj_value_for_current_solution()
         resource_id_usage = {
             k: {
                 individual: {
-                    task: self.get_var_value_for_ith_solution(resource_usage, i)
+                    task: get_var_value_for_current_solution(resource_usage)
                     for task, resource_usage in self.ressource_id_usage[k][
                         individual
                     ].items()

--- a/examples/coloring/coloring_gurobi_solver.py
+++ b/examples/coloring/coloring_gurobi_solver.py
@@ -1,0 +1,40 @@
+#  Copyright (c) 2024 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+import logging
+
+from discrete_optimization.coloring.coloring_parser import (
+    get_data_available,
+    parse_file,
+)
+from discrete_optimization.coloring.coloring_plot import plot_coloring_solution, plt
+from discrete_optimization.coloring.solvers.coloring_lp_solvers import ColoringLP
+from discrete_optimization.generic_tools.callbacks.loggers import NbIterationTracker
+from discrete_optimization.generic_tools.lp_tools import ParametersMilp
+
+
+def run_gurobi_coloring():
+    logging.basicConfig(level=logging.INFO)
+    file = [f for f in get_data_available() if "gc_250_1" in f][0]
+    color_problem = parse_file(file)
+    solver = ColoringLP(color_problem)
+    solver.init_model()
+    p = ParametersMilp.default()
+    result_store = solver.solve(
+        callbacks=[
+            NbIterationTracker(
+                step_verbosity_level=logging.INFO, end_verbosity_level=logging.INFO
+            )
+        ],
+        parameters_milp=p,
+    )
+    solution, fit = result_store.get_best_solution_fit()
+    plot_coloring_solution(solution)
+    plt.show()
+    print(solution, fit)
+    print("Evaluation : ", color_problem.evaluate(solution))
+    print("Satisfy : ", color_problem.satisfy(solution))
+
+
+if __name__ == "__main__":
+    run_gurobi_coloring()

--- a/tests/coloring/test_coloring.py
+++ b/tests/coloring/test_coloring.py
@@ -68,20 +68,16 @@ def test_load_file(coloring_problem_file):
     assert coloring_model.satisfy(dummy_solution)
 
 
-def test_solvers():
+@pytest.mark.parametrize("solver_class", solvers_map)
+def test_solvers(solver_class):
+    if solver_class == ColoringLP and not gurobi_available:
+        pytest.skip("You need Gurobi to test this solver.")
     small_example = [f for f in get_data_available() if "gc_20_1" in f][0]
     coloring_model: ColoringProblem = parse_file(small_example)
-    assert coloring_model.graph is not None
-    assert coloring_model.number_of_nodes is not None
-    assert coloring_model.graph.nodes_name is not None
-    solvers = solvers_map.keys()
-    for s in solvers:
-        logging.info(f"Running {s}")
-        if s == ColoringLP and not gurobi_available:
-            # you need a gurobi licence to test this solver.
-            continue
-        results = solve(method=s, problem=coloring_model, **solvers_map[s][1])
-        sol, fit = results.get_best_solution_fit()
+    results = solve(
+        method=solver_class, problem=coloring_model, **solvers_map[solver_class][1]
+    )
+    sol, fit = results.get_best_solution_fit()
 
 
 def test_solvers_subset():


### PR DESCRIPTION
- replace method to implement (for all milp solvers) `retrieve_ith_solution()` by `retrieve_current_solution()` that take a callable  `get_var_value_for_current_solution()`. Then
  - `retrieve_ith_solution` is `retrieve_current_solution` with
    `get_var_value_for_ith_solution`
  - during a gurobi callback, it will be called with `model.cbGetSolution`
- update milp solvers to reflect that
- create a `GurobiCallback` class that
   - populates on the fly a result_storage by using
     `retreive_current_solution()`
   - calls user-defined d-o callbacks
   - terminate solve if user-defined callbacks decide to early stop
- add a test using d-o callbacks with gurobi for coloring solver
- the gurobi pickup-vrp solver still does not use callbacks as it is
  overriding `GurobiMilpSolver.solve()` to perform a loop.