### PR TITLE
Fix some issues in preparation for python 3.12 support

### DIFF
--- a/discrete_optimization/generic_tools/optuna/timed_percentile_pruner.py
+++ b/discrete_optimization/generic_tools/optuna/timed_percentile_pruner.py
@@ -4,202 +4,211 @@
 #
 # This module is adapted from https://github.com/optuna/optuna/blob/master/optuna/pruners/_percentile.py
 
+from __future__ import annotations
+
 import functools
+import logging
 import math
 from typing import KeysView, List
 
 import numpy as np
-import optuna
-from optuna.pruners import BasePruner
-from optuna.study._study_direction import StudyDirection
-from optuna.trial._state import TrialState
+
+logger = logging.getLogger(__name__)
 
 
-def _get_best_intermediate_result_over_steps(
-    trial: "optuna.trial.FrozenTrial", direction: StudyDirection
-) -> float:
-    values = np.asarray(list(trial.intermediate_values.values()), dtype=float)
-    if direction == StudyDirection.MAXIMIZE:
-        return np.nanmax(values)
-    return np.nanmin(values)
+try:
+    import optuna
+except ImportError:
+    logger.warning("You should install optuna to use TimedPercentilePruner for optuna.")
+else:
+    from optuna.pruners import BasePruner
+    from optuna.study._study_direction import StudyDirection
+    from optuna.trial._state import TrialState
 
+    def _get_best_intermediate_result_over_steps(
+        trial: "optuna.trial.FrozenTrial", direction: StudyDirection
+    ) -> float:
+        values = np.asarray(list(trial.intermediate_values.values()), dtype=float)
+        if direction == StudyDirection.MAXIMIZE:
+            return np.nanmax(values)
+        return np.nanmin(values)
 
-def _get_interpolated_intermediate_value(
-    trial: "optuna.trial.FrozenTrial", step: float
-) -> float:
-    xp = sorted(trial.intermediate_values)
-    yp = [trial.intermediate_values[xx] for xx in xp]
-    if len(xp) > 0:
-        return np.interp(step, xp=xp, fp=yp, left=np.nan, right=np.nan)
-    else:
-        return np.nan
+    def _get_interpolated_intermediate_value(
+        trial: "optuna.trial.FrozenTrial", step: float
+    ) -> float:
+        xp = sorted(trial.intermediate_values)
+        yp = [trial.intermediate_values[xx] for xx in xp]
+        if len(xp) > 0:
+            return np.interp(step, xp=xp, fp=yp, left=np.nan, right=np.nan)
+        else:
+            return np.nan
 
