### PR TITLE
Implement callbacks for minizinc-based solvers

### DIFF
--- a/.github/workflows/build-doc.yml
+++ b/.github/workflows/build-doc.yml
@@ -41,9 +41,10 @@ jobs:
       python-version: "3.9"
       minizinc_config_cmdline: export PATH=$PATH:$(pwd)/bin/squashfs-root/usr/bin; export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(pwd)/bin/squashfs-root/usr/lib
       minizinc_cache_path: $(pwd)/bin/squashfs-root
-      minizinc_url: https://github.com/MiniZinc/MiniZincIDE/releases/download/2.6.3/MiniZincIDE-2.6.3-x86_64.AppImage
+      minizinc_url: https://github.com/MiniZinc/MiniZincIDE/releases/download/2.8.3/MiniZincIDE-2.8.3-x86_64.AppImage
       minizinc_downloaded_filepath: bin/minizinc.AppImage
       minizinc_install_cmdline: cd bin; sudo chmod +x minizinc.AppImage; sudo ./minizinc.AppImage --appimage-extract; cd ..
+      minizinc_prerequisites_cmdline: sudo apt update && sudo apt install libegl1 -y
     steps:
       - name: Set env variables for github links in doc
         run: |
@@ -92,7 +93,10 @@ jobs:
             docs/requirements.txt
       - name: Create bin/
         run: mkdir -p bin
-      - name: get MininZinc path to cache
+      - name: Minizinc prerequisites
+        run: |
+          ${{ matrix.minizinc_prerequisites_cmdline }}
+      - name: get MiniZinc path to cache
         id: get-mzn-cache-path
         run: |
           echo "path=${{ env.minizinc_cache_path }}" >> $GITHUB_OUTPUT  # expands variables

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,21 +96,24 @@ jobs:
           - os: "ubuntu-latest"
             minizinc_config_cmdline: export PATH=$PATH:$(pwd)/bin/squashfs-root/usr/bin; export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(pwd)/bin/squashfs-root/usr/lib
             minizinc_cache_path: $(pwd)/bin/squashfs-root
-            minizinc_url: https://github.com/MiniZinc/MiniZincIDE/releases/download/2.6.3/MiniZincIDE-2.6.3-x86_64.AppImage
+            minizinc_url: https://github.com/MiniZinc/MiniZincIDE/releases/download/2.8.3/MiniZincIDE-2.8.3-x86_64.AppImage
             minizinc_downloaded_filepath: bin/minizinc.AppImage
             minizinc_install_cmdline: cd bin; sudo chmod +x minizinc.AppImage; sudo ./minizinc.AppImage --appimage-extract; cd ..
+            minizinc_prerequisites_cmdline: sudo apt update && sudo apt install libegl1 -y
           - os: "macos-latest"
             minizinc_config_cmdline: export PATH=$PATH:$(pwd)/bin/MiniZincIDE.app/Contents/Resources
             minizinc_cache_path: $(pwd)/bin/MiniZincIDE.app
-            minizinc_url: https://github.com/MiniZinc/MiniZincIDE/releases/download/2.6.3/MiniZincIDE-2.6.3-bundled.dmg
+            minizinc_url: https://github.com/MiniZinc/MiniZincIDE/releases/download/2.8.3/MiniZincIDE-2.8.3-bundled.dmg
             minizinc_downloaded_filepath: bin/minizinc.dmg
             minizinc_install_cmdline: sudo hdiutil attach bin/minizinc.dmg; sudo cp -R /Volumes/MiniZinc*/MiniZincIDE.app bin/.
+            minizinc_prerequisites_cmdline: ""
           - os: "windows-latest"
             minizinc_config_cmdline: export PATH=$PATH:~/AppData/Local/Programs/MiniZinc
             minizinc_cache_path: ~/AppData/Local/Programs/MiniZinc
