### PR TITLE
Freeze ortools for windows tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,6 +163,11 @@ jobs:
         run: |
           python -m pip install -U pip
           pip install mip==1.16rc0
+      - name: Prevent installing newest release or ortools on windows (segmentation fault)
+        if: matrix.os == 'windows-latest'
+        run: |
+          python -m pip install -U pip
+          pip install "ortools<9.10"
       - name: Install only discrete-optimization
         run: |
           python -m pip install -U pip


### PR DESCRIPTION
ortools 9.10 results in segmentation fault on github runner windows-latest.
Could maybe be solved by updating Microsoft Visual C++ Redistributable https://github.com/google/or-tools/issues/4227