-
-def _get_percentile_intermediate_result_over_trials(
-    completed_trials: List["optuna.trial.FrozenTrial"],
-    direction: StudyDirection,
-    step: int,
-    percentile: float,
-    n_min_trials: int,
-) -> float:
-    if len(completed_trials) == 0:
-        raise ValueError("No trials have been completed.")
-
-    intermediate_values = [
-        _get_interpolated_intermediate_value(trial=t, step=step)
-        for t in completed_trials
-    ]
-    intermediate_values = [v for v in intermediate_values if not np.isnan(v)]
-
-    if len(intermediate_values) < n_min_trials:
-        return math.nan
-
-    if direction == StudyDirection.MAXIMIZE:
-        percentile = 100 - percentile
-
-    return float(
-        np.nanpercentile(
-            np.array(intermediate_values, dtype=float),
-            percentile,
-        )
-    )
-
-
-def _is_first_in_interval_step(
-    step: int,
-    intermediate_steps: KeysView[int],
-    n_warmup_steps: int,
-    interval_steps: int,
-) -> bool:
-    nearest_lower_pruning_step = (
-        step - n_warmup_steps
-    ) // interval_steps * interval_steps + n_warmup_steps
-    assert nearest_lower_pruning_step >= 0
-
-    # `intermediate_steps` may not be sorted so we must go through all elements.
-    second_last_step = functools.reduce(
-        lambda second_last_step, s: s
-        if s > second_last_step and s != step
-        else second_last_step,
-        intermediate_steps,
-        -1,
-    )
-
-    return second_last_step < nearest_lower_pruning_step
-
-
-class TimedPercentilePruner(BasePruner):
-    """Pruner to keep the specified percentile of the trials.
-
-    Prune if the best intermediate value is in the bottom percentile among trials at the same step.
-    If no report for the exact step exits in other trials, we use an interpolated value.
-
-    Args:
-        percentile:
-            Percentile which must be between 0 and 100 inclusive
-            (e.g., When given 25.0, top of 25th percentile trials are kept).
-        n_startup_trials:
-            Pruning is disabled until the given number of trials finish in the same study.
-        n_warmup_steps:
-            Pruning is disabled until the trial exceeds the given number of step. Note that
-            this feature assumes that ``step`` starts at zero.
-        interval_steps:
-            Interval in number of steps between the pruning checks, offset by the warmup steps.
-            If no value has been reported at the time of a pruning check, that particular check
-            will be postponed until a value is reported. Value must be at least 1.
-        n_min_trials:
-            Minimum number of reported trial results at a step to judge whether to prune.
-            If the number of reported intermediate values from all trials at the current step
-            is less than ``n_min_trials``, the trial will not be pruned. This can be used to ensure
-            that a minimum number of trials are run to completion without being pruned.
-    """
-
-    def __init__(
-        self,
+    def _get_percentile_intermediate_result_over_trials(
+        completed_trials: List["optuna.trial.FrozenTrial"],
+        direction: StudyDirection,
+        step: int,
         percentile: float,
-        n_startup_trials: int = 5,
-        n_warmup_steps: int = 0,
-        interval_steps: int = 1,
-        *,
-        n_min_trials: int = 1,
-    ) -> None:
-        if not 0.0 <= percentile <= 100:
-            raise ValueError(
-                "Percentile must be between 0 and 100 inclusive but got {}.".format(
-                    percentile
-                )
-            )
-        if n_startup_trials < 0:
-            raise ValueError(
-                "Number of startup trials cannot be negative but got {}.".format(
-                    n_startup_trials
-                )
-            )
-        if n_warmup_steps < 0:
-            raise ValueError(
-                "Number of warmup steps cannot be negative but got {}.".format(
-                    n_warmup_steps
-                )
-            )
-        if interval_steps < 1:
-            raise ValueError(
-                "Pruning interval steps must be at least 1 but got {}.".format(
-                    interval_steps
-                )
-            )
-        if n_min_trials < 1:
-            raise ValueError(
-                "Number of trials for pruning must be at least 1 but got {}.".format(
-                    n_min_trials
-                )
-            )
+        n_min_trials: int,
+    ) -> float:
+        if len(completed_trials) == 0:
+            raise ValueError("No trials have been completed.")
 
-        self._percentile = percentile
-        self._n_startup_trials = n_startup_trials
-        self._n_warmup_steps = n_warmup_steps
-        self._interval_steps = interval_steps
-        self._n_min_trials = n_min_trials
+        intermediate_values = [
+            _get_interpolated_intermediate_value(trial=t, step=step)
+            for t in completed_trials
+        ]
+        intermediate_values = [v for v in intermediate_values if not np.isnan(v)]
 
-    def prune(
-        self, study: "optuna.study.Study", trial: "optuna.trial.FrozenTrial"
-    ) -> bool:
-        completed_trials = study.get_trials(
-            deepcopy=False, states=(TrialState.COMPLETE,)
-        )
-        n_trials = len(completed_trials)
-
-        if n_trials == 0:
-            return False
-
-        if n_trials < self._n_startup_trials:
-            return False
-
-        step = trial.last_step
-        if step is None:
-            return False
-
-        n_warmup_steps = self._n_warmup_steps
-        if step < n_warmup_steps:
-            return False
-
-        if not _is_first_in_interval_step(
-            step, trial.intermediate_values.keys(), n_warmup_steps, self._interval_steps
-        ):
-            return False
-
-        direction = study.direction
-        best_intermediate_result = _get_best_intermediate_result_over_steps(
-            trial, direction
-        )
-        if math.isnan(best_intermediate_result):
-            return True
-
-        p = _get_percentile_intermediate_result_over_trials(
-            completed_trials, direction, step, self._percentile, self._n_min_trials
-        )
-        if math.isnan(p):
-            return False
+        if len(intermediate_values) < n_min_trials:
+            return math.nan
 
         if direction == StudyDirection.MAXIMIZE:
