### PR TITLE
Make easier hyperparameters definition for LNS solvers

### DIFF
--- a/discrete_optimization/coloring/solvers/coloring_cp_lns.py
+++ b/discrete_optimization/coloring/solvers/coloring_cp_lns.py
@@ -20,6 +20,10 @@ from discrete_optimization.coloring.solvers.coloring_solver import SolverColorin
 from discrete_optimization.generic_tools.callbacks.callback import Callback
 from discrete_optimization.generic_tools.cp_tools import ParametersCP
 from discrete_optimization.generic_tools.do_problem import ParamsObjectiveFunction
+from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
+    SubBrickHyperparameter,
+    SubBrickKwargsHyperparameter,
+)
 from discrete_optimization.generic_tools.lns_cp import (
     LNS_CP,
     TrivialPostProcessSolution,
@@ -74,6 +78,38 @@ class LnsCpColoring(SolverColoring):
     Most easy way to use LNS-CP for coloring with some default parameters for constraint handler.
     """
 
+    hyperparameters = [
+        SubBrickHyperparameter("cp_solver_cls", choices=[ColoringCP], default=None),
+        SubBrickKwargsHyperparameter(
+            "cp_solver_kwargs", subbrick_hyperparameter="cp_solver_cls"
+        ),
+        SubBrickHyperparameter(
+            "initial_solution_provider_cls", choices=[InitialColoring], default=None
+        ),
+        SubBrickKwargsHyperparameter(
+            "initial_solution_provider_kwargs",
+            subbrick_hyperparameter="initial_solution_provider_cls",
+        ),
+        SubBrickHyperparameter(
+            "constraint_handler_cls",
+            choices=[ConstraintHandlerFixColorsCP],
+            default=None,
+        ),
+        SubBrickKwargsHyperparameter(
+            "constraint_handler_kwargs",
+            subbrick_hyperparameter="constraint_handler_cls",
+        ),
+        SubBrickHyperparameter(
+            "post_process_solution_cls",
+            choices=[TrivialPostProcessSolution, PostProcessSolutionColoring],
+            default=None,
+        ),
+        SubBrickKwargsHyperparameter(
+            "post_process_solution_kwargs",
+            subbrick_hyperparameter="post_process_solution_cls",
+        ),
+    ]
+
     def __init__(
         self,
         problem: ColoringProblem,
@@ -84,28 +120,82 @@ class LnsCpColoring(SolverColoring):
             problem=problem, params_objective_function=params_objective_function
         )
 
+        kwargs = self.complete_with_default_hyperparameters(kwargs)
+
         solver = kwargs.get("cp_solver", None)
         if solver is None:
-            solver = build_default_cp_model(coloring_model=self.problem, **kwargs)
+            if kwargs["cp_solver_kwargs"] is None:
+                cp_solver_kwargs = kwargs
+            else:
+                cp_solver_kwargs = kwargs["cp_solver_kwargs"]
+            if kwargs["cp_solver_cls"] is None:
+                solver = build_default_cp_model(
+                    coloring_model=self.problem, **cp_solver_kwargs
+                )
+            else:
+                cp_solver_cls = kwargs["cp_solver_cls"]
+                solver = cp_solver_cls(problem=self.problem, **cp_solver_kwargs)
+                solver.init_model(**cp_solver_kwargs)
         self.cp_solver = solver
+
         self.parameters_cp = kwargs.get("parameters_cp", ParametersCP.default())
+
         self.constraint_handler = kwargs.get("constraint_handler", None)
         if self.constraint_handler is None:
-            self.constraint_handler = build_default_constraint_handler(
-                coloring_model=self.problem, **kwargs
-            )
+            if kwargs["constraint_handler_kwargs"] is None:
+                constraint_handler_kwargs = kwargs
+            else:
+                constraint_handler_kwargs = kwargs["constraint_handler_kwargs"]
+            if kwargs["constraint_handler_cls"] is None:
+                self.constraint_handler = build_default_constraint_handler(
+                    coloring_model=self.problem, **constraint_handler_kwargs
+                )
+            else:
+                constraint_handler_cls = kwargs["constraint_handler_cls"]
+                self.constraint_handler = constraint_handler_cls(
+                    problem=self.problem, **constraint_handler_kwargs
+                )
+
         self.post_pro = kwargs.get("post_process_solution", None)
         if self.post_pro is None:
-            self.post_pro = build_default_postprocess(
-                coloring_model=self.problem,
-                params_objective_function=self.params_objective_function,
-            )
+            if kwargs["post_process_solution_kwargs"] is None:
+                post_process_solution_kwargs = kwargs
+            else:
+                post_process_solution_kwargs = kwargs["post_process_solution_kwargs"]
+            if kwargs["post_process_solution_cls"] is None:
+                self.post_pro = build_default_postprocess(
+                    coloring_model=self.problem,
+                    params_objective_function=self.params_objective_function,
+                )
+            else:
+                post_process_solution_cls = kwargs["post_process_solution_cls"]
+                self.post_pro = post_process_solution_cls(
+                    problem=self.problem,
+                    params_objective_function=self.params_objective_function,
+                    **post_process_solution_kwargs
+                )
+
         self.initial_solution_provider = kwargs.get("initial_solution_provider", None)
         if self.initial_solution_provider is None:
-            self.initial_solution_provider = build_default_initial_solution(
-                coloring_model=self.problem,
-                params_objective_function=self.params_objective_function,
-            )
+            if kwargs["initial_solution_provider_kwargs"] is None:
+                initial_solution_provider_kwargs = kwargs
+            else:
+                initial_solution_provider_kwargs = kwargs[
+                    "initial_solution_provider_kwargs"
+                ]
+            if kwargs["initial_solution_provider_cls"] is None:
+                self.initial_solution_provider = build_default_initial_solution(
+                    coloring_model=self.problem,
+                    params_objective_function=self.params_objective_function,
+                )
+            else:
+                initial_solution_provider_cls = kwargs["initial_solution_provider_cls"]
+                self.initial_solution_provider = initial_solution_provider_cls(
+                    problem=self.problem,
+                    params_objective_function=self.params_objective_function,
+                    **initial_solution_provider_kwargs
+                )
+
         self.lns_solver = LNS_CP(
             problem=self.problem,
             cp_solver=self.cp_solver,

--- a/discrete_optimization/coloring/solvers/coloring_cp_lns_solvers.py
+++ b/discrete_optimization/coloring/solvers/coloring_cp_lns_solvers.py
@@ -23,6 +23,10 @@ from discrete_optimization.generic_tools.do_problem import (
     ParamsObjectiveFunction,
     build_aggreg_function_and_params_objective,
 )
+from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
+    EnumHyperparameter,
+    FloatHyperparameter,
+)
 from discrete_optimization.generic_tools.lns_cp import (
     ConstraintHandler,
     InitialSolution,
@@ -45,6 +49,14 @@ class InitialColoring(InitialSolution):
         problem (ColoringProblem): input coloring problem
         initial_method (InitialColoringMethod): the method to use to provide the initial solution.
     """
+
+    hyperparameters = [
+        EnumHyperparameter(
+            "initial_method",
+            enum=InitialColoringMethod,
+            default=InitialColoringMethod.GREEDY,
+        )
+    ]
 
     def __init__(
         self,
@@ -92,6 +104,10 @@ class ConstraintHandlerFixColorsCP(ConstraintHandler):
         problem (ColoringProblem): input coloring problem
         fraction_to_fix (float): float between 0 and 1, representing the proportion of nodes to constrain.
     """
+
+    hyperparameters = [
+        FloatHyperparameter("fraction_to_fix", low=0.0, high=1.0, default=0.9),
+    ]
 
     def __init__(self, problem: ColoringProblem, fraction_to_fix: float = 0.9):
         self.problem = problem

--- a/discrete_optimization/generic_tools/do_solver.py
+++ b/discrete_optimization/generic_tools/do_solver.py
@@ -6,7 +6,7 @@
 from __future__ import annotations  # see annotations as str
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from discrete_optimization.generic_tools.callbacks.callback import Callback
 from discrete_optimization.generic_tools.do_problem import (
@@ -14,34 +14,18 @@ from discrete_optimization.generic_tools.do_problem import (
     Problem,
     build_aggreg_function_and_params_objective,
 )
-from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
-    Hyperparameter,
-    SubSolverKwargsHyperparameter,
+from discrete_optimization.generic_tools.hyperparameters.hyperparametrizable import (
+    Hyperparametrizable,
 )
 from discrete_optimization.generic_tools.result_storage.result_storage import (
     ResultStorage,
 )
 
-if TYPE_CHECKING:  # only for type checkers
-    try:
-        import optuna
-    except ImportError:
-        pass
 
-
-class SolverDO:
+class SolverDO(Hyperparametrizable):
     """Base class for a discrete-optimization solver."""
 
     problem: Problem
-    hyperparameters: List[Hyperparameter] = []
-    """Hyperparameters available for this solver.
-
-    These hyperparameters are to be feed to **kwargs found in
-        - __init__()
-        - init_model() (when available)
-        - solve()
-
-    """
 
     def __init__(
         self,
@@ -58,178 +42,6 @@ class SolverDO:
             problem=self.problem,
             params_objective_function=params_objective_function,
         )
-
-    @classmethod
-    def get_hyperparameters_names(cls) -> List[str]:
-        """List of hyperparameters names."""
-        return [h.name for h in cls.hyperparameters]
-
-    @classmethod
-    def get_hyperparameters_by_name(cls) -> Dict[str, Hyperparameter]:
-        """Mapping from name to corresponding hyperparameter."""
-        return {h.name: h for h in cls.hyperparameters}
-
-    @classmethod
-    def get_hyperparameter(cls, name: str) -> Hyperparameter:
-        """Get hyperparameter from given name."""
-        return cls.get_hyperparameters_by_name()[name]
-
-    @classmethod
-    def get_default_hyperparameters(
-        cls, names: Optional[List[str]] = None
-    ) -> Dict[str, Any]:
-        """Get hyperparameters default values.
-
-        Args:
-            names: names of the hyperparameters to choose.
-                By default, all available hyperparameters will be suggested.
-
-        Returns:
-            a mapping between hyperparameter name and its default value (None if not specified)
-
-        """
-        if names is None:
-            names = cls.get_hyperparameters_names()
-        hyperparameters_by_names = cls.get_hyperparameters_by_name()
-        return {name: hyperparameters_by_names[name].default for name in names}
-
-    @classmethod
-    def complete_with_default_hyperparameters(
-        cls, kwargs: Dict[str, Any], names: Optional[List[str]] = None
-    ):
-        """Add missing hyperparameters to kwargs by using default values
-
-        Args:
-            kwargs: keyword arguments to complete (for `__init__`, `init_model`, or `solve`)
-            names: names of the hyperparameters to add if missing.
-                By default, all available hyperparameters.
-
-        Returns:
-             a new dictionary, completion of kwargs
-
-        """
-        kwargs_complete = cls.get_default_hyperparameters(names=names)
-        kwargs_complete.update(kwargs)  # ensure preferring values from kwargs
-        return kwargs_complete
-
-    @classmethod
-    def suggest_hyperparameter_with_optuna(
-        cls, trial: optuna.trial.Trial, name: str, prefix: str = "", **kwargs
-    ) -> Any:
-        """Suggest hyperparameter value during an Optuna trial.
-
-        This can be used during Optuna hyperparameters tuning.
-
-        Args:
-            trial: optuna trial during hyperparameters tuning
-            name: name of the hyperparameter to choose
-            prefix: prefix to add to optuna corresponding parameter name
-              (useful for disambiguating hyperparameters from subsolvers in case of meta-solvers)
-            **kwargs: options for optuna hyperparameter suggestions
-
-        Returns:
-
-
-        kwargs can be used to pass relevant arguments to
-        - trial.suggest_float()
-        - trial.suggest_int()
-        - trial.suggest_categorical()
-
-        For instance it can
-        - add a low/high value if not existing for the hyperparameter
-          or override it to narrow the search. (for float or int hyperparameters)
-        - add a step or log argument (for float or int hyperparameters,
-          see optuna.trial.Trial.suggest_float())
-        - override choices for categorical or enum parameters to narrow the search
-
-        """
-        return cls.get_hyperparameter(name=name).suggest_with_optuna(
-            trial=trial, prefix=prefix, **kwargs
-        )
-
-    @classmethod
-    def suggest_hyperparameters_with_optuna(
-        cls,
-        trial: optuna.trial.Trial,
-        names: Optional[List[str]] = None,
-        kwargs_by_name: Optional[Dict[str, Dict[str, Any]]] = None,
-        fixed_hyperparameters: Optional[Dict[str, Any]] = None,
-        prefix: str = "",
-    ) -> Dict[str, Any]:
-        """Suggest hyperparameters values during an Optuna trial.
-
-        Args:
-            trial: optuna trial during hyperparameters tuning
-            names: names of the hyperparameters to choose.
-                By default, all available hyperparameters will be suggested.
-            kwargs_by_name: options for optuna hyperparameter suggestions, by hyperparameter name
-            fixed_hyperparameters: values of fixed hyperparameters, useful for suggesting subsolver hyperparameters,
-                if the subsolver class is not suggested by this method, but already fixed.
-            prefix: prefix to add to optuna corresponding parameters
-              (useful for disambiguating hyperparameters from subsolvers in case of meta-solvers)
-
-
-        Returns:
-            mapping between the hyperparameter name and its suggested value
-
-        kwargs_by_name[some_name] will be passed as **kwargs to suggest_hyperparameter_with_optuna(name=some_name)
-
-        """
-        if names is None:
-            names = cls.get_hyperparameters_names()
-        if kwargs_by_name is None:
-            kwargs_by_name = {}
-        if fixed_hyperparameters is None:
-            fixed_hyperparameters = {}
-
-        # Meta-solvers: when defining subsolvers hyperparameters,
-        #  be careful to suggest them before trying to suggest their own subset of hyperparameters
-        name2hyperparameter = cls.get_hyperparameters_by_name()
-        first_batch_hyperparameter_names = [
-            name
-            for name in names
-            if not (
-                isinstance(name2hyperparameter[name], SubSolverKwargsHyperparameter)
-            )
-        ]
-        subsolvers_kwargs_hyperparameters: List[SubSolverKwargsHyperparameter] = [
-            name2hyperparameter[name]
-            for name in names
-            if isinstance(name2hyperparameter[name], SubSolverKwargsHyperparameter)
-        ]
-
-        suggested_hyperparameters = {
-            name: cls.suggest_hyperparameter_with_optuna(
-                trial=trial, name=name, prefix=prefix, **kwargs_by_name.get(name, {})
-            )
-            for name in first_batch_hyperparameter_names
-        }
-        for hyperparameter in subsolvers_kwargs_hyperparameters:
-            kwargs_for_optuna_suggestion = kwargs_by_name.get(hyperparameter.name, {})
-            if hyperparameter.subsolver_hyperparameter in names:
-                kwargs_for_optuna_suggestion["subsolver"] = suggested_hyperparameters[
-                    hyperparameter.subsolver_hyperparameter
-                ]
-            elif hyperparameter.subsolver_hyperparameter in fixed_hyperparameters:
-                kwargs_for_optuna_suggestion["subsolver"] = fixed_hyperparameters[
-                    hyperparameter.subsolver_hyperparameter
-                ]
-            else:
-                raise ValueError(
-                    f"The choice of '{hyperparameter.subsolver_hyperparameter}' should be "
-                    "either suggested by this method with `names` containing it or being None "
-                    "or given via `fixed_hyperparameters`."
-                )
-            kwargs_for_optuna_suggestion[
-                "prefix"
-            ] = f"{prefix}{hyperparameter.subsolver_hyperparameter}."
-            suggested_hyperparameters[
-                hyperparameter.name
-            ] = cls.suggest_hyperparameter_with_optuna(
-                trial=trial, name=hyperparameter.name, **kwargs_for_optuna_suggestion
-            )
-
-        return suggested_hyperparameters
 
     @abstractmethod
     def solve(

--- a/discrete_optimization/generic_tools/hyperparameters/hyperparametrizable.py
+++ b/discrete_optimization/generic_tools/hyperparameters/hyperparametrizable.py
@@ -1,0 +1,209 @@
+#  Copyright (c) 2024 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations  # see annotations as str
+
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
+    Hyperparameter,
+    SubBrickKwargsHyperparameter,
+)
+
+if TYPE_CHECKING:  # only for type checkers
+    try:
+        import optuna
+    except ImportError:
+        pass
+
+
+class Hyperparametrizable:
+    """Base class for classes like SolverDO having (tunable) hyperparmeters.
+
+    They have utility methods to
+    - retrieve available hyperparameters
+    - fill kwargs with default hyperparameters values
+    - suggest hyperparameters by making use of optuna trials methods
+
+    """
+
+    hyperparameters: List[Hyperparameter] = []
+    """Hyperparameters available for this solver.
+
+    These hyperparameters are to be feed to **kwargs found in
+        - __init__()
+        - init_model() (when available)
+        - solve()
+
+    """
+
+    @classmethod
+    def get_hyperparameters_names(cls) -> List[str]:
+        """List of hyperparameters names."""
+        return [h.name for h in cls.hyperparameters]
+
+    @classmethod
+    def get_hyperparameters_by_name(cls) -> Dict[str, Hyperparameter]:
+        """Mapping from name to corresponding hyperparameter."""
+        return {h.name: h for h in cls.hyperparameters}
+
+    @classmethod
+    def get_hyperparameter(cls, name: str) -> Hyperparameter:
+        """Get hyperparameter from given name."""
+        return cls.get_hyperparameters_by_name()[name]
+
+    @classmethod
+    def get_default_hyperparameters(
+        cls, names: Optional[List[str]] = None
+    ) -> Dict[str, Any]:
+        """Get hyperparameters default values.
+
+        Args:
+            names: names of the hyperparameters to choose.
+                By default, all available hyperparameters will be suggested.
+
+        Returns:
+            a mapping between hyperparameter name and its default value (None if not specified)
+
+        """
+        if names is None:
+            names = cls.get_hyperparameters_names()
+        hyperparameters_by_names = cls.get_hyperparameters_by_name()
+        return {name: hyperparameters_by_names[name].default for name in names}
+
+    @classmethod
+    def complete_with_default_hyperparameters(
+        cls, kwargs: Dict[str, Any], names: Optional[List[str]] = None
+    ):
+        """Add missing hyperparameters to kwargs by using default values
+
+        Args:
+            kwargs: keyword arguments to complete (for `__init__`, `init_model`, or `solve`)
+            names: names of the hyperparameters to add if missing.
+                By default, all available hyperparameters.
+
+        Returns:
+             a new dictionary, completion of kwargs
+
+        """
+        kwargs_complete = cls.get_default_hyperparameters(names=names)
+        kwargs_complete.update(kwargs)  # ensure preferring values from kwargs
+        return kwargs_complete
+
+    @classmethod
+    def suggest_hyperparameter_with_optuna(
+        cls, trial: optuna.trial.Trial, name: str, prefix: str = "", **kwargs
+    ) -> Any:
+        """Suggest hyperparameter value during an Optuna trial.
+
+        This can be used during Optuna hyperparameters tuning.
+
+        Args:
+            trial: optuna trial during hyperparameters tuning
+            name: name of the hyperparameter to choose
+            prefix: prefix to add to optuna corresponding parameter name
+              (useful for disambiguating hyperparameters from subsolvers in case of meta-solvers)
+            **kwargs: options for optuna hyperparameter suggestions
+
+        Returns:
+
+
+        kwargs can be used to pass relevant arguments to
+        - trial.suggest_float()
+        - trial.suggest_int()
+        - trial.suggest_categorical()
+
+        For instance it can
+        - add a low/high value if not existing for the hyperparameter
+          or override it to narrow the search. (for float or int hyperparameters)
+        - add a step or log argument (for float or int hyperparameters,
+          see optuna.trial.Trial.suggest_float())
+        - override choices for categorical or enum parameters to narrow the search
+
+        """
+        return cls.get_hyperparameter(name=name).suggest_with_optuna(
+            trial=trial, prefix=prefix, **kwargs
+        )
+
+    @classmethod
+    def suggest_hyperparameters_with_optuna(
+        cls,
+        trial: optuna.trial.Trial,
+        names: Optional[List[str]] = None,
+        kwargs_by_name: Optional[Dict[str, Dict[str, Any]]] = None,
+        fixed_hyperparameters: Optional[Dict[str, Any]] = None,
+        prefix: str = "",
+    ) -> Dict[str, Any]:
+        """Suggest hyperparameters values during an Optuna trial.
+
+        Args:
+            trial: optuna trial during hyperparameters tuning
+            names: names of the hyperparameters to choose.
+                By default, all available hyperparameters will be suggested.
+            kwargs_by_name: options for optuna hyperparameter suggestions, by hyperparameter name
+            fixed_hyperparameters: values of fixed hyperparameters, useful for suggesting subbrick hyperparameters,
+                if the subbrick class is not suggested by this method, but already fixed.
+            prefix: prefix to add to optuna corresponding parameters
+              (useful for disambiguating hyperparameters from subsolvers in case of meta-solvers)
+
+
+        Returns:
+            mapping between the hyperparameter name and its suggested value
+
+        kwargs_by_name[some_name] will be passed as **kwargs to suggest_hyperparameter_with_optuna(name=some_name)
+
+        """
+        if names is None:
+            names = cls.get_hyperparameters_names()
+        if kwargs_by_name is None:
+            kwargs_by_name = {}
+        if fixed_hyperparameters is None:
+            fixed_hyperparameters = {}
+
+        # Meta-solvers: when defining subsolvers hyperparameters,
+        #  be careful to suggest them before trying to suggest their own subset of hyperparameters
+        name2hyperparameter = cls.get_hyperparameters_by_name()
+        first_batch_hyperparameter_names = [
+            name
+            for name in names
+            if not (isinstance(name2hyperparameter[name], SubBrickKwargsHyperparameter))
+        ]
+        subsolvers_kwargs_hyperparameters: List[SubBrickKwargsHyperparameter] = [
+            name2hyperparameter[name]
+            for name in names
+            if isinstance(name2hyperparameter[name], SubBrickKwargsHyperparameter)
+        ]
+
+        suggested_hyperparameters = {
+            name: cls.suggest_hyperparameter_with_optuna(
+                trial=trial, name=name, prefix=prefix, **kwargs_by_name.get(name, {})
+            )
+            for name in first_batch_hyperparameter_names
+        }
+        for hyperparameter in subsolvers_kwargs_hyperparameters:
+            kwargs_for_optuna_suggestion = kwargs_by_name.get(hyperparameter.name, {})
+            if hyperparameter.subbrick_hyperparameter in names:
+                kwargs_for_optuna_suggestion["subbrick"] = suggested_hyperparameters[
+                    hyperparameter.subbrick_hyperparameter
+                ]
+            elif hyperparameter.subbrick_hyperparameter in fixed_hyperparameters:
+                kwargs_for_optuna_suggestion["subbrick"] = fixed_hyperparameters[
+                    hyperparameter.subbrick_hyperparameter
+                ]
+            else:
+                raise ValueError(
+                    f"The choice of '{hyperparameter.subbrick_hyperparameter}' should be "
+                    "either suggested by this method with `names` containing it or being None "
+                    "or given via `fixed_hyperparameters`."
+                )
+            kwargs_for_optuna_suggestion[
+                "prefix"
+            ] = f"{prefix}{hyperparameter.subbrick_hyperparameter}."
+            suggested_hyperparameters[
+                hyperparameter.name
+            ] = cls.suggest_hyperparameter_with_optuna(
+                trial=trial, name=hyperparameter.name, **kwargs_for_optuna_suggestion
+            )
+
+        return suggested_hyperparameters

--- a/discrete_optimization/generic_tools/lns_cp.py
+++ b/discrete_optimization/generic_tools/lns_cp.py
@@ -28,6 +28,9 @@ from discrete_optimization.generic_tools.do_problem import (
     Problem,
 )
 from discrete_optimization.generic_tools.do_solver import SolverDO
+from discrete_optimization.generic_tools.hyperparameters.hyperparametrizable import (
+    Hyperparametrizable,
+)
 from discrete_optimization.generic_tools.lns_mip import (
     InitialSolution,
     PostProcessSolution,
@@ -47,7 +50,7 @@ else:
 logger = logging.getLogger(__name__)
 
 
-class ConstraintHandler:
+class ConstraintHandler(Hyperparametrizable):
     @abstractmethod
     def adding_constraint_from_results_store(
         self,

--- a/discrete_optimization/generic_tools/lns_mip.py
+++ b/discrete_optimization/generic_tools/lns_mip.py
@@ -17,6 +17,9 @@ from discrete_optimization.generic_tools.do_problem import (
     Problem,
 )
 from discrete_optimization.generic_tools.do_solver import SolverDO
+from discrete_optimization.generic_tools.hyperparameters.hyperparametrizable import (
+    Hyperparametrizable,
+)
 from discrete_optimization.generic_tools.lp_tools import MilpSolver, ParametersMilp
 from discrete_optimization.generic_tools.result_storage.result_storage import (
     ResultStorage,
@@ -25,7 +28,7 @@ from discrete_optimization.generic_tools.result_storage.result_storage import (
 logger = logging.getLogger(__name__)
 
 
-class ConstraintHandler:
+class ConstraintHandler(Hyperparametrizable):
     @abstractmethod
     def adding_constraint_from_results_store(
         self, milp_solver: MilpSolver, result_storage: ResultStorage
@@ -39,7 +42,7 @@ class ConstraintHandler:
         ...
 
 
-class InitialSolution:
+class InitialSolution(Hyperparametrizable):
     @abstractmethod
     def get_starting_solution(self) -> ResultStorage:
         ...
@@ -65,7 +68,7 @@ class TrivialInitialSolution(InitialSolution):
         return self.solution
 
 
-class PostProcessSolution:
+class PostProcessSolution(Hyperparametrizable):
     # From solution from MIP or CP you can build other solution.
     # Here you can have many different approaches:
     # if solution from mip/cp are not feasible you can code a repair function

--- a/discrete_optimization/generic_tools/lns_mip.py
+++ b/discrete_optimization/generic_tools/lns_mip.py
@@ -80,6 +80,9 @@ class PostProcessSolution(Hyperparametrizable):
 
 
 class TrivialPostProcessSolution(PostProcessSolution):
+    def __init__(self, **kwargs):
+        ...
+
     def build_other_solution(self, result_storage: ResultStorage) -> ResultStorage:
         return result_storage
 

--- a/discrete_optimization/knapsack/solvers/knapsack_decomposition.py
+++ b/discrete_optimization/knapsack/solvers/knapsack_decomposition.py
@@ -13,8 +13,8 @@ from discrete_optimization.generic_tools.callbacks.callback import (
 from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
     FloatHyperparameter,
     IntegerHyperparameter,
-    SubSolverHyperparameter,
-    SubSolverKwargsHyperparameter,
+    SubBrickHyperparameter,
+    SubBrickKwargsHyperparameter,
 )
 from discrete_optimization.generic_tools.result_storage.result_storage import (
     ResultStorage,
@@ -72,17 +72,17 @@ class KnapsackDecomposedSolver(SolverKnapsack):
             name="proportion_to_remove", low=0.0, high=1.0, default=0.7
         ),
         IntegerHyperparameter(name="nb_iteration", low=0, high=int(10e6), default=100),
-        SubSolverHyperparameter(
+        SubBrickHyperparameter(
             name="initial_solver", choices=subsolvers, default=GreedyBest
         ),
-        SubSolverKwargsHyperparameter(
-            name="initial_solver_kwargs", subsolver_hyperparameter="initial_solver"
+        SubBrickKwargsHyperparameter(
+            name="initial_solver_kwargs", subbrick_hyperparameter="initial_solver"
         ),
-        SubSolverHyperparameter(
+        SubBrickHyperparameter(
             name="root_solver", choices=subsolvers, default=GreedyBest
         ),
-        SubSolverKwargsHyperparameter(
-            name="root_solver_kwargs", subsolver_hyperparameter="root_solver"
+        SubBrickKwargsHyperparameter(
+            name="root_solver_kwargs", subbrick_hyperparameter="root_solver"
         ),
     ]
 

--- a/tests/generic_tools/hyperparameters/test_hyperparameter.py
+++ b/tests/generic_tools/hyperparameters/test_hyperparameter.py
@@ -11,8 +11,8 @@ from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
     EnumHyperparameter,
     FloatHyperparameter,
     IntegerHyperparameter,
-    SubSolverHyperparameter,
-    SubSolverKwargsHyperparameter,
+    SubBrickHyperparameter,
+    SubBrickKwargsHyperparameter,
 )
 from discrete_optimization.generic_tools.result_storage.result_storage import (
     ResultStorage,
@@ -54,9 +54,9 @@ class DummySolver2(SolverDO):
 class MetaSolver(SolverDO):
     hyperparameters = [
         IntegerHyperparameter("nb", low=0, high=1, default=1),
-        SubSolverHyperparameter("subsolver", choices=[DummySolver, DummySolver2]),
-        SubSolverKwargsHyperparameter(
-            "kwargs_subsolver", subsolver_hyperparameter="subsolver"
+        SubBrickHyperparameter("subsolver", choices=[DummySolver, DummySolver2]),
+        SubBrickKwargsHyperparameter(
+            "kwargs_subsolver", subbrick_hyperparameter="subsolver"
         ),
     ]
 
@@ -69,9 +69,9 @@ class MetaSolver(SolverDO):
 class MetaMetaSolver(SolverDO):
     hyperparameters = [
         IntegerHyperparameter("nb", low=1, high=1, default=1),
-        SubSolverHyperparameter("subsolver", choices=[MetaSolver]),
-        SubSolverKwargsHyperparameter(
-            "kwargs_subsolver", subsolver_hyperparameter="subsolver"
+        SubBrickHyperparameter("subsolver", choices=[MetaSolver]),
+        SubBrickKwargsHyperparameter(
+            "kwargs_subsolver", subbrick_hyperparameter="subsolver"
         ),
     ]
 


### PR DESCRIPTION
- We create a class for "hyperparametrizable" objects, with all stuff related to hyperparameters management
- `SolverDO` derive from `Hyperparametrizable`
- main bricks for LNS solvers also derive from it:
  - `ConstraintHandler`
  - `InitialSolution`
  - `PostProcessSolution`
- We apply this to `LnsCpColoring` 