### PR TITLE
Fix github actions with macos-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,6 +156,11 @@ jobs:
         with:
           name: dist
           path: dist
+      - name: Install prerelease version of pymip (only for macos arm64)
+        if: matrix.os == 'macos-latest'
+        run: |
+          python -m pip install -U pip
+          pip install mip==1.16rc0
       - name: Install only discrete-optimization
         run: |
           python -m pip install -U pip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,6 +119,15 @@ jobs:
             os: "ubuntu-latest"
             python-version: "3.11"
             wo_gurobi: ""
+          - os: "macos-12"
+            python-version: "3.8"
+            wo_gurobi: ""
+            minizinc_config_cmdline: export PATH=$PATH:$(pwd)/bin/MiniZincIDE.app/Contents/Resources
+            minizinc_cache_path: $(pwd)/bin/MiniZincIDE.app
+            minizinc_url: https://github.com/MiniZinc/MiniZincIDE/releases/download/2.8.3/MiniZincIDE-2.8.3-bundled.dmg
+            minizinc_downloaded_filepath: bin/minizinc.dmg
+            minizinc_install_cmdline: sudo hdiutil attach bin/minizinc.dmg; sudo cp -R /Volumes/MiniZinc*/MiniZincIDE.app bin/.
+            minizinc_prerequisites_cmdline: ""
         exclude:
           - os: "windows-latest"
             wo_gurobi: "without gurobi"
@@ -126,6 +135,8 @@ jobs:
             wo_gurobi: "without gurobi"
           - os: "ubuntu-latest"
             wo_gurobi: "without gurobi"
+            python-version: "3.8"
+          - os: "macos-latest"
             python-version: "3.8"
     runs-on: ${{ matrix.os }}
     defaults:


### PR DESCRIPTION
The github runner "macos-latest" is now an aliasfor macos-14 on arm64.

- There is no gurobipy for python 3.8 +  macos arm64, so we use macos-12 (x86_64) instead when testing on python 3.8.
- We use prerelease 1.16 for mip when on macos-latest to avoid an error with cbc-mip, waiting for mip 1.16 to be officially released (see  https://github.com/coin-or/python-mip/issues/335#issuecomment-1986745529)