### PR TITLE
Update solvers to make them use `complete_with_default_hyperparameters`

### DIFF
--- a/discrete_optimization/coloring/solvers/coloring_solver_with_starting_solution.py
+++ b/discrete_optimization/coloring/solvers/coloring_solver_with_starting_solution.py
@@ -25,7 +25,11 @@ logger = logging.getLogger(__name__)
 class SolverColoringWithStartingSolution(SolverColoring):
     hyperparameters = [
         CategoricalHyperparameter("greedy_start", choices=[True], default=True),
-        EnumHyperparameter("greedy_method", enum=NXGreedyColoringMethod),
+        EnumHyperparameter(
+            "greedy_method",
+            enum=NXGreedyColoringMethod,
+            default=NXGreedyColoringMethod.best,
+        ),
     ]
 
     def get_starting_solution(self, **kwargs: Any) -> ColoringSolution:
@@ -39,7 +43,8 @@ class SolverColoringWithStartingSolution(SolverColoring):
         Returns (ColoringSolution): a starting coloring solution that can be used by lns.
 
         """
-        greedy_start = kwargs.get("greedy_start", True)
+        kwargs = self.complete_with_default_hyperparameters(kwargs)
+        greedy_start = kwargs["greedy_start"]
         params_objective_function = kwargs.get("params_objective_function", None)
         if greedy_start:
             logger.info("Computing greedy solution")
@@ -47,9 +52,7 @@ class SolverColoringWithStartingSolution(SolverColoring):
                 self.problem,
                 params_objective_function=params_objective_function,
             )
-            result_store = greedy_solver.solve(
-                strategy=kwargs.get("greedy_method", NXGreedyColoringMethod.best),
-            )
+            result_store = greedy_solver.solve(strategy=kwargs["greedy_method"])
             solution = result_store.get_best_solution()
             if solution is None:
                 raise RuntimeError(

--- a/discrete_optimization/knapsack/solvers/cp_solvers.py
+++ b/discrete_optimization/knapsack/solvers/cp_solvers.py
@@ -116,9 +116,8 @@ class CPKnapsackMZN(MinizincCPSolver, SolverKnapsack):
         )
 
     def init_model(self, **kwargs: Any) -> None:
-        cp_solver_name = kwargs.get(
-            "cp_solver_name", self.get_hyperparameter("cp_solver_name").default
-        )
+        kwargs = self.complete_with_default_hyperparameters(kwargs)
+        cp_solver_name = kwargs["cp_solver_name"]
         model = Model(os.path.join(this_path, "../minizinc/knapsack_mzn.mzn"))
         solver = Solver.lookup(find_right_minizinc_solver_name(cp_solver_name))
         instance = Instance(solver, model)
@@ -153,9 +152,8 @@ class CPKnapsackMZN2(MinizincCPSolver, SolverKnapsack):
         self.silent_solve_error = silent_solve_error
 
     def init_model(self, **kwargs: Any) -> None:
-        cp_solver_name = kwargs.get(
-            "cp_solver_name", self.get_hyperparameter("cp_solver_name").default
-        )
+        kwargs = self.complete_with_default_hyperparameters(kwargs)
+        cp_solver_name = kwargs["cp_solver_name"]
         model = Model(os.path.join(this_path, "../minizinc/knapsack_global.mzn"))
         solver = Solver.lookup(find_right_minizinc_solver_name(cp_solver_name))
         instance = Instance(solver, model)
@@ -231,9 +229,8 @@ class CPMultidimensionalSolver(MinizincCPSolver):
         self.custom_output_type = False
 
     def init_model(self, **kwargs: Any) -> None:
-        cp_solver_name = kwargs.get(
-            "cp_solver_name", self.get_hyperparameter("cp_solver_name").default
-        )
+        kwargs = self.complete_with_default_hyperparameters(kwargs)
+        cp_solver_name = kwargs["cp_solver_name"]
         model = Model(
             os.path.join(this_path, "../minizinc/multidimension_knapsack.mzn")
         )
@@ -316,9 +313,8 @@ class CPMultidimensionalMultiScenarioSolver(MinizincCPSolver):
         self.custom_output_type = False
 
     def init_model(self, **kwargs: Any) -> None:
-        cp_solver_name = kwargs.get(
-            "cp_solver_name", self.get_hyperparameter("cp_solver_name").default
-        )
+        kwargs = self.complete_with_default_hyperparameters(kwargs)
+        cp_solver_name = kwargs["cp_solver_name"]
         model = Model(
             os.path.join(this_path, "../minizinc/multidim_multiscenario_knapsack.mzn")
         )

--- a/discrete_optimization/knapsack/solvers/dyn_prog_knapsack.py
+++ b/discrete_optimization/knapsack/solvers/dyn_prog_knapsack.py
@@ -51,9 +51,8 @@ class KnapsackDynProg(SolverKnapsack):
         self.table = np.zeros((self.nb_items + 1, self.capacity + 1))
 
     def solve(self, **kwargs: Any) -> ResultStorage:
-        start_by_most_promising = kwargs.get(
-            "greedy_start", self.get_hyperparameter("greedy_start").default
-        )
+        kwargs = self.complete_with_default_hyperparameters(kwargs)
+        start_by_most_promising = kwargs["greedy_start"]
         max_items = kwargs.get("max_items", self.problem.nb_items + 1)
         max_items = min(self.problem.nb_items + 1, max_items)
         max_time_seconds = kwargs.get("max_time_seconds", None)

--- a/discrete_optimization/knapsack/solvers/knapsack_decomposition.py
+++ b/discrete_optimization/knapsack/solvers/knapsack_decomposition.py
@@ -75,15 +75,11 @@ class KnapsackDecomposedSolver(SolverKnapsack):
         return solution
 
     def solve(self, **kwargs: Any) -> ResultStorage:
+        kwargs = self.complete_with_default_hyperparameters(kwargs)
         initial_solver = kwargs.get("initial_solver", GreedyBest)
         sub_solver = kwargs.get("root_solver", GreedyBest)
-        nb_iteration = kwargs.get(
-            "nb_iteration", self.get_hyperparameter("nb_iteration").default
-        )
-        proportion_to_remove = kwargs.get(
-            "proportion_to_remove",
-            self.get_hyperparameter("proportion_to_remove").default,
-        )
+        nb_iteration = kwargs["nb_iteration"]
+        proportion_to_remove = kwargs["proportion_to_remove"]
         initial_results = solve(method=initial_solver, problem=self.problem, **kwargs)
         results_storage = ResultStorage(
             list_solution_fits=initial_results.list_solution_fits,


### PR DESCRIPTION
The idea is
- to define once for all default values for hyperparameters when
  defining them in solver.hyperparameters
- reuse these default values to complete kwargs in solve/init_model in
  one line

Thus
- we add default values in hyperparmeters definitons when missing
-  we call `complete_with_default_hyperparameters` before getting
hyperparameter values from kwargs