### PR TITLE
Hyperparameters improvements and refactoring

### DIFF
--- a/discrete_optimization/generic_tools/do_solver.py
+++ b/discrete_optimization/generic_tools/do_solver.py
@@ -110,14 +110,15 @@ class SolverDO:
     def suggest_hyperparameters_values_with_optuna(
         cls,
         trial: optuna.trial.Trial,
-        names: List[str],
+        names: Optional[List[str]] = None,
         kwargs_by_name: Optional[Dict[str, Dict[str, Any]]] = None,
     ) -> List[Any]:
         """Suggest hyperparameter value during an Optuna trial.
 
         Args:
             trial: optuna trial during hyperparameters tuning
-            names: names of the hyperparameters to choose
+            names: names of the hyperparameters to choose.
+                By default, all hyperparameters will be suggested, ordered as in `self.hyperparameters`.
             kwargs_by_name: options for optuna hyperparameter suggestions, by hyperparameter name
 
         Returns:
@@ -125,6 +126,8 @@ class SolverDO:
         kwargs_by_name[some_name] will be passed as **kwargs to suggest_hyperparameter_value_with_optuna(name=some_name)
 
         """
+        if names is None:
+            names = cls.get_hyperparameters_names()
         if kwargs_by_name is None:
             kwargs_by_name = {}
         return [

--- a/discrete_optimization/generic_tools/do_solver.py
+++ b/discrete_optimization/generic_tools/do_solver.py
@@ -74,6 +74,25 @@ class SolverDO:
         return cls.get_hyperparameters_by_name()[name]
 
     @classmethod
+    def get_default_hyperparameters(
+        cls, names: Optional[List[str]] = None
+    ) -> Dict[str, Any]:
+        """Get hyperparameters default values.
+
+        Args:
+            names: names of the hyperparameters to choose.
+                By default, all available hyperparameters will be suggested.
+
+        Returns:
+            a mapping between hyperparameter name and its default value (None if not specified)
+
+        """
+        if names is None:
+            names = cls.get_hyperparameters_names()
+        hyperparameters_by_names = cls.get_hyperparameters_by_name()
+        return {name: hyperparameters_by_names[name].default for name in names}
+
+    @classmethod
     def suggest_hyperparameter_with_optuna(
         cls, trial: optuna.trial.Trial, name: str, **kwargs
     ) -> Any:

--- a/discrete_optimization/generic_tools/do_solver.py
+++ b/discrete_optimization/generic_tools/do_solver.py
@@ -94,6 +94,25 @@ class SolverDO:
         return {name: hyperparameters_by_names[name].default for name in names}
 
     @classmethod
+    def complete_with_default_hyperparameters(
+        cls, kwargs: Dict[str, Any], names: Optional[List[str]] = None
+    ):
+        """Add missing hyperparameters to kwargs by using default values
+
+        Args:
+            kwargs: keyword arguments to complete (for `__init__`, `init_model`, or `solve`)
+            names: names of the hyperparameters to add if missing.
+                By default, all available hyperparameters.
+
+        Returns:
+             a new dictionary, completion of kwargs
+
+        """
+        kwargs_complete = cls.get_default_hyperparameters(names=names)
+        kwargs_complete.update(kwargs)  # ensure preferring values from kwargs
+        return kwargs_complete
+
+    @classmethod
     def suggest_hyperparameter_with_optuna(
         cls, trial: optuna.trial.Trial, name: str, prefix: str = "", **kwargs
     ) -> Any:

--- a/discrete_optimization/generic_tools/do_solver.py
+++ b/discrete_optimization/generic_tools/do_solver.py
@@ -74,7 +74,7 @@ class SolverDO:
         return cls.get_hyperparameters_by_name()[name]
 
     @classmethod
-    def suggest_hyperparameter_value_with_optuna(
+    def suggest_hyperparameter_with_optuna(
         cls, trial: optuna.trial.Trial, name: str, **kwargs
     ) -> Any:
         """Suggest hyperparameter value during an Optuna trial.
@@ -107,35 +107,36 @@ class SolverDO:
         )
 
     @classmethod
-    def suggest_hyperparameters_values_with_optuna(
+    def suggest_hyperparameters_with_optuna(
         cls,
         trial: optuna.trial.Trial,
         names: Optional[List[str]] = None,
         kwargs_by_name: Optional[Dict[str, Dict[str, Any]]] = None,
-    ) -> List[Any]:
-        """Suggest hyperparameter value during an Optuna trial.
+    ) -> Dict[str, Any]:
+        """Suggest hyperparameters values during an Optuna trial.
 
         Args:
             trial: optuna trial during hyperparameters tuning
             names: names of the hyperparameters to choose.
-                By default, all hyperparameters will be suggested, ordered as in `self.hyperparameters`.
+                By default, all available hyperparameters will be suggested.
             kwargs_by_name: options for optuna hyperparameter suggestions, by hyperparameter name
 
         Returns:
+            mapping between the hyperparameter name and its suggested value
 
-        kwargs_by_name[some_name] will be passed as **kwargs to suggest_hyperparameter_value_with_optuna(name=some_name)
+        kwargs_by_name[some_name] will be passed as **kwargs to suggest_hyperparameter_with_optuna(name=some_name)
 
         """
         if names is None:
             names = cls.get_hyperparameters_names()
         if kwargs_by_name is None:
             kwargs_by_name = {}
-        return [
-            cls.suggest_hyperparameter_value_with_optuna(
+        return {
+            name: cls.suggest_hyperparameter_with_optuna(
                 trial=trial, name=name, **kwargs_by_name.get(name, {})
             )
             for name in names
-        ]
+        }
 
     @abstractmethod
     def solve(

--- a/discrete_optimization/generic_tools/hyperparameters/hyperparameter.py
+++ b/discrete_optimization/generic_tools/hyperparameters/hyperparameter.py
@@ -6,69 +6,205 @@ from __future__ import annotations  # see annotations as str
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Type
 
 if TYPE_CHECKING:  # only for type checkers
     try:
-        import optuna
+        import optuna  # not necessary to import this module
     except ImportError:
         pass
 
 
 @dataclass
 class Hyperparameter:
+    """Hyperparameter base class used to specify d-o solver hyperparameters."""
+
     name: str
+    """Name of the hyperparameter.
+
+    Should correspond to how the hyperparameter is specified in the solver
+    `__init__()`, `init_model()`, or `solve()` keywords arguments.
+
+    """
+
     default: Optional[Any] = None
+    """Default value for the hyperparameter.
+
+    None means "no default value".
+
+    """
 
     def suggest_with_optuna(self, trial: optuna.trial.Trial, **kwargs: Any) -> Any:
+        """Suggest hyperparameter value for an Optuna trial.
+
+        Args:
+            trial: optuna Trial used for choosing the hyperparameter value
+            **kwargs: passed to `trial.suggest_xxx()`
+
+        Returns:
+
+        """
         ...
 
 
 @dataclass
 class IntegerHyperparameter(Hyperparameter):
-    low: Optional[int] = None
-    high: Optional[int] = None
-    default: Optional[int] = None
+    """Integer hyperparameter."""
 
-    def suggest_with_optuna(self, trial: optuna.trial.Trial, **kwargs: Any) -> Any:
-        if self.low is not None and "low" not in kwargs:
-            kwargs["low"] = self.low
-        if self.high is not None and "high" not in kwargs:
-            kwargs["high"] = self.high
-        return trial.suggest_int(name=self.name, **kwargs)
+    low: Optional[int] = None
+    """Lower bound.
+
+    If None, the hyperparameter value has no lower bound.
+
+    """
+
+    high: Optional[int] = None
+    """Upper bound.
+
+    If None, the hyperparameter value has no upper bound.
+
+    """
+
+    default: Optional[int] = None
+    """Default value for the hyperparameter.
+
+    None means "no default value".
+
+    """
+
+    def suggest_with_optuna(
+        self,
+        trial: optuna.trial.Trial,
+        low: Optional[int] = None,
+        high: Optional[int] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Suggest hyperparameter value for an Optuna trial.
+
+        Args:
+            trial: optuna Trial used for choosing the hyperparameter value
+            low: can be used to restrict lower bound
+            high: can be used to restrict upper bound
+            **kwargs: passed to `trial.suggest_int()`
+
+        Returns:
+
+        """
+        if low is None:
+            low = self.low
+        if high is None:
+            high = self.high
+        return trial.suggest_int(name=self.name, low=low, high=high, **kwargs)  # type: ignore
 
 
 @dataclass
 class FloatHyperparameter(Hyperparameter):
-    low: Optional[float] = None
-    high: Optional[float] = None
-    default: Optional[float] = None
+    """Float parameter."""
 
-    def suggest_with_optuna(self, trial: optuna.trial.Trial, **kwargs: Any) -> Any:
-        if self.low is not None and "low" not in kwargs:
-            kwargs["low"] = self.low
-        if self.high is not None and "high" not in kwargs:
-            kwargs["high"] = self.high
-        return trial.suggest_float(name=self.name, **kwargs)
+    low: Optional[float] = None
+    """Lower bound.
+
+    If None, the hyperparameter value has no lower bound.
+
+    """
+
+    high: Optional[float] = None
+    """Upper bound.
+
+    If None, the hyperparameter value has no upper bound.
+
+    """
+
+    default: Optional[float] = None
+    """Default value for the hyperparameter.
+
+    None means "no default value".
+
+    """
+
+    def suggest_with_optuna(
+        self,
+        trial: optuna.trial.Trial,
+        low: Optional[float] = None,
+        high: Optional[float] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Suggest hyperparameter value for an Optuna trial.
+
+        Args:
+            trial: optuna Trial used for choosing the hyperparameter value
+            low: can be used to restrict lower bound
+            high: can be used to restrict upper bound
+            **kwargs: passed to `trial.suggest_float()`
+
+        Returns:
+
+        """
+        if low is None:
+            low = self.low
+        if high is None:
+            high = self.high
+        return trial.suggest_float(name=self.name, low=low, high=high, **kwargs)
 
 
 @dataclass
 class CategoricalHyperparameter(Hyperparameter):
-    choices: List[Any] = field(default_factory=list)
+    """Categorical hyperparameter."""
 
-    def suggest_with_optuna(self, trial: optuna.trial.Trial, **kwargs: Any) -> Any:
+    choices: List[Any] = field(default_factory=list)
+    """List of possible choices."""
+
+    def suggest_with_optuna(
+        self,
+        trial: optuna.trial.Trial,
+        choices: Optional[Iterable[Any]] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Suggest hyperparameter value for an Optuna trial.
+
+        Args:
+            trial: optuna Trial used for choosing the hyperparameter value
+            choices: restricts list of choices
+            **kwargs: passed to `trial.suggest_categorical()`
+
+        Returns:
+
+        """
         if self.choices is not None and "choices" not in kwargs:
             kwargs["choices"] = self.choices
         return trial.suggest_categorical(name=self.name, **kwargs)
 
 
 class EnumHyperparameter(CategoricalHyperparameter):
-    def __init__(self, name: str, enum: Enum, default: Optional[Any] = None):
+    """Hyperparameter taking value among an enumeration.
+
+    Args:
+        enum: enumeration used to create the hyperparameter
+
+    """
+
+    def __init__(self, name: str, enum: Type[Enum], default: Optional[Any] = None):
         super().__init__(name, choices=list(enum), default=default)
         self.enum = enum
 
-    def suggest_with_optuna(self, trial: optuna.trial.Trial, **kwargs: Any) -> Any:
-        choices = kwargs.get("choices", self.choices)
+    def suggest_with_optuna(
+        self,
+        trial: optuna.trial.Trial,
+        choices: Optional[Iterable[Enum]] = None,
+        **kwargs: Any,
+    ) -> Enum:
+        """Suggest hyperparameter value for an Optuna trial.
+
+        Args:
+            trial: optuna Trial used for choosing the hyperparameter value
+            choices: restricts list of choices among the enumeration `self.enum`
+            **kwargs: passed to `trial.suggest_categorical()`
+
+        Returns:
+
+        """
+        if choices is None:
+            choices = self.choices
         choices_str = [c.name for c in choices]
-        choice_str = trial.suggest_categorical(name=self.name, choices=choices_str)
+        choice_str: str = trial.suggest_categorical(name=self.name, choices=choices_str, **kwargs)  # type: ignore
         return self.enum[choice_str]

--- a/discrete_optimization/generic_tools/hyperparameters/hyperparameter.py
+++ b/discrete_optimization/generic_tools/hyperparameters/hyperparameter.py
@@ -310,6 +310,7 @@ class SubSolverKwargsHyperparameter(Hyperparameter):
         subsolver: Type[SolverDO],
         names: Optional[List[str]] = None,
         kwargs_by_name: Optional[Dict[str, Dict[str, Any]]] = None,
+        fixed_hyperparameters: Optional[Dict[str, Any]] = None,
         prefix: str = "",
     ) -> Dict[str, Any]:
         """Suggest hyperparameter value for an Optuna trial.
@@ -326,6 +327,8 @@ class SubSolverKwargsHyperparameter(Hyperparameter):
                 Passed to `subsolver.suggest_hyperparameters_with_optuna()`.
             kwargs_by_name: options for optuna hyperparameter suggestions, by hyperparameter name.
                 Passed to `subsolver.suggest_hyperparameters_with_optuna()`.
+            fixed_hyperparameters: values of fixed hyperparameters, useful for suggesting subsolver hyperparameters,
+                if the subsolver class is not suggested by this method, but already fixed.
             prefix: prefix to add to optuna corresponding parameter name
               (useful for disambiguating hyperparameters from subsolvers in case of meta-solvers)
 
@@ -339,5 +342,6 @@ class SubSolverKwargsHyperparameter(Hyperparameter):
             trial=trial,
             names=names,
             kwargs_by_name=kwargs_by_name,
+            fixed_hyperparameters=fixed_hyperparameters,
             prefix=prefix,
         )

--- a/examples/pickup_vrp/optuna_full_example.py
+++ b/examples/pickup_vrp/optuna_full_example.py
@@ -93,9 +93,7 @@ def objective(trial: Trial):
     solver_class = solvers_by_name[solver_name]
 
     # hyperparameters for the chosen solver
-    hyperparameters_names = solver_class.get_hyperparameters_names()
-    hyperparameters_values = ORToolsGPDP.suggest_hyperparameters_values_with_optuna(
-        names=hyperparameters_names,
+    suggested_hyperparameters_kwargs = solver_class.suggest_hyperparameters_with_optuna(
         trial=trial,
     )
 
@@ -126,8 +124,8 @@ def objective(trial: Trial):
     logger.info(f"Launching trial {trial.number} with parameters: {trial.params}")
 
     # construct kwargs for __init__, init_model, and solve
-    kwargs = kwargs_fixed_by_solver[solver_class]
-    kwargs.update(dict(zip(hyperparameters_names, hyperparameters_values)))
+    kwargs = dict(kwargs_fixed_by_solver[solver_class])  # copy the frozen kwargs dict
+    kwargs.update(suggested_hyperparameters_kwargs)
 
     # solver init
     solver = solver_class(problem=problem, **kwargs)

--- a/examples/pickup_vrp/pickup_vrp_ortools_with_optuna_auto.py
+++ b/examples/pickup_vrp/pickup_vrp_ortools_with_optuna_auto.py
@@ -13,6 +13,7 @@ Results can be viewed on optuna-dashboard with:
 """
 
 import logging
+from operator import itemgetter
 
 import numpy as np
 import optuna
@@ -65,22 +66,25 @@ def objective(trial: Trial):
         sense_function=ModeOptim.MINIMIZATION,
     )
     # hyperparameters
+    hyperparameters_names = [
+        "first_solution_strategy",
+        "local_search_metaheuristic",
+        "use_lns",
+        "use_cp",
+        "use_cp_sat",
+    ]
+    hyperparameters = ORToolsGPDP.suggest_hyperparameters_with_optuna(
+        names=hyperparameters_names,
+        trial=trial,
+    )
+    # extract individual hyperparameter from the hyperparameters dict
     (
         first_solution_strategy,
         local_search_metaheuristic,
         use_lns,
         use_cp,
         use_cp_sat,
-    ) = ORToolsGPDP.suggest_hyperparameters_values_with_optuna(
-        names=[
-            "first_solution_strategy",
-            "local_search_metaheuristic",
-            "use_lns",
-            "use_cp",
-            "use_cp_sat",
-        ],
-        trial=trial,
-    )
+    ) = itemgetter(hyperparameters_names)(hyperparameters)
 
     n_solutions = trial.suggest_int("n_solutions", 10, 200)
 

--- a/examples/pickup_vrp/pickup_vrp_ortools_with_optuna_with_pruning_v4_auto.py
+++ b/examples/pickup_vrp/pickup_vrp_ortools_with_optuna_with_pruning_v4_auto.py
@@ -13,6 +13,7 @@ Results can be viewed on optuna-dashboard with:
 """
 
 import logging
+from operator import itemgetter
 
 import optuna
 from optuna.trial import Trial, TrialState
@@ -61,21 +62,17 @@ def objective(trial: Trial):
         sense_function=ModeOptim.MINIMIZATION,
     )
     # hyperparameters
-    # hyperparameters
-    (
-        first_solution_strategy,
-        local_search_metaheuristic,
-        use_lns,
-        use_cp_sat,
-    ) = ORToolsGPDP.suggest_hyperparameters_values_with_optuna(
-        names=[
-            "first_solution_strategy",
-            "local_search_metaheuristic",
-            "use_lns",
-            "use_cp_sat",
-        ],
+    hyperparameters_names = [
+        "first_solution_strategy",
+        "local_search_metaheuristic",
+        "use_lns",
+        "use_cp_sat",
+    ]
+    hyperparameters = ORToolsGPDP.suggest_hyperparameters_with_optuna(
+        names=hyperparameters_names,
         trial=trial,
         kwargs_by_name={
+            # restrict choices for `first_solution_strategy`
             "first_solution_strategy": dict(
                 choices=[
                     FirstSolutionStrategy.AUTOMATIC,
@@ -84,6 +81,14 @@ def objective(trial: Trial):
             )
         },
     )
+    # extract individual hyperparameter from the hyperparameters dict
+    (
+        first_solution_strategy,
+        local_search_metaheuristic,
+        use_lns,
+        use_cp_sat,
+    ) = itemgetter(hyperparameters_names)(hyperparameters)
+
     use_cp = True
     n_solutions = trial.suggest_int("n_solutions_max", 10, 200)
 

--- a/tests/generic_tools/hyperparameters/test_hyperparameter.py
+++ b/tests/generic_tools/hyperparameters/test_hyperparameter.py
@@ -103,6 +103,29 @@ def test_get_default_hyperparameters():
     assert kwargs["method"] == Method.GREEDY
 
 
+def test_complete_with_default_hyperparameters():
+    kwargs = {"coeff": 0.5, "toto": "youpi"}
+    kwargs = DummySolver.complete_with_default_hyperparameters(kwargs)
+
+    assert kwargs["toto"] == "youpi"
+    assert kwargs["coeff"] == 0.5
+    assert kwargs["nb"] == 1
+    assert kwargs["use_it"]
+    assert kwargs["method"] == Method.GREEDY
+
+
+def test_complete_with_default_hyperparameters_specific_names():
+    kwargs = {"coeff": 0.5, "toto": "youpi"}
+    kwargs = DummySolver.complete_with_default_hyperparameters(
+        kwargs, names=["nb", "coeff"]
+    )
+
+    assert kwargs["toto"] == "youpi"
+    assert kwargs["coeff"] == 0.5
+    assert kwargs["nb"] == 1
+    assert "use_it" not in kwargs
+
+
 def test_suggest_with_optuna():
     def objective(trial: optuna.Trial) -> float:
         # hyperparameters for the chosen solver


### PR DESCRIPTION
- add documentation
- renaming 
  - `suggest_hyperparameters_values_with_optuna` -> `suggest_hyperparameters_with_optuna`
  - `suggest_hyperparameter_value_with_optuna` -> `suggest_hyperparameter_with_optuna`
- allow names=None for `suggest_hyperparameters_with_optuna() `=> all possible parameters
- `suggest_hyperparameters_with_optuna()` returns now a dict to be directly used as `**kwargs` in `__init__()`, `init_model()`, and `solve()`.
- new hyperparameter types for meta-solvers:
  - `SubSolverHyperparameter`: specifying a `SolverDO` class
  - `SubSolverKwargsHyperparameter`: specifying the hyperparameters for a given subsolver as a dictionary to  be used as kwargs. The associated `suggest_with_optuna()` actually call the `suggest_hyperparameters_with_optuna()` from the subsolver
- add a method to extract default values for all hyperparameters 
- add tests on hyperparameters