### PR TITLE
Fix optuna callback

### DIFF
--- a/discrete_optimization/generic_tools/callbacks/optuna.py
+++ b/discrete_optimization/generic_tools/callbacks/optuna.py
@@ -58,7 +58,7 @@ class OptunaReportSingleFitCallback(Callback):
 
         """
         if step % self.report_nb_steps == 0:
-            fit = res.best_fit
+            _, fit = res.get_best_solution_fit()
 
             # Report current score and step to Optuna's trial.
             self.trial.report(float(fit), step=step)
@@ -99,7 +99,7 @@ class OptunaPruningSingleFitCallback(Callback):
 
         """
         if step % self.report_nb_steps == 0:
-            fit = res.best_fit
+            _, fit = res.get_best_solution_fit()
 
             # Report current score and step to Optuna's trial.
             self.trial.report(float(fit), step=step)


### PR DESCRIPTION
Optuna callback was relying on `ResultStorage.best_fit` to get the current best fitness. But this property is correctly filled only if  the result_storage has been filled using `add_solution()`. And lost of solvers actually directly append solutions to the attribute `ResultSorage.list_solution_fits`.

So we rather use `ResultStorage_get_best_solution_fit()` which works always.