-            return best_intermediate_result < p
-        return best_intermediate_result > p
+            percentile = 100 - percentile
+
+        return float(
+            np.nanpercentile(
+                np.array(intermediate_values, dtype=float),
+                percentile,
+            )
+        )
+
+    def _is_first_in_interval_step(
+        step: int,
+        intermediate_steps: KeysView[int],
+        n_warmup_steps: int,
+        interval_steps: int,
+    ) -> bool:
+        nearest_lower_pruning_step = (
+            step - n_warmup_steps
+        ) // interval_steps * interval_steps + n_warmup_steps
+        assert nearest_lower_pruning_step >= 0
+
+        # `intermediate_steps` may not be sorted so we must go through all elements.
+        second_last_step = functools.reduce(
+            lambda second_last_step, s: s
+            if s > second_last_step and s != step
+            else second_last_step,
+            intermediate_steps,
+            -1,
+        )
+
+        return second_last_step < nearest_lower_pruning_step
+
+    class TimedPercentilePruner(BasePruner):
+        """Pruner to keep the specified percentile of the trials.
+
+        Prune if the best intermediate value is in the bottom percentile among trials at the same step.
+        If no report for the exact step exits in other trials, we use an interpolated value.
+
+        Args:
+            percentile:
+                Percentile which must be between 0 and 100 inclusive
+                (e.g., When given 25.0, top of 25th percentile trials are kept).
+            n_startup_trials:
+                Pruning is disabled until the given number of trials finish in the same study.
+            n_warmup_steps:
+                Pruning is disabled until the trial exceeds the given number of step. Note that
+                this feature assumes that ``step`` starts at zero.
+            interval_steps:
+                Interval in number of steps between the pruning checks, offset by the warmup steps.
+                If no value has been reported at the time of a pruning check, that particular check
+                will be postponed until a value is reported. Value must be at least 1.
+            n_min_trials:
+                Minimum number of reported trial results at a step to judge whether to prune.
+                If the number of reported intermediate values from all trials at the current step
+                is less than ``n_min_trials``, the trial will not be pruned. This can be used to ensure
+                that a minimum number of trials are run to completion without being pruned.
+        """
+
+        def __init__(
+            self,
+            percentile: float,
+            n_startup_trials: int = 5,
+            n_warmup_steps: int = 0,
+            interval_steps: int = 1,
+            *,
+            n_min_trials: int = 1,
+        ) -> None:
+            if not 0.0 <= percentile <= 100:
+                raise ValueError(
+                    "Percentile must be between 0 and 100 inclusive but got {}.".format(
+                        percentile
+                    )
+                )
+            if n_startup_trials < 0:
+                raise ValueError(
+                    "Number of startup trials cannot be negative but got {}.".format(
+                        n_startup_trials
+                    )
+                )
+            if n_warmup_steps < 0:
+                raise ValueError(
+                    "Number of warmup steps cannot be negative but got {}.".format(
+                        n_warmup_steps
+                    )
+                )
+            if interval_steps < 1:
+                raise ValueError(
+                    "Pruning interval steps must be at least 1 but got {}.".format(
+                        interval_steps
+                    )
+                )
+            if n_min_trials < 1:
+                raise ValueError(
+                    "Number of trials for pruning must be at least 1 but got {}.".format(
+                        n_min_trials
+                    )
+                )
+
+            self._percentile = percentile
+            self._n_startup_trials = n_startup_trials
+            self._n_warmup_steps = n_warmup_steps
+            self._interval_steps = interval_steps
+            self._n_min_trials = n_min_trials
+
+        def prune(
+            self, study: "optuna.study.Study", trial: "optuna.trial.FrozenTrial"
+        ) -> bool:
+            completed_trials = study.get_trials(
+                deepcopy=False, states=(TrialState.COMPLETE,)
+            )
+            n_trials = len(completed_trials)
+
+            if n_trials == 0:
+                return False
+
+            if n_trials < self._n_startup_trials:
+                return False
+
+            step = trial.last_step
+            if step is None:
+                return False
+
+            n_warmup_steps = self._n_warmup_steps
+            if step < n_warmup_steps:
+                return False
+
+            if not _is_first_in_interval_step(
+                step,
+                trial.intermediate_values.keys(),
+                n_warmup_steps,
+                self._interval_steps,
+            ):
+                return False
+
+            direction = study.direction
+            best_intermediate_result = _get_best_intermediate_result_over_steps(
+                trial, direction
+            )
+            if math.isnan(best_intermediate_result):
+                return True
+
+            p = _get_percentile_intermediate_result_over_trials(
+                completed_trials, direction, step, self._percentile, self._n_min_trials
+            )
+            if math.isnan(p):
+                return False
+
+            if direction == StudyDirection.MAXIMIZE:
+                return best_intermediate_result < p
+            return best_intermediate_result > p

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
     "numpy>=1.21",
     "typing_extensions>=4.4",
     "clingo>=5.6",
