### PR TITLE
Use time instead of number of iteration to display and/or prune the trials with optuna

### DIFF
--- a/discrete_optimization/generic_tools/callbacks/optuna.py
+++ b/discrete_optimization/generic_tools/callbacks/optuna.py
@@ -5,6 +5,7 @@
 from __future__ import annotations  # see annotations as str
 
 import logging
+import time
 from typing import Optional
 
 from discrete_optimization.generic_tools.callbacks.callback import Callback
@@ -22,11 +23,16 @@ except ImportError:
     logger.warning("You should install optuna to use callbacks for optuna.")
 
 
-class OptunaReportSingleFitCallback(Callback):
-    """Callback to report intermediary objective values, this is mostly useful for visualisation purposes.
-
+class OptunaCallback(Callback):
+    """Callback reporting intermediate values to prune unpromising trials during Optuna hyperparameters tuning.
 
     Adapted to single objective optimization (res.fit is a float)
+
+    The callback report to optuna intermediate fitness with the corresponding step number
+    or elapsed time since starting time.
+    It also updates the user attribute used to store computing time,
+    so that pruned or failed trials will still have the user attribute updated.
+    If the optuna pruner see that the trial should be pruned, raise the appropriate TrialPruned exception.
 
     Args:
         trial:
@@ -34,14 +40,36 @@ class OptunaReportSingleFitCallback(Callback):
             objective function.
         optuna_report_nb_steps: report intermediate result every `optuna_report_nb_steps` steps
             when the number of iterations is high, setting this to 1 could slow too much run of a single trial
