### PR TITLE
Adapted the colormap usage in the different plot functions

### DIFF
--- a/discrete_optimization/generic_tools/plot_utils.py
+++ b/discrete_optimization/generic_tools/plot_utils.py
@@ -1,0 +1,23 @@
+#  Copyright (c) 2024 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+"""
+Contains common utilities to plot solution,
+for now it's mainly to patch API break happening with matplotlib3.9.0 on colors.
+"""
+import matplotlib
+import matplotlib.cm
+
+
+def get_cmap_with_nb_colors(color_map_str: str, nb_colors: int = 2):
+    try:
+        return matplotlib.colormaps[color_map_str].resampled(nb_colors)
+    except:
+        return matplotlib.cm.get_cmap(color_map_str, nb_colors)
+
+
+def get_cmap(color_map_str: str):
+    try:
+        return matplotlib.colormaps[color_map_str]
+    except:
+        return matplotlib.cm.get_cmap(color_map_str)

--- a/discrete_optimization/generic_tools/result_storage/resultcomparator.py
+++ b/discrete_optimization/generic_tools/result_storage/resultcomparator.py
@@ -6,7 +6,6 @@ import logging
 import math
 from typing import Dict, List, Optional, Tuple, cast
 
-import matplotlib.cm as cm
 import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
@@ -18,6 +17,7 @@ from discrete_optimization.generic_tools.do_problem import (
     Solution,
     TupleFitness,
 )
+from discrete_optimization.generic_tools.plot_utils import get_cmap_with_nb_colors
 from discrete_optimization.generic_tools.result_storage.result_storage import (
     ParetoFront,
     ResultStorage,
@@ -139,8 +139,9 @@ class ResultComparator:
             for obj in objectives_str:
                 obj_index = self.objectives_str.index(obj)
                 objectives_index.append(obj_index)
-
-        colors = cm.rainbow(np.linspace(0, 1, len(self.list_result_storage)))
+        colors = get_cmap_with_nb_colors(
+            color_map_str="rainbow", nb_colors=len(self.list_result_storage)
+        )
         fig, ax = plt.subplots(1)
         ax.set_xlabel(objecives_names[0])
         ax.set_ylabel(objecives_names[1])
@@ -165,10 +166,10 @@ class ResultComparator:
     ) -> Figure:
 
         if objectives_str is None:
-            objecives_names = self.objectives_str[:2]
+            objectives_names = self.objectives_str[:2]
             objectives_index = [0, 1]
         else:
-            objecives_names = objectives_str
+            objectives_names = objectives_str
             objectives_index = []
             for obj in objectives_str:
                 obj_index = self.objectives_str.index(obj)
@@ -180,7 +181,9 @@ class ResultComparator:
         )  # I have to do this to ensure at least 2 rows or else it creates axs with only 1 diumension and it crashes
         fig, axs = plt.subplots(rows, cols)
         axis = axs.flatten()
-        colors = cm.rainbow(np.linspace(0, 1, len(self.list_result_storage)))
+        colors = get_cmap_with_nb_colors(
+            color_map_str="rainbow", nb_colors=len(self.list_result_storage)
+        )
         for i, ax in zip(
             range(len(self.list_result_storage)), axis[: len(self.list_result_storage)]
         ):

--- a/discrete_optimization/pickup_vrp/plots/gpdp_plot_utils.py
+++ b/discrete_optimization/pickup_vrp/plots/gpdp_plot_utils.py
@@ -6,10 +6,10 @@ from __future__ import print_function
 from typing import Tuple
 
 import matplotlib.pyplot as plt
-from matplotlib import pyplot as plt
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 
+from discrete_optimization.generic_tools.plot_utils import get_cmap_with_nb_colors
 from discrete_optimization.pickup_vrp.gpdp import GPDP, GPDPSolution
 
 
@@ -23,9 +23,8 @@ def plot_gpdp_solution(
         )
     vehicle_tours = sol.trajectories
     fig, ax = plt.subplots(1)
-    nb_colors = problem.number_vehicle
     nb_colors_clusters = len(problem.clusters_set)
-    colors_nodes = plt.cm.get_cmap("hsv", nb_colors_clusters)
+    colors_nodes = get_cmap_with_nb_colors("hsv", nb_colors_clusters)
     ax.scatter(
         [problem.coordinates_2d[node][0] for node in problem.clusters_dict],
         [problem.coordinates_2d[node][1] for node in problem.clusters_dict],

--- a/discrete_optimization/rcpsp/plots/rcpsp_utils_preemptive.py
+++ b/discrete_optimization/rcpsp/plots/rcpsp_utils_preemptive.py
@@ -5,7 +5,6 @@
 import logging
 from typing import List, Union
 
-import matplotlib.cm
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.collections import PatchCollection
@@ -13,6 +12,10 @@ from matplotlib.font_manager import FontProperties
 from matplotlib.patches import Polygon as pp
 from shapely.geometry import Polygon
 
+from discrete_optimization.generic_tools.plot_utils import (
+    get_cmap,
+    get_cmap_with_nb_colors,
+)
 from discrete_optimization.rcpsp.rcpsp_model_preemptive import (
     RCPSPModelPreemptive,
     RCPSPSolutionPreemptive,
@@ -149,7 +152,7 @@ def plot_ressource_view(
             x, y = polygon.exterior.xy
             ax[i].plot(x, y, zorder=-1, color="b")
             patches.append(pp(xy=polygon.exterior.coords))
-        p = PatchCollection(patches, cmap=matplotlib.cm.get_cmap("Blues"), alpha=0.4)
+        p = PatchCollection(patches, cmap=get_cmap("Blues"), alpha=0.4)
 
         ax[i].add_collection(p)
     merged_times, merged_cons = compute_nice_resource_consumption(
@@ -226,7 +229,7 @@ def plot_task_gantt(
     patches = []
     for j in range(nb_task):
         nb_colors = len(tasks) // 2
-        colors = plt.cm.get_cmap("hsv", nb_colors)
+        colors = get_cmap_with_nb_colors("hsv", nb_colors)
         for start, end in zip(
             rcpsp_sol.rcpsp_schedule[tasks[j]]["starts"],
             rcpsp_sol.rcpsp_schedule[tasks[j]]["ends"],
@@ -481,7 +484,7 @@ def plot_resource_individual_gantt(
     for i in range(len(resources_list)):
         patches = []
         nb_colors = len(sorted_task_by_start) // 2
-        colors = plt.cm.get_cmap("hsv", nb_colors)
+        colors = get_cmap_with_nb_colors("hsv", nb_colors)
         for boxe in array_ressource_usage[resources_list[i]]["boxes_time"]:
             polygon = Polygon([(b[1], b[0]) for b in boxe])
             activity = boxe[0][2]

--- a/discrete_optimization/rcpsp/rcpsp_utils.py
+++ b/discrete_optimization/rcpsp/rcpsp_utils.py
@@ -20,6 +20,7 @@ from typing import (
     Union,
 )
 
+import matplotlib
 import matplotlib.cm
 import matplotlib.pyplot as plt
 import numpy as np
@@ -30,6 +31,10 @@ from matplotlib.patches import Polygon as pp
 from shapely.geometry import Polygon
 
 from discrete_optimization.generic_tools.graph_api import Graph
+from discrete_optimization.generic_tools.plot_utils import (
+    get_cmap,
+    get_cmap_with_nb_colors,
+)
 from discrete_optimization.rcpsp.rcpsp_model_preemptive import RCPSPSolutionPreemptive
 
 if TYPE_CHECKING:  # avoid circular imports due to annotations
@@ -158,7 +163,7 @@ def plot_ressource_view(
             x, y = polygon.exterior.xy
             ax[i].plot(x, y, zorder=-1, color="b")
             patches.append(pp(xy=polygon.exterior.coords))
-        p = PatchCollection(patches, cmap=matplotlib.cm.get_cmap("Blues"), alpha=0.4)
+        p = PatchCollection(patches, cmap=get_cmap("Blues"), alpha=0.4)
         ax[i].add_collection(p)
     merged_times, merged_cons = compute_nice_resource_consumption(
         rcpsp_model, rcpsp_sol, list_resources=list_resource
@@ -227,7 +232,7 @@ def plot_task_gantt(
     patches = []
     for j in range(nb_task):
         nb_colors = len(tasks) // 2
-        colors = plt.cm.get_cmap("hsv", nb_colors)
+        colors = get_cmap_with_nb_colors("hsv", nb_colors)
         box = [
             (j - 0.25, rcpsp_sol.rcpsp_schedule[tasks[j]]["start_time"]),
             (j - 0.25, rcpsp_sol.rcpsp_schedule[tasks[j]]["end_time"]),
@@ -428,7 +433,7 @@ def plot_resource_individual_gantt(
     for i in range(len(resources_list)):
         patches = []
         nb_colors = len(sorted_task_by_start) // 2
-        colors = plt.cm.get_cmap("hsv", nb_colors)
+        colors = get_cmap_with_nb_colors("hsv", nb_colors)
         for boxe in array_ressource_usage[resources_list[i]]["boxes_time"]:
             polygon = Polygon([(b[1], b[0]) for b in boxe])
             activity = boxe[0][2]

--- a/discrete_optimization/rcpsp_multiskill/plots/plot_solution.py
+++ b/discrete_optimization/rcpsp_multiskill/plots/plot_solution.py
@@ -9,6 +9,7 @@ from matplotlib.font_manager import FontProperties
 from matplotlib.patches import Polygon as pp
 from shapely.geometry import Polygon
 
+from discrete_optimization.generic_tools.plot_utils import get_cmap_with_nb_colors
 from discrete_optimization.rcpsp_multiskill.rcpsp_multiskill import (
     MS_RCPSPModel,
     MS_RCPSPSolution,
@@ -163,7 +164,7 @@ def plot_resource_individual_gantt(
     for i in range(len(sorted_employees)):
         patches = []
         nb_colors = len(sorted_task_by_start) // 2
-        colors = plt.cm.get_cmap("hsv", nb_colors)
+        colors = get_cmap_with_nb_colors("hsv", nb_colors)
         for boxe in array_ressource_usage[sorted_employees[i]]["boxes_time"]:
             polygon = Polygon([(b[1], b[0]) for b in boxe])
             activity = boxe[0][2]
@@ -253,7 +254,7 @@ def plot_resource_individual_gantt_preemptive(
     for i in range(len(sorted_employees)):
         patches = []
         nb_colors = len(sorted_task_by_start) // 2
-        colors = plt.cm.get_cmap("hsv", nb_colors)
+        colors = get_cmap_with_nb_colors("hsv", nb_colors)
         for boxe in array_ressource_usage[sorted_employees[i]]["boxes_time"]:
             polygon = Polygon([(b[1], b[0]) for b in boxe])
             activity = boxe[0][2]
@@ -336,7 +337,7 @@ def plot_task_gantt(
     patches = []
     for j in range(nb_task):
         nb_colors = len(tasks) // 2
-        colors = plt.cm.get_cmap("hsv", nb_colors)
+        colors = get_cmap_with_nb_colors("hsv", nb_colors)
         for start, end in zip(
             rcpsp_sol.get_start_times_list(tasks[j]),
             rcpsp_sol.get_end_times_list(tasks[j]),


### PR DESCRIPTION
-Api break of matplotlib 3.9 prevents the usage of matplotlib.cm.get_cmap
and should be replaced for example by matplotlib.colormaps[color_map_str]
-creation of a common plot_utils module patching this api change should fix most of issues. 