### PR TITLE
Modified parse_file function to include the possibility to read in patterson rcpsp files

### DIFF
--- a/discrete_optimization/rcpsp/rcpsp_parser.py
+++ b/discrete_optimization/rcpsp/rcpsp_parser.py
@@ -124,7 +124,7 @@ def parse_patterson(input_data: str) -> RCPSPModel:
 
     # Creating resource dict with only renewable resources
     resources: Dict[str, Union[int, List[int]]] = {
-        "R" + str(i + 1): parsed_values[2] for i in range(n_renewable_resources)
+        "R" + str(i + 1): parsed_values[2+i] for i in range(n_renewable_resources)
     }
 
     # no non-renewable resources in patterson files


### PR DESCRIPTION
Included a function "parse_patterson" to read in RCPSP-instances in Patterson file format.
This file format is (by now) much more wide-spread than the explicit file format of PSPLIB-instances.

The "parse_patterson" method is called, if an RCPSP-instance-file ends with ".rcp".

See also here: https://www.projectmanagement.ugent.be/research/project_scheduling/rcpsp

e.g. datasets RG30 and RG300