### PR TITLE
Fix binder build trigger for releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -327,7 +327,7 @@ jobs:
           git push origin ${new_tag_name}
           # store new tag name as notebooks branch
           echo "notebooks_branch=${new_tag_name}" >> $GITHUB_ENV
-          echo 'binder_full_ref="${{ github.repository }}/${new_tag_name}"' >> $GITHUB_ENV
+          echo "binder_full_ref=${{ github.repository }}/${new_tag_name}" >> $GITHUB_ENV
       - name: write new notebooks branch in job outputs
         id: write-output
         run: |


### PR DESCRIPTION
In case of release, the variable binder_full_ref was not properly defined and thus resulting in a trigger on incorrect github reference.