-            minizinc_url: https://github.com/MiniZinc/MiniZincIDE/releases/download/2.6.3/MiniZincIDE-2.6.3-bundled-setup-win64.exe
+            minizinc_url: https://github.com/MiniZinc/MiniZincIDE/releases/download/2.8.3/MiniZincIDE-2.8.3-bundled-setup-win64.exe
             minizinc_downloaded_filepath: minizinc_setup.exe
             minizinc_install_cmdline: cmd //c "minizinc_setup.exe /verysilent /currentuser /norestart /suppressmsgboxes /sp"
+            minizinc_prerequisites_cmdline: ""
           - coverage: false  # generally no coverage to avoid multiple reports
           - coverage: true  # coverage only for one entry of the matrix
             os: "ubuntu-latest"
@@ -163,7 +166,10 @@ jobs:
           "
       - name: Create bin/
         run: mkdir -p bin
-      - name: get MininZinc path to cache
+      - name: Minizinc prerequisites
+        run: |
+          ${{ matrix.minizinc_prerequisites_cmdline }}
+      - name: get MiniZinc path to cache
         id: get-mzn-cache-path
         run: |
           echo "path=${{ matrix.minizinc_cache_path }}" >> $GITHUB_OUTPUT  # expands variables

--- a/discrete_optimization/coloring/coloring_solvers.py
+++ b/discrete_optimization/coloring/coloring_solvers.py
@@ -10,8 +10,6 @@ from discrete_optimization.coloring.solvers.coloring_asp_solver import ColoringA
 from discrete_optimization.coloring.solvers.coloring_cp_solvers import (
     ColoringCP,
     ColoringCPModel,
-    CPSolverName,
-    ParametersCP,
 )
 from discrete_optimization.coloring.solvers.coloring_cpsat_solver import (
     ColoringCPSatSolver,
@@ -41,6 +39,7 @@ from discrete_optimization.coloring.solvers.greedy_coloring import (
     GreedyColoring,
     NXGreedyColoringMethod,
 )
+from discrete_optimization.generic_tools.cp_tools import CPSolverName, ParametersCP
 from discrete_optimization.generic_tools.do_problem import Problem
 from discrete_optimization.generic_tools.lp_tools import ParametersMilp
 from discrete_optimization.generic_tools.result_storage.result_storage import (

--- a/discrete_optimization/facility/facility_solvers.py
+++ b/discrete_optimization/facility/facility_solvers.py
@@ -9,10 +9,8 @@ from discrete_optimization.facility.facility_model import (
     FacilityProblem2DPoints,
 )
 from discrete_optimization.facility.solvers.facility_cp_solvers import (
-    CPSolverName,
     FacilityCP,
     FacilityCPModel,
-    ParametersCP,
 )
 from discrete_optimization.facility.solvers.facility_lp_solver import (
     LP_Facility_Solver,
@@ -26,6 +24,7 @@ from discrete_optimization.facility.solvers.greedy_solvers import (
     GreedySolverDistanceBased,
     GreedySolverFacility,
 )
+from discrete_optimization.generic_tools.cp_tools import CPSolverName, ParametersCP
 from discrete_optimization.generic_tools.do_problem import Problem
 from discrete_optimization.generic_tools.result_storage.result_storage import (
     ResultStorage,

--- a/discrete_optimization/generic_tools/cp_tools.py
+++ b/discrete_optimization/generic_tools/cp_tools.py
@@ -300,7 +300,10 @@ class MinizincCPSolver(CPSolver):
                 optimisation_level=parameters_cp.optimisation_level,
             )
         except Exception as e:
-            self.status_solver = StatusSolver.UNKNOWN
+            if len(output_type.res.list_solution_fits) > 0:
+                self.status_solver = StatusSolver.SATISFIED
+            else:
+                self.status_solver = StatusSolver.UNKNOWN
             if isinstance(e, SolveEarlyStop):
                 logger.info(e)
             elif self.silent_solve_error:

--- a/discrete_optimization/knapsack/knapsack_solvers.py
+++ b/discrete_optimization/knapsack/knapsack_solvers.py
@@ -4,6 +4,7 @@
 
 from typing import Any, Dict, List, Tuple, Type
 
+from discrete_optimization.generic_tools.cp_tools import CPSolverName
 from discrete_optimization.generic_tools.do_problem import Problem
 from discrete_optimization.generic_tools.lp_tools import ParametersMilp
 from discrete_optimization.generic_tools.result_storage.result_storage import (
@@ -13,7 +14,6 @@ from discrete_optimization.knapsack.knapsack_model import KnapsackModel
 from discrete_optimization.knapsack.solvers.cp_solvers import (
     CPKnapsackMZN,
     CPKnapsackMZN2,
-    CPSolverName,
 )
 from discrete_optimization.knapsack.solvers.dyn_prog_knapsack import KnapsackDynProg
 from discrete_optimization.knapsack.solvers.greedy_solvers import GreedyBest

--- a/discrete_optimization/rcpsp/rcpsp_solvers.py
+++ b/discrete_optimization/rcpsp/rcpsp_solvers.py
@@ -16,7 +16,7 @@ from discrete_optimization.generic_rcpsp_tools.ls_solver import (
     LS_RCPSP_Solver,
 )
 from discrete_optimization.generic_rcpsp_tools.typing import ANY_CLASSICAL_RCPSP
-from discrete_optimization.generic_tools.cp_tools import ParametersCP
+from discrete_optimization.generic_tools.cp_tools import CPSolverName, ParametersCP
 from discrete_optimization.generic_tools.ea.ga_tools import (
     ParametersAltGa,
     ParametersGa,
@@ -35,7 +35,6 @@ from discrete_optimization.rcpsp.solver.cp_solvers import (
     CP_MRCPSP_MZN_PREEMPTIVE,
     CP_RCPSP_MZN,
     CP_RCPSP_MZN_PREEMPTIVE,
-    CPSolverName,
 )
 from discrete_optimization.rcpsp.solver.cpm import CPM
 from discrete_optimization.rcpsp.solver.cpsat_solver import CPSatRCPSPSolver

--- a/discrete_optimization/rcpsp/robust_rcpsp.py
+++ b/discrete_optimization/rcpsp/robust_rcpsp.py
@@ -12,6 +12,7 @@ from scipy.stats import poisson, randint, rv_discrete
 from discrete_optimization.generic_tools.do_problem import (
     MethodAggregating,
     RobustProblem,
+    Solution,
 )
 from discrete_optimization.rcpsp import RCPSPModel
 from discrete_optimization.rcpsp.rcpsp_solution import RCPSPSolution
@@ -30,13 +31,26 @@ class AggregRCPSPModel(RobustProblem, RCPSPModel):
         RobustProblem.__init__(
             self, list_problem=list_problem, method_aggregating=method_aggregating
         )
-        self.horizon = list_problem[0].horizon
-        self.horizon_multiplier = list_problem[0].horizon_multiplier
-        self.resources = list_problem[0].resources
-        self.successors = list_problem[0].successors
-        self.n_jobs = list_problem[0].n_jobs
-        self.mode_details = list_problem[0].mode_details
-        self.resources_list = list_problem[0].resources_list
+        RCPSPModel.__init__(
+            self,
+            resources=list_problem[0].resources,
+            non_renewable_resources=list_problem[0].non_renewable_resources,
+            mode_details=list_problem[0].mode_details,
+            successors=list_problem[0].successors,
+            horizon=list_problem[0].horizon,
+            horizon_multiplier=list_problem[0].horizon_multiplier,
+            tasks_list=list_problem[0].tasks_list,
+            source_task=list_problem[0].source_task,
+            sink_task=list_problem[0].sink_task,
+            name_task=list_problem[0].name_task,
+            calendar_details=list_problem[0].calendar_details,
+            special_constraints=list_problem[0].special_constraints
+            if list_problem[0].do_special_constraints
+            else None,
+            relax_the_start_at_end=list_problem[0].relax_the_start_at_end,
+            fixed_permutation=list_problem[0].fixed_permutation,
+            fixed_modes=list_problem[0].fixed_modes,
+        )
 
     def get_dummy_solution(self) -> RCPSPSolution:
         a: RCPSPSolution = self.list_problem[0].get_dummy_solution()

--- a/discrete_optimization/rcpsp_multiskill/minizinc/ms_rcpsp_multi_mode_mzn_calendar.mzn
+++ b/discrete_optimization/rcpsp_multiskill/minizinc/ms_rcpsp_multi_mode_mzn_calendar.mzn
@@ -110,7 +110,7 @@ constraint forall(sk in Skill, i in Act)(
 
 % Prune.
 constraint forall(w in Units, i in Act)(
-    let{var opt set of Skill: sk = {skl | skl in Skill where skillunits[w, skl]>0 /\
+    let{var set of int: sk = {skl | skl in Skill where skillunits[w, skl]>0 /\
        sum(m in modes[i])(skillreq[skl, m])>0}}
         in(
             if sk=={} then

--- a/discrete_optimization/rcpsp_multiskill/multiskill_to_rcpsp.py
+++ b/discrete_optimization/rcpsp_multiskill/multiskill_to_rcpsp.py
@@ -6,11 +6,10 @@ from typing import Dict
 
 import numpy as np
 
+from discrete_optimization.generic_tools.cp_tools import CPSolverName, ParametersCP
 from discrete_optimization.rcpsp.rcpsp_model import RCPSPModel
 from discrete_optimization.rcpsp_multiskill.solvers.cp_solvers import (
-    CPSolverName,
     MS_RCPSPModel,
-    ParametersCP,
     PrecomputeEmployeesForTasks,
 )
 

--- a/discrete_optimization/rcpsp_multiskill/rcpsp_multiskill_solvers.py
+++ b/discrete_optimization/rcpsp_multiskill/rcpsp_multiskill_solvers.py
@@ -10,13 +10,12 @@ from discrete_optimization.generic_rcpsp_tools.ls_solver import (
     LS_SOLVER,
     LS_RCPSP_Solver,
 )
-from discrete_optimization.generic_tools.cp_tools import ParametersCP
+from discrete_optimization.generic_tools.cp_tools import CPSolverName, ParametersCP
 from discrete_optimization.generic_tools.ea.ga_tools import ParametersAltGa
 from discrete_optimization.generic_tools.lp_tools import ParametersMilp
 from discrete_optimization.generic_tools.result_storage.result_storage import (
     ResultStorage,
 )
-from discrete_optimization.rcpsp.solver.cp_solvers import CPSolverName
 from discrete_optimization.rcpsp_multiskill.rcpsp_multiskill import (
     MS_RCPSPModel,
     MS_RCPSPModel_Variant,

--- a/discrete_optimization/tsp/tsp_solvers.py
+++ b/discrete_optimization/tsp/tsp_solvers.py
@@ -4,6 +4,7 @@
 
 from typing import Any, Dict, List, Sequence, Tuple, Type
 
+from discrete_optimization.generic_tools.cp_tools import CPSolverName
 from discrete_optimization.generic_tools.do_problem import Problem
 from discrete_optimization.generic_tools.result_storage.result_storage import (
     ResultStorage,
@@ -13,11 +14,7 @@ from discrete_optimization.tsp.solver.solver_lp_iterative import (
     MILPSolver,
 )
 from discrete_optimization.tsp.solver.solver_ortools import TSP_ORtools
-from discrete_optimization.tsp.solver.tsp_cp_solver import (
-    CPSolverName,
-    TSP_CP_Solver,
-    TSP_CPModel,
-)
+from discrete_optimization.tsp.solver.tsp_cp_solver import TSP_CP_Solver, TSP_CPModel
 from discrete_optimization.tsp.solver.tsp_solver import SolverTSP
 from discrete_optimization.tsp.tsp_model import (
     TSPModel,

--- a/examples/knapsack/knapsack_decomposition_solver.py
+++ b/examples/knapsack/knapsack_decomposition_solver.py
@@ -6,15 +6,12 @@ import logging
 import os
 
 os.environ["DO_SKIP_MZN_CHECK"] = "1"
+from discrete_optimization.generic_tools.cp_tools import ParametersCP
 from discrete_optimization.knapsack.knapsack_parser import (
     get_data_available,
     parse_file,
 )
-from discrete_optimization.knapsack.solvers.cp_solvers import (
-    CPKnapsackMZN,
-    CPKnapsackMZN2,
-    ParametersCP,
-)
+from discrete_optimization.knapsack.solvers.cp_solvers import CPKnapsackMZN2
 from discrete_optimization.knapsack.solvers.greedy_solvers import GreedyBest
 from discrete_optimization.knapsack.solvers.knapsack_asp_solver import KnapsackASPSolver
 from discrete_optimization.knapsack.solvers.knapsack_cpsat_solver import (

--- a/examples/knapsack/knapsack_multidimensional.py
+++ b/examples/knapsack/knapsack_multidimensional.py
@@ -7,6 +7,7 @@ import logging
 import numpy as np
 
 from discrete_optimization.generic_tools.callbacks.early_stoppers import TimerStopper
+from discrete_optimization.generic_tools.cp_tools import ParametersCP
 from discrete_optimization.generic_tools.do_problem import (
     BaseMethodAggregating,
     MethodAggregating,
@@ -45,7 +46,6 @@ from discrete_optimization.knapsack.solvers.cp_solvers import (
     CPMultidimensionalMultiScenarioSolver,
     CPMultidimensionalSolver,
     KnapConstraintHandler,
-    ParametersCP,
 )
 
 logging.basicConfig(level=logging.DEBUG)

--- a/examples/rcpsp/robustness_experiments.py
+++ b/examples/rcpsp/robustness_experiments.py
@@ -11,9 +11,10 @@ from functools import partial
 import matplotlib.pyplot as plt
 import numpy as np
 
-from discrete_optimization.generic_tools.cp_tools import CPSolverName
+from discrete_optimization.generic_tools.cp_tools import CPSolverName, ParametersCP
 from discrete_optimization.generic_tools.do_problem import (
     BaseMethodAggregating,
+    MethodAggregating,
     ModeOptim,
     ObjectiveHandling,
     ParamsObjectiveFunction,
@@ -38,7 +39,7 @@ from discrete_optimization.generic_tools.result_storage.result_storage import (
 from discrete_optimization.generic_tools.robustness.robustness_tool import (
     RobustnessTool,
 )
-from discrete_optimization.rcpsp.rcpsp_model import MethodAggregating, RCPSPModel
+from discrete_optimization.rcpsp.rcpsp_model import RCPSPModel
 from discrete_optimization.rcpsp.rcpsp_parser import get_data_available, parse_file
 from discrete_optimization.rcpsp.rcpsp_solution import RCPSPSolution
 from discrete_optimization.rcpsp.robust_rcpsp import (
@@ -49,10 +50,7 @@ from discrete_optimization.rcpsp.robust_rcpsp import (
     create_poisson_laws_duration,
     create_poisson_laws_resource,
 )
-from discrete_optimization.rcpsp.solver.cp_solvers_multiscenario import (
-    CP_MULTISCENARIO,
-    ParametersCP,
-)
+from discrete_optimization.rcpsp.solver.cp_solvers_multiscenario import CP_MULTISCENARIO
 from discrete_optimization.rcpsp.solver.rcpsp_pile import Executor
 
 logging.basicConfig(level=logging.DEBUG)

--- a/examples/rcpsp/robustness_experiments.py
+++ b/examples/rcpsp/robustness_experiments.py
@@ -162,7 +162,7 @@ def run_cp_multiscenario():
         annealing += [model.evaluate(s)["makespan"]]
 
     solver = CP_MULTISCENARIO(
-        list_problem=list_rcpsp_model, cp_solver_name=CPSolverName.CHUFFED
+        problem=model_aggreg_mean, cp_solver_name=CPSolverName.CHUFFED
     )
     solver.init_model(
         output_type=True, relax_ordering=False, nb_incoherence_limit=2, max_time=300
@@ -172,8 +172,8 @@ def run_cp_multiscenario():
     params_cp.free_search = True
     result = solver.solve(parameters_cp=params_cp)
     solution_fit = result.list_solution_fits
-    objectives_cp = [s[0][1] for s in solution_fit]
-    real_objective = [s[1] for s in solution_fit]
+    objectives_cp = [sol.minizinc_obj for sol, fit in solution_fit]
+    real_objective = [fit for sol, fit in solution_fit]
 
     plt.scatter(objectives_cp, real_objective)
     plt.show()

--- a/examples/rcpsp_multiskill/mspsp/mspsp_parse_and_solve.py
+++ b/examples/rcpsp_multiskill/mspsp/mspsp_parse_and_solve.py
@@ -7,10 +7,6 @@
 import logging
 
 from discrete_optimization.generic_tools.cp_tools import CPSolverName, ParametersCP
-from discrete_optimization.rcpsp_multiskill.rcpsp_multiskill import (
-    MS_RCPSPModel,
-    MS_RCPSPSolution,
-)
 from discrete_optimization.rcpsp_multiskill.rcpsp_multiskill_mspsp_parser import (
     get_data_available_mspsp,
     parse_dzn_file,

--- a/tests/facility/test_facility_cp.py
+++ b/tests/facility/test_facility_cp.py
@@ -14,8 +14,8 @@ from discrete_optimization.facility.facility_parser import (
 from discrete_optimization.facility.solvers.facility_cp_solvers import (
     FacilityCP,
     FacilityCPModel,
-    ParametersCP,
 )
+from discrete_optimization.generic_tools.cp_tools import ParametersCP
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Much too long on windows")

--- a/tests/knapsack/test_knapsack_decomposition_solver.py
+++ b/tests/knapsack/test_knapsack_decomposition_solver.py
@@ -3,20 +3,16 @@
 #  LICENSE file in the root directory of this source tree.
 
 import logging
-import os
 
 from discrete_optimization.generic_tools.callbacks.early_stoppers import (
     NbIterationStopper,
 )
+from discrete_optimization.generic_tools.cp_tools import ParametersCP
 from discrete_optimization.knapsack.knapsack_parser import (
     get_data_available,
     parse_file,
 )
-from discrete_optimization.knapsack.solvers.cp_solvers import (
-    CPKnapsackMZN,
-    CPKnapsackMZN2,
-    ParametersCP,
-)
+from discrete_optimization.knapsack.solvers.cp_solvers import CPKnapsackMZN2
 from discrete_optimization.knapsack.solvers.greedy_solvers import GreedyBest
 from discrete_optimization.knapsack.solvers.knapsack_asp_solver import KnapsackASPSolver
 from discrete_optimization.knapsack.solvers.knapsack_decomposition import (

--- a/tests/rcpsp_multiskill/test_rcpsp_ms_cp.py
+++ b/tests/rcpsp_multiskill/test_rcpsp_ms_cp.py
@@ -5,7 +5,7 @@
 from typing import Dict, List, Set
 
 from discrete_optimization.generic_tools.callbacks.early_stoppers import TimerStopper
-from discrete_optimization.generic_tools.cp_tools import CPSolverName
+from discrete_optimization.generic_tools.cp_tools import CPSolverName, ParametersCP
 from discrete_optimization.rcpsp.solver.rcpsp_lp_lns_solver import InitialMethodRCPSP
 from discrete_optimization.rcpsp_multiskill.rcpsp_multiskill import (
     Employee,
@@ -19,7 +19,6 @@ from discrete_optimization.rcpsp_multiskill.rcpsp_multiskill_parser import (
 )
 from discrete_optimization.rcpsp_multiskill.solvers.cp_solvers import (
     CP_MS_MRCPSP_MZN,
-    ParametersCP,
     SearchStrategyMS_MRCPSP,
 )
 from discrete_optimization.rcpsp_multiskill.solvers.ms_rcpsp_cp_lns_solver import (

--- a/tests/rcpsp_multiskill/test_rcpsp_ms_partially_preemptive.py
+++ b/tests/rcpsp_multiskill/test_rcpsp_ms_partially_preemptive.py
@@ -10,6 +10,7 @@ from discrete_optimization.generic_rcpsp_tools.ls_solver import (
     LS_SOLVER,
     LS_RCPSP_Solver,
 )
+from discrete_optimization.generic_tools.cp_tools import ParametersCP
 from discrete_optimization.rcpsp.plots.rcpsp_utils_preemptive import plot_ressource_view
 from discrete_optimization.rcpsp.special_constraints import (
     SpecialConstraintsDescription,
@@ -26,7 +27,6 @@ from discrete_optimization.rcpsp_multiskill.rcpsp_multiskill import (
 )
 from discrete_optimization.rcpsp_multiskill.solvers.cp_solvers import (
     CP_MS_MRCPSP_MZN_PARTIAL_PREEMPTIVE,
-    ParametersCP,
 )
 
 

--- a/tests/rcpsp_multiskill/test_rcpsp_ms_to_rcpsp.py
+++ b/tests/rcpsp_multiskill/test_rcpsp_ms_to_rcpsp.py
@@ -9,11 +9,8 @@ import numpy as np
 import pytest
 
 from discrete_optimization.generic_tools.callbacks.early_stoppers import TimerStopper
-from discrete_optimization.rcpsp.solver.cp_solvers import (
-    CP_MRCPSP_MZN,
-    CPSolverName,
-    ParametersCP,
-)
+from discrete_optimization.generic_tools.cp_tools import CPSolverName, ParametersCP
+from discrete_optimization.rcpsp.solver.cp_solvers import CP_MRCPSP_MZN
 from discrete_optimization.rcpsp.solver.rcpsp_cp_lns_solver import (
     LNS_CP_RCPSP_SOLVER,
     OptionNeighbor,


### PR DESCRIPTION
We use the `instance.output_type` as an entry point.
During the `solve()` call, we create dynamically a subclass of `MinizincCPSolution` which:
- wraps an actual d-o solution
- has class attributes properly initialized for tracking
  - full `ResultStorage`
  - current number of step
  - solver instance
  - user-defined callbacks
This class will be called each time a new solution is found by minizinc, and thus update the result storage and call upon user-defined callbacks.

If a stopping criteria is reached in callbacks, we raise a `SolveEarlyStop` exception which will be caught in `solve()`.

In addition to that a `MinizincCPSolver` must now implement `retrieve_solution()`
which converts a solution from minzinc into a d-o one.
It replaces former `retrieve_solutions()` and means that solutions will be now converted on the fly, and directly added to the current result_storage.

We also fix other bugs in minizinc solvers on the way:
- when using latest version of minzinc, rcpsp_multiskill solver was raising an issue, we fixed the minizinc file defining the model
- we upgrade the minizinc version used by github runners to test compatibility of our solvers with latest version of minizinc
- we fix CP_MULTISCENARIO, which was not really filling the result storage with solutions but rather with tuple of solutions for different variations of the same model. Instead,we make it work on AggregRCPSPModel so that the fitness is computed correctly on the list of submodels.