+        starting_time: float representing the start time of the solving process.
+            Should be the result of a call to `time.perf_counter()`.
+            Default to `time.perf_counter()` called by `on_solve_start()`.
+            Useful to be on par with a clock set outside the callback.
+        elapsed_time_attr: key of trial user attribute used to store the elapsed time at each step
+        report_time: if True, report to optuna intermediate fitness with elapsed time instead of step
+        pruning: if True, use the optuna pruner to decide if we the trial should be pruned. Else never try to prune.
 
     """
 
     def __init__(
-        self, trial: optuna.trial.Trial, optuna_report_nb_steps: int = 1, **kwargs
+        self,
+        trial: optuna.trial.Trial,
+        optuna_report_nb_steps: int = 1,
+        starting_time: Optional[float] = None,
+        elapsed_time_attr: str = "elapsed_time",
+        report_time: bool = False,
+        pruning: bool = True,
+        **kwargs,
     ) -> None:
+        self.pruning = pruning
+        self.report_time = report_time
+        self.elapsed_time_attr = elapsed_time_attr
         self.report_nb_steps = optuna_report_nb_steps
         self.trial = trial
+        self.starting_time = starting_time
+
+    def on_solve_start(self, solver: SolverDO):
+        if self.starting_time is None:
+            self.starting_time = time.perf_counter()
 
     def on_step_end(
         self, step: int, res: ResultStorage, solver: SolverDO
@@ -60,51 +88,17 @@ class OptunaReportSingleFitCallback(Callback):
         if step % self.report_nb_steps == 0:
             _, fit = res.get_best_solution_fit()
 
-            # Report current score and step to Optuna's trial.
-            self.trial.report(float(fit), step=step)
-
-
-class OptunaPruningSingleFitCallback(Callback):
-    """Callback to prune unpromising trials during Optuna hyperparameters tuning.
-
-    Adapted to single objective optimization (res.fit is a float)
-
-    Args:
-        trial:
-            A :class:`optuna.trial.Trial` corresponding to the current evaluation of the
-            objective function.
-        optuna_report_nb_steps: report intermediate result every `optuna_report_nb_steps` steps
-            when the number of iterations is high, setting this to 1 could slow too much run of a single trial
-
-    """
-
-    def __init__(
-        self, trial: optuna.trial.Trial, optuna_report_nb_steps: int = 1, **kwargs
-    ) -> None:
-        self.report_nb_steps = optuna_report_nb_steps
-        self.trial = trial
-
-    def on_step_end(
-        self, step: int, res: ResultStorage, solver: SolverDO
-    ) -> Optional[bool]:
-        """Called at the end of an optimization step.
-
-        Args:
-            step: index of step
-            res: current result storage
-            solver: solvers using the callback
-
-        Returns:
-            If `True`, the optimization process is stopped, else it goes on.
-
-        """
-        if step % self.report_nb_steps == 0:
-            _, fit = res.get_best_solution_fit()
+            step_time = time.perf_counter() - self.starting_time
+            self.trial.set_user_attr(self.elapsed_time_attr, step_time)
 
             # Report current score and step to Optuna's trial.
-            self.trial.report(float(fit), step=step)
+            if self.report_time:
+                self.trial.report(float(fit), step=float(step_time))
+            else:
+                self.trial.report(float(fit), step=step)
 
             # Prune trial if needed
-            if self.trial.should_prune():
-                message = "Trial was pruned at step {}.".format(step)
-                raise optuna.TrialPruned(message)
+            if self.pruning:
+                if self.trial.should_prune():
+                    message = "Trial was pruned at step {}.".format(step)
+                    raise optuna.TrialPruned(message)

--- a/discrete_optimization/generic_tools/optuna/timed_percentile_pruner.py
+++ b/discrete_optimization/generic_tools/optuna/timed_percentile_pruner.py
@@ -1,0 +1,205 @@
+#  Copyright (c) 2024 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+#
+# This module is adapted from https://github.com/optuna/optuna/blob/master/optuna/pruners/_percentile.py
+
+import functools
+import math
+from typing import KeysView, List
+
+import numpy as np
+import optuna
+from optuna.pruners import BasePruner
+from optuna.study._study_direction import StudyDirection
+from optuna.trial._state import TrialState
+
+
+def _get_best_intermediate_result_over_steps(
+    trial: "optuna.trial.FrozenTrial", direction: StudyDirection
+) -> float:
+    values = np.asarray(list(trial.intermediate_values.values()), dtype=float)
+    if direction == StudyDirection.MAXIMIZE:
+        return np.nanmax(values)
+    return np.nanmin(values)
+
+
+def _get_interpolated_intermediate_value(
+    trial: "optuna.trial.FrozenTrial", step: float
+) -> float:
+    xp = sorted(trial.intermediate_values)
+    yp = [trial.intermediate_values[xx] for xx in xp]
+    if len(xp) > 0:
+        return np.interp(step, xp=xp, fp=yp, left=np.nan, right=np.nan)
+    else:
+        return np.nan
+
+
+def _get_percentile_intermediate_result_over_trials(
+    completed_trials: List["optuna.trial.FrozenTrial"],
+    direction: StudyDirection,
+    step: int,
+    percentile: float,
+    n_min_trials: int,
+) -> float:
+    if len(completed_trials) == 0:
+        raise ValueError("No trials have been completed.")
+
+    intermediate_values = [
+        _get_interpolated_intermediate_value(trial=t, step=step)
+        for t in completed_trials
+    ]
+    intermediate_values = [v for v in intermediate_values if not np.isnan(v)]
+
+    if len(intermediate_values) < n_min_trials:
+        return math.nan
+
+    if direction == StudyDirection.MAXIMIZE:
+        percentile = 100 - percentile
+
+    return float(
+        np.nanpercentile(
+            np.array(intermediate_values, dtype=float),
+            percentile,
+        )
+    )
+
+
+def _is_first_in_interval_step(
+    step: int,
+    intermediate_steps: KeysView[int],
+    n_warmup_steps: int,
+    interval_steps: int,
+) -> bool:
+    nearest_lower_pruning_step = (
+        step - n_warmup_steps
+    ) // interval_steps * interval_steps + n_warmup_steps
+    assert nearest_lower_pruning_step >= 0
+
+    # `intermediate_steps` may not be sorted so we must go through all elements.
+    second_last_step = functools.reduce(
+        lambda second_last_step, s: s
+        if s > second_last_step and s != step
+        else second_last_step,
+        intermediate_steps,
+        -1,
+    )
+
+    return second_last_step < nearest_lower_pruning_step
+
+
+class TimedPercentilePruner(BasePruner):
+    """Pruner to keep the specified percentile of the trials.
+
+    Prune if the best intermediate value is in the bottom percentile among trials at the same step.
+    If no report for the exact step exits in other trials, we use an interpolated value.
+
+    Args:
+        percentile:
+            Percentile which must be between 0 and 100 inclusive
+            (e.g., When given 25.0, top of 25th percentile trials are kept).
+        n_startup_trials:
+            Pruning is disabled until the given number of trials finish in the same study.
+        n_warmup_steps:
+            Pruning is disabled until the trial exceeds the given number of step. Note that
+            this feature assumes that ``step`` starts at zero.
+        interval_steps:
+            Interval in number of steps between the pruning checks, offset by the warmup steps.
+            If no value has been reported at the time of a pruning check, that particular check
+            will be postponed until a value is reported. Value must be at least 1.
+        n_min_trials:
+            Minimum number of reported trial results at a step to judge whether to prune.
+            If the number of reported intermediate values from all trials at the current step
+            is less than ``n_min_trials``, the trial will not be pruned. This can be used to ensure
+            that a minimum number of trials are run to completion without being pruned.
+    """
+
+    def __init__(
+        self,
+        percentile: float,
+        n_startup_trials: int = 5,
+        n_warmup_steps: int = 0,
+        interval_steps: int = 1,
+        *,
+        n_min_trials: int = 1,
+    ) -> None:
+        if not 0.0 <= percentile <= 100:
+            raise ValueError(
+                "Percentile must be between 0 and 100 inclusive but got {}.".format(
+                    percentile
+                )
+            )
+        if n_startup_trials < 0:
+            raise ValueError(
+                "Number of startup trials cannot be negative but got {}.".format(
+                    n_startup_trials
+                )
+            )
+        if n_warmup_steps < 0:
+            raise ValueError(
+                "Number of warmup steps cannot be negative but got {}.".format(
+                    n_warmup_steps
+                )
+            )
+        if interval_steps < 1:
+            raise ValueError(
+                "Pruning interval steps must be at least 1 but got {}.".format(
+                    interval_steps
+                )
+            )
+        if n_min_trials < 1:
+            raise ValueError(
+                "Number of trials for pruning must be at least 1 but got {}.".format(
+                    n_min_trials
+                )
+            )
+
+        self._percentile = percentile
+        self._n_startup_trials = n_startup_trials
+        self._n_warmup_steps = n_warmup_steps
+        self._interval_steps = interval_steps
+        self._n_min_trials = n_min_trials
+
+    def prune(
+        self, study: "optuna.study.Study", trial: "optuna.trial.FrozenTrial"
+    ) -> bool:
+        completed_trials = study.get_trials(
+            deepcopy=False, states=(TrialState.COMPLETE,)
+        )
+        n_trials = len(completed_trials)
+
+        if n_trials == 0:
+            return False
+
+        if n_trials < self._n_startup_trials:
+            return False
+
+        step = trial.last_step
+        if step is None:
+            return False
+
+        n_warmup_steps = self._n_warmup_steps
+        if step < n_warmup_steps:
+            return False
+
+        if not _is_first_in_interval_step(
+            step, trial.intermediate_values.keys(), n_warmup_steps, self._interval_steps
+        ):
+            return False
+
+        direction = study.direction
+        best_intermediate_result = _get_best_intermediate_result_over_steps(
+            trial, direction
+        )
+        if math.isnan(best_intermediate_result):
+            return True
+
+        p = _get_percentile_intermediate_result_over_trials(
+            completed_trials, direction, step, self._percentile, self._n_min_trials
+        )
+        if math.isnan(p):
+            return False
+
+        if direction == StudyDirection.MAXIMIZE:
+            return best_intermediate_result < p
+        return best_intermediate_result > p

--- a/examples/coloring/optuna_all_solvers_coloring.py
+++ b/examples/coloring/optuna_all_solvers_coloring.py
@@ -38,10 +38,7 @@ from discrete_optimization.generic_tools.callbacks.early_stoppers import (
     NbIterationStopper,
 )
 from discrete_optimization.generic_tools.callbacks.loggers import ObjectiveLogger
-from discrete_optimization.generic_tools.callbacks.optuna import (
-    OptunaPruningSingleFitCallback,
-    OptunaReportSingleFitCallback,
-)
+from discrete_optimization.generic_tools.callbacks.optuna import OptunaCallback
 from discrete_optimization.generic_tools.cp_tools import ParametersCP
 from discrete_optimization.generic_tools.do_problem import ModeOptim
 from discrete_optimization.generic_tools.do_solver import SolverDO
@@ -150,7 +147,7 @@ def objective(trial: Trial):
     # solve
     res = solver.solve(
         callbacks=[
-            OptunaReportSingleFitCallback(trial=trial, **kwargs),
+            OptunaCallback(trial=trial, pruning=False, **kwargs),
             ObjectiveLogger(
                 step_verbosity_level=logging.INFO, end_verbosity_level=logging.INFO
             ),

--- a/examples/coloring/optuna_all_solvers_coloring_with_pruning_based_on_time.py
+++ b/examples/coloring/optuna_all_solvers_coloring_with_pruning_based_on_time.py
@@ -1,0 +1,204 @@
+#  Copyright (c) 2024 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+"""Example using OPTUNA to choose a solving method and tune its hyperparameters for coloring.
+
+Results can be viewed on optuna-dashboard with:
+
+    optuna-dashboard optuna-journal.log
+
+"""
+import logging
+import time
+from collections import defaultdict
+from typing import Any, Dict, List, Type
+
+import optuna
+from optuna.storages import JournalFileStorage, JournalStorage
+from optuna.trial import Trial, TrialState
+
+from discrete_optimization.coloring.coloring_parser import (
+    get_data_available,
+    parse_file,
+)
+from discrete_optimization.coloring.coloring_solvers import (
+    ColoringASPSolver,
+    ColoringLP,
+    ParametersMilp,
+    solvers_map,
+    toulbar2_available,
+)
+from discrete_optimization.coloring.solvers.coloring_cp_solvers import ColoringCP
+from discrete_optimization.coloring.solvers.coloring_cpsat_solver import (
+    ColoringCPSatSolver,
+)
+from discrete_optimization.coloring.solvers.coloring_lp_solvers import ColoringLP_MIP
+from discrete_optimization.coloring.solvers.coloring_toulbar_solver import (
+    ToulbarColoringSolver,
+)
+from discrete_optimization.generic_tools.callbacks.loggers import ObjectiveLogger
+from discrete_optimization.generic_tools.callbacks.optuna import OptunaCallback
+from discrete_optimization.generic_tools.cp_tools import ParametersCP
+from discrete_optimization.generic_tools.do_problem import ModeOptim
+from discrete_optimization.generic_tools.do_solver import SolverDO
+from discrete_optimization.generic_tools.lp_tools import gurobi_available
+from discrete_optimization.generic_tools.optuna.timed_percentile_pruner import (
+    TimedPercentilePruner,
+)
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s:%(levelname)s:%(message)s")
+
+
+seed = 42
+optuna_nb_trials = 100
+gurobi_full_license_available = False
+create_another_study = True  # avoid relaunching the same study, keep the previous ones
+max_time_per_solver = 20  # max duration (s)
+min_time_per_solver = 5  # min duration before pruning (s)
+
+modelfilename = "gc_70_9"
+
+suffix = f"-{time.time()}" if create_another_study else ""
+study_name = f"coloring_all_solvers-auto-pruning-{modelfilename}{suffix}"
+storage_path = "./optuna-journal.log"  # NFS path for distributed optimization
+elapsed_time_attr = "elapsed_time"  # name of the user attribute used to store duration of trials (updated during intermediate reports)
+
+# Solvers to test and their associated kwargs
+solvers_to_remove = {ColoringLP_MIP, ColoringCP}
+if not gurobi_available or not gurobi_full_license_available:
+    solvers_to_remove.add(ColoringLP)
+if not toulbar2_available:
+    solvers_to_remove.add(ToulbarColoringSolver)
+solvers_to_test: List[Type[SolverDO]] = [
+    s for s in solvers_map if s not in solvers_to_remove
+]
+# solvers_to_test = [ColoringLP]
+p = ParametersCP.default_cpsat()
+p.nb_process = 6
+p.time_limit = max_time_per_solver
+p_m = ParametersMilp.default()
+p_m.time_limit = max_time_per_solver
+kwargs_fixed_by_solver: Dict[Type[SolverDO], Dict[str, Any]] = defaultdict(
+    dict,  # default kwargs for unspecified solvers
+    {
+        ColoringCPSatSolver: dict(parameters_cp=p),
+        ColoringCP: dict(parameters_cp=p),
+        ColoringLP: dict(parameters_milp=p_m),
+        ColoringASPSolver: dict(timeout_seconds=max_time_per_solver),
+        ToulbarColoringSolver: dict(time_limit=max_time_per_solver),
+    },
+)
+
+# we need to map the classes to a unique string, to be seen as a categorical hyperparameter by optuna
+# by default, we use the class name, but if there are identical names, f"{cls.__module__}.{cls.__name__}" could be used.
+solvers_by_name: Dict[str, Type[SolverDO]] = {
+    cls.__name__: cls for cls in solvers_to_test
+}
+
+# problem definition
+file = [f for f in get_data_available() if "gc_70_9" in f][0]
+problem = parse_file(file)
+
+# sense of optimization
+objective_register = problem.get_objective_register()
+if objective_register.objective_sense == ModeOptim.MINIMIZATION:
+    direction = "minimize"
+else:
+    direction = "maximize"
+
+# objective names
+objs, weights = objective_register.get_list_objective_and_default_weight()
+
+
+# objective definition
+def objective(trial: Trial):
+    # hyperparameters to test
+
+    # first parameter: solver choice
+    solver_name: str = trial.suggest_categorical("solver", choices=solvers_by_name)
+    solver_class = solvers_by_name[solver_name]
+
+    # hyperparameters for the chosen solver
+    suggested_hyperparameters_kwargs = solver_class.suggest_hyperparameters_with_optuna(
+        trial=trial, prefix=solver_name + "."
+    )
+
+    # use existing value if corresponding to a previous complete trial
+    states_to_consider = (TrialState.COMPLETE,)
+    trials_to_consider = trial.study.get_trials(
+        deepcopy=False, states=states_to_consider
+    )
+    for t in reversed(trials_to_consider):
+        if trial.params == t.params:
+            logger.warning(
+                "Trial with same hyperparameters as a previous complete trial: returning previous fit."
+            )
+            return t.value
+
+    # prune if corresponding to a previous failed trial
+    states_to_consider = (TrialState.FAIL,)
+    trials_to_consider = trial.study.get_trials(
+        deepcopy=False, states=states_to_consider
+    )
+    for t in reversed(trials_to_consider):
+        if trial.params == t.params:
+            raise optuna.TrialPruned(
+                "Pruning trial identical to a previous failed trial."
+            )
+
+    logger.info(f"Launching trial {trial.number} with parameters: {trial.params}")
+
+    # construct kwargs for __init__, init_model, and solve
+    kwargs = dict(kwargs_fixed_by_solver[solver_class])  # copy the frozen kwargs dict
+    kwargs.update(suggested_hyperparameters_kwargs)
+
+    # solver init
+    solver = solver_class(problem=problem, **kwargs)
+    solver.init_model(**kwargs)
+
+    # init timer
+    starting_time = time.perf_counter()
+
+    # solve
+    res = solver.solve(
+        callbacks=[
+            OptunaCallback(
+                trial=trial,
+                starting_time=starting_time,
+                elapsed_time_attr=elapsed_time_attr,
+                report_time=True,
+            ),
+            ObjectiveLogger(
+                step_verbosity_level=logging.INFO, end_verbosity_level=logging.INFO
+            ),
+        ],
+        **kwargs,
+    )
+
+    # store elapsed time
+    elapsed_time = time.perf_counter() - starting_time
+    trial.set_user_attr(elapsed_time_attr, elapsed_time)
+
+    if len(res.list_solution_fits) != 0:
+        _, fit = res.get_best_solution_fit()
+        return fit
+    else:
+        raise optuna.TrialPruned("Pruned because failed")
+
+
+# create study + database to store it
+storage = JournalStorage(JournalFileStorage(storage_path))
+study = optuna.create_study(
+    study_name=study_name,
+    direction=direction,
+    sampler=optuna.samplers.TPESampler(seed=seed),
+    pruner=TimedPercentilePruner(  # intermediate values interpolated at same "step"
+        percentile=50,  # median pruner
+        n_warmup_steps=min_time_per_solver,  # no pruning during first seconds
+    ),
+    storage=storage,
+    load_if_exists=True,
+)
+study.set_metric_names(["nb_colors"])
+study.optimize(objective, n_trials=optuna_nb_trials)

--- a/examples/coloring/optuna_full_example_coloring.py
+++ b/examples/coloring/optuna_full_example_coloring.py
@@ -26,10 +26,7 @@ from discrete_optimization.coloring.solvers.coloring_cpsat_solver import (
 from discrete_optimization.generic_tools.callbacks.early_stoppers import (
     NbIterationStopper,
 )
-from discrete_optimization.generic_tools.callbacks.optuna import (
-    OptunaPruningSingleFitCallback,
-    OptunaReportSingleFitCallback,
-)
+from discrete_optimization.generic_tools.callbacks.optuna import OptunaCallback
 from discrete_optimization.generic_tools.cp_tools import ParametersCP
 from discrete_optimization.generic_tools.do_problem import ModeOptim
 from discrete_optimization.generic_tools.do_solver import SolverDO
@@ -125,8 +122,7 @@ def objective(trial: Trial):
     # solve
     sol, fit = solver.solve(
         callbacks=[
-            # OptunaReportSingleFitCallback(trial=trial, **kwargs)
-            OptunaPruningSingleFitCallback(trial=trial, **kwargs),
+            OptunaCallback(trial=trial, **kwargs),
         ],
         **kwargs,
     ).get_best_solution_fit()

--- a/examples/knapsack/optuna_example.py
+++ b/examples/knapsack/optuna_example.py
@@ -16,9 +16,7 @@ import optuna
 from optuna.storages import JournalFileStorage, JournalStorage
 from optuna.trial import Trial, TrialState
 
-from discrete_optimization.generic_tools.callbacks.optuna import (
-    OptunaPruningSingleFitCallback,
-)
+from discrete_optimization.generic_tools.callbacks.optuna import OptunaCallback
 from discrete_optimization.generic_tools.cp_tools import CPSolverName, ParametersCP
 from discrete_optimization.generic_tools.do_problem import ModeOptim
 from discrete_optimization.generic_tools.do_solver import SolverDO
@@ -160,7 +158,7 @@ def objective(trial: Trial):
     # solve
     sol, fit = solver.solve(
         callbacks=[
-            OptunaPruningSingleFitCallback(trial=trial, **kwargs),
+            OptunaCallback(trial=trial, **kwargs),
         ],
         **kwargs,
     ).get_best_solution_fit()

--- a/examples/pickup_vrp/optuna_full_example.py
+++ b/examples/pickup_vrp/optuna_full_example.py
@@ -16,9 +16,7 @@ import optuna
 from optuna.storages import JournalFileStorage, JournalStorage
 from optuna.trial import Trial, TrialState
 
-from discrete_optimization.generic_tools.callbacks.optuna import (
-    OptunaPruningSingleFitCallback,
-)
+from discrete_optimization.generic_tools.callbacks.optuna import OptunaCallback
 from discrete_optimization.generic_tools.do_problem import ModeOptim
 from discrete_optimization.generic_tools.do_solver import SolverDO
 from discrete_optimization.pickup_vrp.builders.instance_builders import (
@@ -58,7 +56,7 @@ kwargs_fixed_by_solver: Dict[Type[SolverDO], Dict[str, Any]] = defaultdict(
             include_mandatory=True,
             include_pickup_and_delivery=False,
             time_limit=20,
-            optuna_report_nb_steps=1,  # nb of steps between OptunaPruningSingleFitCallback reports for current best fit
+            optuna_report_nb_steps=1,  # nb of steps between OptunaCallback reports for current best fit
         ),
     },
 )
@@ -134,7 +132,7 @@ def objective(trial: Trial):
     # solve
     sol, fit = solver.solve(
         callbacks=[
-            OptunaPruningSingleFitCallback(trial=trial, **kwargs),
+            OptunaCallback(trial=trial, **kwargs),
         ],
         **kwargs,
     ).get_best_solution_fit()

--- a/examples/pickup_vrp/pickup_vrp_ortools_with_optuna_with_pruning.py
+++ b/examples/pickup_vrp/pickup_vrp_ortools_with_optuna_with_pruning.py
@@ -20,9 +20,7 @@ from optuna.trial import Trial, TrialState
 from discrete_optimization.generic_tools.callbacks.early_stoppers import (
     NbIterationStopper,
 )
-from discrete_optimization.generic_tools.callbacks.optuna import (
-    OptunaPruningSingleFitCallback,
-)
+from discrete_optimization.generic_tools.callbacks.optuna import OptunaCallback
 from discrete_optimization.generic_tools.do_problem import (
     ModeOptim,
     ObjectiveHandling,
@@ -104,7 +102,7 @@ def objective(trial: Trial):
     sol, fit = solver.solve(
         callbacks=[
             nb_iteration_stopper,
-            OptunaPruningSingleFitCallback(trial=trial, optuna_report_nb_steps=1),
+            OptunaCallback(trial=trial, optuna_report_nb_steps=1),
         ]
     ).get_best_solution_fit()
     trial.set_user_attr("n_solutions_found", nb_iteration_stopper.nb_iteration)

--- a/examples/pickup_vrp/pickup_vrp_ortools_with_optuna_with_pruning_v4.py
+++ b/examples/pickup_vrp/pickup_vrp_ortools_with_optuna_with_pruning_v4.py
@@ -20,9 +20,7 @@ from optuna.trial import Trial, TrialState
 from discrete_optimization.generic_tools.callbacks.early_stoppers import (
     NbIterationStopper,
 )
-from discrete_optimization.generic_tools.callbacks.optuna import (
-    OptunaPruningSingleFitCallback,
-)
+from discrete_optimization.generic_tools.callbacks.optuna import OptunaCallback
 from discrete_optimization.generic_tools.do_problem import (
     ModeOptim,
     ObjectiveHandling,
@@ -104,7 +102,7 @@ def objective(trial: Trial):
     sol, fit = solver.solve(
         callbacks=[
             nb_iteration_stopper,
-            OptunaPruningSingleFitCallback(trial=trial, optuna_report_nb_steps=1),
+            OptunaCallback(trial=trial, optuna_report_nb_steps=1),
         ]
     ).get_best_solution_fit()
     trial.set_user_attr("n_solutions_found", nb_iteration_stopper.nb_iteration)

--- a/examples/pickup_vrp/pickup_vrp_ortools_with_optuna_with_pruning_v4_auto.py
+++ b/examples/pickup_vrp/pickup_vrp_ortools_with_optuna_with_pruning_v4_auto.py
@@ -21,9 +21,7 @@ from optuna.trial import Trial, TrialState
 from discrete_optimization.generic_tools.callbacks.early_stoppers import (
     NbIterationStopper,
 )
-from discrete_optimization.generic_tools.callbacks.optuna import (
-    OptunaPruningSingleFitCallback,
-)
+from discrete_optimization.generic_tools.callbacks.optuna import OptunaCallback
 from discrete_optimization.generic_tools.do_problem import (
     ModeOptim,
     ObjectiveHandling,
@@ -121,7 +119,7 @@ def objective(trial: Trial):
     sol, fit = solver.solve(
         callbacks=[
             nb_iteration_stopper,
-            OptunaPruningSingleFitCallback(trial=trial, optuna_report_nb_steps=1),
+            OptunaCallback(trial=trial, optuna_report_nb_steps=1),
         ]
     ).get_best_solution_fit()
     trial.set_user_attr("n_solutions_found", nb_iteration_stopper.nb_iteration)

--- a/examples/rcpsp/rcpsp_local_search_with_optuna_with_pruning.py
+++ b/examples/rcpsp/rcpsp_local_search_with_optuna_with_pruning.py
@@ -20,9 +20,7 @@ import numpy as np
 import optuna
 from optuna.trial import Trial, TrialState
 
-from discrete_optimization.generic_tools.callbacks.optuna import (
-    OptunaPruningSingleFitCallback,
-)
+from discrete_optimization.generic_tools.callbacks.optuna import OptunaCallback
 from discrete_optimization.generic_tools.do_problem import (
     ModeOptim,
     ObjectiveHandling,
@@ -122,9 +120,7 @@ def objective(trial: Trial):
     sol, fit = sa.solve(
         dummy,
         nb_iteration_max=nb_iteration_max,
-        callbacks=[
-            OptunaPruningSingleFitCallback(trial=trial, optuna_report_nb_steps=100)
-        ],
+        callbacks=[OptunaCallback(trial=trial, optuna_report_nb_steps=100)],
     ).get_best_solution_fit()
     return fit
 

--- a/tests/generic_tools/callbacks/test_sa_with_callbacks.py
+++ b/tests/generic_tools/callbacks/test_sa_with_callbacks.py
@@ -18,9 +18,7 @@ from discrete_optimization.generic_tools.callbacks.backup import (
 from discrete_optimization.generic_tools.callbacks.callback import Callback
 from discrete_optimization.generic_tools.callbacks.early_stoppers import TimerStopper
 from discrete_optimization.generic_tools.callbacks.loggers import NbIterationTracker
-from discrete_optimization.generic_tools.callbacks.optuna import (
-    OptunaPruningSingleFitCallback,
-)
+from discrete_optimization.generic_tools.callbacks.optuna import OptunaCallback
 from discrete_optimization.generic_tools.do_problem import (
     ModeOptim,
     ObjectiveHandling,
@@ -188,9 +186,7 @@ def test_sa_with_optuna_callback(random_seed):
         _, fit = sa.solve(
             dummy,
             nb_iteration_max=nb_iteration_max,
-            callbacks=[
-                OptunaPruningSingleFitCallback(trial=trial, optuna_report_nb_steps=10)
-            ],
+            callbacks=[OptunaCallback(trial=trial, optuna_report_nb_steps=10)],
         ).get_best_solution_fit()
         return fit
 

--- a/tests/generic_tools/callbacks/test_sa_with_callbacks.py
+++ b/tests/generic_tools/callbacks/test_sa_with_callbacks.py
@@ -37,6 +37,9 @@ from discrete_optimization.generic_tools.mutations.mutation_catalog import (
     PermutationMutationRCPSP,
     get_available_mutations,
 )
+from discrete_optimization.generic_tools.optuna.timed_percentile_pruner import (
+    TimedPercentilePruner,
+)
 from discrete_optimization.rcpsp.rcpsp_model import RCPSPModel
 from discrete_optimization.rcpsp.rcpsp_parser import get_data_available, parse_file
 
@@ -198,6 +201,99 @@ def test_sa_with_optuna_callback(random_seed):
     )
     study.set_metric_names(["-makespan"])
     study.optimize(objective, n_trials=10)
+
+    pruned_trials = study.get_trials(
+        deepcopy=False, states=[optuna.trial.TrialState.PRUNED]
+    )
+    complete_trials = study.get_trials(
+        deepcopy=False, states=[optuna.trial.TrialState.COMPLETE]
+    )
+    assert len(pruned_trials) > 0
+    assert len(complete_trials) > 0
+
+
+def test_sa_with_optuna_timed_callback(random_seed):
+    def objective(trial: optuna.trial.Trial) -> float:
+        files = get_data_available()
+        files = [f for f in files if "j1010_1.mm" in f]  # Multi mode RCPSP
+        file_path = files[0]
+        rcpsp_model: RCPSPModel = parse_file(file_path)
+        rcpsp_model.set_fixed_modes([1 for i in range(rcpsp_model.n_jobs)])
+
+        dummy = rcpsp_model.get_dummy_solution()
+        _, mutations = get_available_mutations(rcpsp_model, dummy)
+        list_mutation = [
+            mutate[0].build(rcpsp_model, dummy, **mutate[1])
+            for mutate in mutations
+            if mutate[0] == PermutationMutationRCPSP
+        ]
+        mixed_mutation = BasicPortfolioMutation(
+            list_mutation, np.ones((len(list_mutation)))
+        )
+        objectives = ["makespan"]
+        objective_weights = [-1]
+        params_objective_function = ParamsObjectiveFunction(
+            objective_handling=ObjectiveHandling.AGGREGATE,
+            objectives=objectives,
+            weights=objective_weights,
+            sense_function=ModeOptim.MAXIMIZATION,
+        )
+
+        initial_temperature = trial.suggest_float(
+            "initial_temperature", 0.1, 100.0, log=True
+        )
+        one_minus_coefficient_temperature = trial.suggest_float(
+            "one_minus_coefficient_temperature", 0.00001, 0.2, log=True
+        )
+        coefficient_temperature = 1.0 - one_minus_coefficient_temperature
+        nb_iteration_max = trial.suggest_int("nb_iteration_max", 100, 1000)
+        nb_iteration_no_improvement_max = trial.suggest_int(
+            "nb_iteration_no_improvement_max", 10, nb_iteration_max
+        )
+
+        restart_handler = RestartHandlerLimit(
+            nb_iteration_no_improvement=nb_iteration_no_improvement_max
+        )
+        temperature_handler = TemperatureSchedulingFactor(
+            temperature=initial_temperature,
+            restart_handler=restart_handler,
+            coefficient=coefficient_temperature,
+        )
+
+        sa = SimulatedAnnealing(
+            problem=rcpsp_model,
+            mutator=mixed_mutation,
+            restart_handler=restart_handler,
+            temperature_handler=temperature_handler,
+            mode_mutation=ModeMutation.MUTATE,
+            params_objective_function=params_objective_function,
+            store_solution=False,
+        )
+
+        _, fit = sa.solve(
+            dummy,
+            nb_iteration_max=nb_iteration_max,
+            callbacks=[
+                OptunaCallback(
+                    trial=trial,
+                    optuna_report_nb_steps=10,
+                    report_time=True,
+                )
+            ],
+        ).get_best_solution_fit()
+        return fit
+
+    study = optuna.create_study(
+        study_name="rcpsp-sa-pruning",
+        direction="maximize",
+        sampler=optuna.samplers.TPESampler(seed=random_seed),
+        pruner=TimedPercentilePruner(  # intermediate values interpolated at same "step"
+            percentile=2,  # 2% pruner
+            n_min_trials=2,
+        ),
+    )
+    study.set_metric_names(["-makespan"])
+    study.optimize(objective, n_trials=40)
 
     pruned_trials = study.get_trials(
         deepcopy=False, states=[optuna.trial.TrialState.PRUNED]


### PR DESCRIPTION
- We make optuna callbacks store a user_attribute for elapsed time
- We add optuna callbacks reporting intermediate results with elapsed time instead of iteration number
- We add a pruner working with elapsed time by modifying existing pruner so that an interpolation is done on intermediate values of previous trials
- We adapt coloring example to show how it works