+    "setuptools",
 ]
 dynamic = ["version"]
 

--- a/tests/generic_tools/callbacks/test_sa_with_callbacks.py
+++ b/tests/generic_tools/callbacks/test_sa_with_callbacks.py
@@ -9,7 +9,6 @@ import random
 from time import sleep
 
 import numpy as np
-import optuna
 import pytest
 
 from discrete_optimization.generic_tools.callbacks.backup import (
@@ -37,11 +36,18 @@ from discrete_optimization.generic_tools.mutations.mutation_catalog import (
     PermutationMutationRCPSP,
     get_available_mutations,
 )
-from discrete_optimization.generic_tools.optuna.timed_percentile_pruner import (
-    TimedPercentilePruner,
-)
 from discrete_optimization.rcpsp.rcpsp_model import RCPSPModel
 from discrete_optimization.rcpsp.rcpsp_parser import get_data_available, parse_file
+
+try:
+    import optuna
+except ImportError:
+    optuna_available = False
+else:
+    optuna_available = True
+    from discrete_optimization.generic_tools.optuna.timed_percentile_pruner import (
+        TimedPercentilePruner,
+    )
 
 SEED = 42
 
@@ -128,6 +134,9 @@ def test_sa_with_callbacks(caplog, random_seed):
     assert len([line for line in caplog.text.splitlines() if "Pickling" in line]) == 2
 
 
+@pytest.mark.skipif(
+    not optuna_available, reason="You need Optuna to test this callback."
+)
 def test_sa_with_optuna_callback(random_seed):
     def objective(trial: optuna.trial.Trial) -> float:
         files = get_data_available()
@@ -212,6 +221,9 @@ def test_sa_with_optuna_callback(random_seed):
     assert len(complete_trials) > 0
 
 
+@pytest.mark.skipif(
+    not optuna_available, reason="You need Optuna to test this callback."
+)
 def test_sa_with_optuna_timed_callback(random_seed):
     def objective(trial: optuna.trial.Trial) -> float:
         files = get_data_available()

--- a/tests/test_import_all_submodules.py
+++ b/tests/test_import_all_submodules.py
@@ -5,7 +5,6 @@
 import importlib
 import logging
 import pkgutil
-import sys
 
 import discrete_optimization
 
@@ -13,30 +12,11 @@ logger = logging.getLogger(__name__)
 
 
 def find_abs_modules(package):
-    """Find names of all submodules in the package
-
-    https://stackoverflow.com/questions/48879353/how-do-you-recursively-get-all-submodules-in-a-python-package
-
-    """
+    """Find names of all submodules in the package."""
     path_list = []
-    spec_list = []
-    for importer, modname, ispkg in pkgutil.walk_packages(package.__path__):
-        if modname == "hub.__skdecide_hub_cpp":
-            continue
-        import_path = f"{package.__name__}.{modname}"
-        if ispkg:
-            spec = pkgutil._get_spec(importer, modname)
-            try:
-                importlib._bootstrap._load(spec)
-                spec_list.append(spec)
-            except Exception as e:
-                logger.warning(
-                    f"Could not load package {modname}, so it will be ignored ({e})."
-                )
-        else:
-            path_list.append(import_path)
-    for spec in spec_list:
-        del sys.modules[spec.name]
+    for modinfo in pkgutil.walk_packages(package.__path__, f"{package.__name__}."):
+        if not modinfo.ispkg:
+            path_list.append(modinfo.name)
     return path_list
 
 


### PR DESCRIPTION
- Fix tests/test_import_all_submodules.py
  - was not working with python 3.12
  - is now using directly the public api of pkgutil
- Add setuptools in requirements to avoid "No module named 'pkg_resources'" with cpmpy
- Skip tests and module relying on optuna if not installed