### PR TITLE
Unify lns solvers api

### DIFF
--- a/discrete_optimization/coloring/solvers/coloring_cp_lns_solvers.py
+++ b/discrete_optimization/coloring/solvers/coloring_cp_lns_solvers.py
@@ -18,7 +18,7 @@ from discrete_optimization.coloring.solvers.greedy_coloring import (
     GreedyColoring,
     NXGreedyColoringMethod,
 )
-from discrete_optimization.generic_tools.cp_tools import CPSolver
+from discrete_optimization.generic_tools.cp_tools import MinizincCPSolver
 from discrete_optimization.generic_tools.do_problem import (
     ParamsObjectiveFunction,
     build_aggreg_function_and_params_objective,
@@ -28,8 +28,8 @@ from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
     FloatHyperparameter,
 )
 from discrete_optimization.generic_tools.lns_cp import (
-    ConstraintHandler,
     InitialSolution,
+    MznConstraintHandler,
     PostProcessSolution,
 )
 from discrete_optimization.generic_tools.result_storage.result_storage import (
@@ -95,7 +95,7 @@ class InitialColoring(InitialSolution):
             return solver.solve(strategy=NXGreedyColoringMethod.largest_first)
 
 
-class ConstraintHandlerFixColorsCP(ConstraintHandler):
+class ConstraintHandlerFixColorsCP(MznConstraintHandler):
     """Constraint builder for LNS coloring problem.
 
     This constraint handler is pretty basic, it fixes a fraction_to_fix proportion of nodes color.
@@ -115,23 +115,25 @@ class ConstraintHandlerFixColorsCP(ConstraintHandler):
 
     def remove_constraints_from_previous_iteration(
         self,
-        cp_solver: CPSolver,
+        solver: MinizincCPSolver,
         child_instance: Instance,
         previous_constraints: Iterable[Any],
+        **kwargs: Any
     ) -> None:
         pass
 
     def adding_constraint_from_results_store(
         self,
-        cp_solver: CPSolver,
+        solver: MinizincCPSolver,
         child_instance: Instance,
         result_storage: ResultStorage,
         last_result_store: Optional[ResultStorage] = None,
+        **kwargs: Any
     ) -> Iterable[Any]:
         """Include constraint that fix decision on a subset of nodes, according to current solutions found.
 
         Args:
-            cp_solver (CPSolver): a coloring CPSolver
+            solver: a coloring CPSolver
             child_instance: minizinc instance where to include the constraint
             result_storage: current pool of solutions
             last_result_store: pool of solutions found in previous LNS iteration (optional)

--- a/discrete_optimization/generic_rcpsp_tools/large_neighborhood_search_scheduling.py
+++ b/discrete_optimization/generic_rcpsp_tools/large_neighborhood_search_scheduling.py
@@ -46,12 +46,12 @@ from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
     SubBrickHyperparameter,
     SubBrickKwargsHyperparameter,
 )
-from discrete_optimization.generic_tools.lns_cp import LNS_CP, ConstraintHandler
+from discrete_optimization.generic_tools.lns_cp import LNS_CP, MznConstraintHandler
 from discrete_optimization.generic_tools.lns_mip import (
     InitialSolution,
-    InitialSolutionFromSolver,
     PostProcessSolution,
 )
+from discrete_optimization.generic_tools.lns_tools import InitialSolutionFromSolver
 from discrete_optimization.rcpsp.solver.cp_lns_methods_preemptive import (
     PostProLeftShift,
 )
@@ -517,9 +517,9 @@ class LargeNeighborhoodSearchScheduling(LNS_CP, SolverGenericRCPSP):
         self,
         problem: ANY_RCPSP,
         partial_solution=None,
-        cp_solver: Optional[MinizincCPSolver] = None,
+        subsolver: Optional[MinizincCPSolver] = None,
         initial_solution_provider: Optional[InitialSolution] = None,
-        constraint_handler: Optional[ConstraintHandler] = None,
+        constraint_handler: Optional[MznConstraintHandler] = None,
         post_process_solution: Optional[PostProcessSolution] = None,
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
         **kwargs: Any,
@@ -530,22 +530,22 @@ class LargeNeighborhoodSearchScheduling(LNS_CP, SolverGenericRCPSP):
         graph = build_graph_rcpsp_object(self.problem)
         kwargs = self.complete_with_default_hyperparameters(kwargs)
 
-        if cp_solver is None:
-            if "cp_solver_kwargs" not in kwargs or kwargs["cp_solver_kwargs"] is None:
-                cp_solver_kwargs = kwargs
+        if subsolver is None:
+            if "subsolver_kwargs" not in kwargs or kwargs["subsolver_kwargs"] is None:
+                subsolver_kwargs = kwargs
             else:
-                cp_solver_kwargs = kwargs["cp_solver_kwargs"]
-            if "cp_solver_cls" not in kwargs or kwargs["cp_solver_cls"] is None:
-                cp_solver = build_default_cp_model(
+                subsolver_kwargs = kwargs["subsolver_kwargs"]
+            if "subsolver_cls" not in kwargs or kwargs["subsolver_cls"] is None:
+                subsolver = build_default_cp_model(
                     rcpsp_problem=problem,
                     partial_solution=partial_solution,
-                    **cp_solver_kwargs,
+                    **subsolver_kwargs,
                 )
             else:
-                cp_solver_cls = kwargs["cp_solver_cls"]
-                cp_solver = cp_solver_cls(problem=self.problem, **cp_solver_kwargs)
-                cp_solver.init_model(**cp_solver_kwargs)
-        self.cp_solver = cp_solver
+                subsolver_cls = kwargs["subsolver_cls"]
+                subsolver = subsolver_cls(problem=self.problem, **subsolver_kwargs)
+                subsolver.init_model(**subsolver_kwargs)
+        self.subsolver = subsolver
 
         if constraint_handler is None:
             if (

--- a/discrete_optimization/generic_rcpsp_tools/neighbor_builder.py
+++ b/discrete_optimization/generic_rcpsp_tools/neighbor_builder.py
@@ -25,8 +25,8 @@ from discrete_optimization.generic_rcpsp_tools.neighbor_tools_rcpsp import (
 )
 from discrete_optimization.generic_rcpsp_tools.typing import ANY_RCPSP
 from discrete_optimization.generic_tools.lns_cp import (
-    ConstraintHandler,
     ConstraintHandlerMix,
+    MznConstraintHandler,
 )
 from discrete_optimization.rcpsp_multiskill.rcpsp_multiskill import (
     MS_RCPSPModel,
@@ -74,7 +74,7 @@ class Params:
 
 def build_neighbor_random(
     option_neighbor: OptionNeighborRandom, rcpsp_model: ANY_RCPSP
-) -> ConstraintHandler:
+) -> MznConstraintHandler:
     graph = build_graph_rcpsp_object(rcpsp_problem=rcpsp_model)
     params_use_case = [
         ConstraintHandlerScheduling(

--- a/discrete_optimization/generic_tools/cp_tools.py
+++ b/discrete_optimization/generic_tools/cp_tools.py
@@ -213,6 +213,20 @@ class CPSolver(SolverDO):
 
     status_solver: Optional[StatusSolver] = None
 
+    def is_optimal(self) -> Optional[bool]:
+        """Tell if found solution is supposed to be optimal.
+
+        To be called after a solve.
+
+        Returns:
+            optimality of the solution. If information missing, returns None instead.
+
+        """
+        if self.status_solver is None or self.status_solver == StatusSolver.UNKNOWN:
+            return None
+        else:
+            return self.status_solver == StatusSolver.OPTIMAL
+
     @abstractmethod
     def init_model(self, **args: Any) -> None:
         """

--- a/discrete_optimization/generic_tools/do_solver.py
+++ b/discrete_optimization/generic_tools/do_solver.py
@@ -68,3 +68,14 @@ class SolverDO(Hyperparametrizable):
 
         """
         pass
+
+    def is_optimal(self) -> Optional[bool]:
+        """Tell if found solution is supposed to be optimal.
+
+        To be called after a solve.
+
+        Returns:
+            optimality of the solution. If information missing, returns None instead.
+
+        """
+        return None

--- a/discrete_optimization/generic_tools/lns_cp.py
+++ b/discrete_optimization/generic_tools/lns_cp.py
@@ -1,11 +1,10 @@
 #  Copyright (c) 2022 AIRBUS and its affiliates.
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
-
+import contextlib
 import logging
 import random
 import sys
-import time
 from abc import abstractmethod
 from typing import Any, Dict, Iterable, List, Optional
 
@@ -37,7 +36,9 @@ from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
 from discrete_optimization.generic_tools.hyperparameters.hyperparametrizable import (
     Hyperparametrizable,
 )
-from discrete_optimization.generic_tools.lns_mip import (
+from discrete_optimization.generic_tools.lns_tools import (
+    BaseLNS,
+    ConstraintHandler,
     InitialSolution,
     PostProcessSolution,
     TrivialPostProcessSolution,
@@ -56,321 +57,87 @@ else:
 logger = logging.getLogger(__name__)
 
 
-class ConstraintHandler(Hyperparametrizable):
+class MznConstraintHandler(ConstraintHandler):
     @abstractmethod
     def adding_constraint_from_results_store(
         self,
-        cp_solver: CPSolver,
+        solver: MinizincCPSolver,
         child_instance: Instance,
         result_storage: ResultStorage,
         last_result_store: Optional[ResultStorage] = None,
+        **kwargs: Any,
     ) -> Iterable[Any]:
         ...
 
     @abstractmethod
     def remove_constraints_from_previous_iteration(
         self,
-        cp_solver: CPSolver,
+        solver: MinizincCPSolver,
         child_instance: Instance,
         previous_constraints: Iterable[Any],
+        **kwargs: Any,
     ) -> None:
         ...
 
 
-class LNS_CP(SolverDO):
-    hyperparameters = [
-        SubBrickHyperparameter("cp_solver_cls", choices=[], default=None),
-        SubBrickKwargsHyperparameter(
-            "cp_solver_kwargs", subbrick_hyperparameter="cp_solver_cls"
-        ),
-        SubBrickHyperparameter(
-            "initial_solution_provider_cls", choices=[], default=None
-        ),
-        SubBrickKwargsHyperparameter(
-            "initial_solution_provider_kwargs",
-            subbrick_hyperparameter="initial_solution_provider_cls",
-        ),
-        SubBrickHyperparameter(
-            "constraint_handler_cls",
-            choices=[],
-            default=None,
-        ),
-        SubBrickKwargsHyperparameter(
-            "constraint_handler_kwargs",
-            subbrick_hyperparameter="constraint_handler_cls",
-        ),
-        SubBrickHyperparameter(
-            "post_process_solution_cls",
-            choices=[],
-            default=TrivialPostProcessSolution,
-        ),
-        SubBrickKwargsHyperparameter(
-            "post_process_solution_kwargs",
-            subbrick_hyperparameter="post_process_solution_cls",
-        ),
-        CategoricalHyperparameter(
-            name="skip_first_iteration", choices=[True, False], default=False
-        ),
-    ]
+class LNS_CP(BaseLNS):
+    """Large Neighborhood Search solver using a minzinc cp solver at each iteration."""
+
+    subsolver: MinizincCPSolver
+    """Sub-solver used by this lns solver at each iteration."""
+
+    constraint_handler: MznConstraintHandler
 
     def __init__(
         self,
         problem: Problem,
-        cp_solver: Optional[MinizincCPSolver] = None,
+        subsolver: Optional[MinizincCPSolver] = None,
         initial_solution_provider: Optional[InitialSolution] = None,
-        constraint_handler: Optional[ConstraintHandler] = None,
+        constraint_handler: Optional[MznConstraintHandler] = None,
         post_process_solution: Optional[PostProcessSolution] = None,
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
         **kwargs: Any,
     ):
         super().__init__(
-            problem=problem, params_objective_function=params_objective_function
+            problem=problem,
+            subsolver=subsolver,
+            initial_solution_provider=initial_solution_provider,
+            constraint_handler=constraint_handler,
+            post_process_solution=post_process_solution,
+            params_objective_function=params_objective_function,
+            **kwargs,
         )
-        kwargs = self.complete_with_default_hyperparameters(kwargs)
 
-        if cp_solver is None:
-            if kwargs["cp_solver_kwargs"] is None:
-                cp_solver_kwargs = kwargs
-            else:
-                cp_solver_kwargs = kwargs["cp_solver_kwargs"]
-            if kwargs["cp_solver_cls"] is None:
-                raise ValueError(
-                    "`cp_solver_cls` cannot be None if `cp_solver` is not specified."
-                )
-            else:
-                cp_solver_cls = kwargs["cp_solver_cls"]
-                cp_solver = cp_solver_cls(problem=self.problem, **cp_solver_kwargs)
-                cp_solver.init_model(**cp_solver_kwargs)
-        self.cp_solver = cp_solver
-
-        if constraint_handler is None:
-            if kwargs["constraint_handler_kwargs"] is None:
-                constraint_handler_kwargs = kwargs
-            else:
-                constraint_handler_kwargs = kwargs["constraint_handler_kwargs"]
-            if kwargs["constraint_handler_cls"] is None:
-                raise ValueError(
-                    "`constraint_handler_cls` cannot be None if `constraint_handler` is not specified."
-                )
-            else:
-                constraint_handler_cls = kwargs["constraint_handler_cls"]
-                constraint_handler = constraint_handler_cls(
-                    problem=self.problem, **constraint_handler_kwargs
-                )
-        self.constraint_handler = constraint_handler
-
-        if post_process_solution is None:
-            if kwargs["post_process_solution_kwargs"] is None:
-                post_process_solution_kwargs = kwargs
-            else:
-                post_process_solution_kwargs = kwargs["post_process_solution_kwargs"]
-            if kwargs["post_process_solution_cls"] is None:
-                post_process_solution = None
-            else:
-                post_process_solution_cls = kwargs["post_process_solution_cls"]
-                post_process_solution = post_process_solution_cls(
-                    problem=self.problem,
-                    params_objective_function=self.params_objective_function,
-                    **post_process_solution_kwargs,
-                )
-        self.post_process_solution = post_process_solution
-
-        if initial_solution_provider is None:
-            if kwargs["initial_solution_provider_kwargs"] is None:
-                initial_solution_provider_kwargs = kwargs
-            else:
-                initial_solution_provider_kwargs = kwargs[
-                    "initial_solution_provider_kwargs"
-                ]
-            if kwargs["initial_solution_provider_cls"] is None:
-                initial_solution_provider = (
-                    None  # ok if solve_lns with skip_first_iteration
-                )
-            else:
-                initial_solution_provider_cls = kwargs["initial_solution_provider_cls"]
-                initial_solution_provider = initial_solution_provider_cls(
-                    problem=self.problem,
-                    params_objective_function=self.params_objective_function,
-                    **initial_solution_provider_kwargs,
-                )
-        self.initial_solution_provider = initial_solution_provider
-
-    def solve_lns(
-        self,
-        parameters_cp: ParametersCP,
-        nb_iteration_lns: int,
-        nb_iteration_no_improvement: Optional[int] = None,
-        skip_first_iteration: bool = False,
-        stop_first_iteration_if_optimal: bool = True,
-        callbacks: Optional[List[Callback]] = None,
-        **kwargs: Any,
-    ) -> ResultStorage:
-        # wrap all callbacks in a single one
-        callbacks_list = CallbackList(callbacks=callbacks)
-        # start of solve callback
-        callbacks_list.on_solve_start(solver=self)
-
-        # manage None post_process_solution (can happen in subclasses __init__)
-        if self.post_process_solution is None:
-            self.post_process_solution = TrivialPostProcessSolution()
-
-        sense = self.params_objective_function.sense_function
-        if nb_iteration_no_improvement is None:
-            nb_iteration_no_improvement = 2 * nb_iteration_lns
-        current_nb_iteration_no_improvement = 0
-        if self.cp_solver.instance is None:
-            self.cp_solver.init_model()
-            if self.cp_solver.instance is None:  # for mypy
+    def init_model(self, **kwargs: Any) -> None:
+        if self.subsolver.instance is None:
+            self.subsolver.init_model(**kwargs)
+            if self.subsolver.instance is None:  # for mypy
                 raise RuntimeError(
                     "CP model instance must not be None after calling init_model()!"
                 )
-        if not skip_first_iteration:
-            if self.initial_solution_provider is None:
-                raise ValueError(
-                    "self.initial_solution_provider cannot be None if not skip_first_iteration."
-                )
-            store_lns = self.initial_solution_provider.get_starting_solution()
-            store_lns = self.post_process_solution.build_other_solution(store_lns)
-            init_solution, objective = store_lns.get_best_solution_fit()
-            if init_solution is None:
-                satisfy = False
-            else:
-                satisfy = self.problem.satisfy(init_solution)
-            logger.debug(f"Satisfy Initial solution {satisfy}")
-            try:
-                logger.debug(
-                    f"Nb task preempted = {init_solution.get_nb_task_preemption()}"  # type: ignore
-                )
-                logger.debug(f"Nb max preemption = {init_solution.get_max_preempted()}")  # type: ignore
-            except:
-                pass
-            best_objective = objective
-            # end of step callback: stopping?
-            stopping = callbacks_list.on_step_end(step=0, res=store_lns, solver=self)
-        else:
-            best_objective = (
-                float("inf") if sense == ModeOptim.MINIMIZATION else -float("inf")
+
+    def create_submodel(self) -> contextlib.AbstractContextManager:
+        """Create a branch of the current instance, wrapped in a context manager."""
+        return self.subsolver.instance.branch()
+
+    def solve_with_subsolver(
+        self,
+        iteration: int,
+        instance: Instance,
+        parameters_cp: ParametersCP,
+        **kwargs: Any,
+    ) -> ResultStorage:
+        if iteration == 0:
+            parameters_cp0 = parameters_cp.copy()
+            parameters_cp0.time_limit = parameters_cp.time_limit_iter0
+            result_store = self.subsolver.solve(
+                parameters_cp=parameters_cp0, instance=instance
             )
-            store_lns = None
-            stopping = False
-
-        result_store: ResultStorage
-        if not stopping:
-            for iteration in range(nb_iteration_lns):
-                logger.info(
-                    f"Starting iteration n° {iteration} current objective {best_objective}"
-                )
-                with self.cp_solver.instance.branch() as child:
-                    if iteration == 0 and not skip_first_iteration or iteration >= 1:
-                        constraint_iterable = self.constraint_handler.adding_constraint_from_results_store(
-                            cp_solver=self.cp_solver,
-                            child_instance=child,
-                            result_storage=store_lns,
-                            last_result_store=store_lns
-                            if iteration == 0
-                            else result_store,
-                        )
-                    try:
-                        if iteration == 0:
-                            parameters_cp0 = parameters_cp.copy()
-                            parameters_cp0.time_limit = parameters_cp.time_limit_iter0
-                            result_store = self.cp_solver.solve(
-                                parameters_cp=parameters_cp0, instance=child
-                            )
-
-                        else:
-                            result_store = self.cp_solver.solve(
-                                parameters_cp=parameters_cp, instance=child
-                            )
-                        logger.info(f"iteration n° {iteration} Solved !!!")
-                        logger.info(self.cp_solver.status_solver)
-                        if len(result_store.list_solution_fits) > 0:
-                            logger.debug("Solved !!!")
-                            bsol, fit = result_store.get_best_solution_fit()
-                            logger.debug(f"Fitness Before = {fit}")
-                            if bsol is not None:
-                                logger.debug(
-                                    f"Satisfaction Before = {self.problem.satisfy(bsol)}"
-                                )
-                            else:
-                                logger.debug(f"Satisfaction Before = {False}")
-                            logger.debug("Post Process..")
-                            result_store = (
-                                self.post_process_solution.build_other_solution(
-                                    result_store
-                                )
-                            )
-                            bsol, fit = result_store.get_best_solution_fit()
-                            if bsol is not None:
-                                logger.debug(
-                                    f"Satisfaction After = {self.problem.satisfy(bsol)}"
-                                )
-                            else:
-                                logger.debug(f"Satisfaction After = {False}")
-                            if (
-                                sense == ModeOptim.MAXIMIZATION
-                                and fit >= best_objective
-                            ):
-                                if fit > best_objective:
-                                    current_nb_iteration_no_improvement = 0
-                                else:
-                                    current_nb_iteration_no_improvement += 1
-                                best_objective = fit
-                            elif sense == ModeOptim.MAXIMIZATION:
-                                current_nb_iteration_no_improvement += 1
-                            elif (
-                                sense == ModeOptim.MINIMIZATION
-                                and fit <= best_objective
-                            ):
-                                if fit < best_objective:
-                                    current_nb_iteration_no_improvement = 0
-                                else:
-                                    current_nb_iteration_no_improvement += 1
-                                best_objective = fit
-                            elif sense == ModeOptim.MINIMIZATION:
-                                current_nb_iteration_no_improvement += 1
-                            if skip_first_iteration and iteration == 0:
-                                store_lns = result_store
-                            else:
-                                for s, f in list(result_store.list_solution_fits):
-                                    store_lns.add_solution(solution=s, fitness=f)
-                        else:
-                            current_nb_iteration_no_improvement += 1
-                        if (
-                            skip_first_iteration
-                            and self.cp_solver.status_solver == StatusSolver.OPTIMAL
-                            and iteration == 0
-                            and self.problem.satisfy(bsol)
-                            and stop_first_iteration_if_optimal
-                        ):
-                            logger.info("Finish LNS because found optimal solution")
-                            break
-                    except Exception as e:
-                        current_nb_iteration_no_improvement += 1
-                        logger.warning(f"Failed ! reason : {e}")
-                    logger.debug(
-                        f"{current_nb_iteration_no_improvement} / {nb_iteration_no_improvement}"
-                    )
-                    if (
-                        current_nb_iteration_no_improvement
-                        > nb_iteration_no_improvement
-                    ):
-                        logger.info("Finish LNS with maximum no improvement iteration ")
-                        break
-                # end of step callback: stopping?
-                if skip_first_iteration:
-                    step = iteration
-                else:
-                    step = iteration + 1
-                stopping = callbacks_list.on_step_end(
-                    step=step, res=store_lns, solver=self
-                )
-                if stopping:
-                    break
-
-        # end of solve callback
-        callbacks_list.on_solve_end(res=store_lns, solver=self)
-        return store_lns
+        else:
+            result_store = self.subsolver.solve(
+                parameters_cp=parameters_cp, instance=instance
+            )
+        return result_store
 
     def solve(
         self,
@@ -384,183 +151,12 @@ class LNS_CP(SolverDO):
     ) -> ResultStorage:
         if parameters_cp is None:
             parameters_cp = ParametersCP.default()
-        return self.solve_lns(
+        return super().solve(
             parameters_cp=parameters_cp,
             nb_iteration_lns=nb_iteration_lns,
             nb_iteration_no_improvement=nb_iteration_no_improvement,
             skip_first_iteration=skip_first_iteration,
             stop_first_iteration_if_optimal=stop_first_iteration_if_optimal,
-            callbacks=callbacks,
-            **kwargs,
-        )
-
-
-class LNS_CPlex(SolverDO):
-    def __init__(
-        self,
-        problem: Problem,
-        cp_solver: CPSolver,
-        initial_solution_provider: InitialSolution,
-        constraint_handler: ConstraintHandler,
-        post_process_solution: Optional[PostProcessSolution] = None,
-        params_objective_function: Optional[ParamsObjectiveFunction] = None,
-    ):
-        super().__init__(
-            problem=problem, params_objective_function=params_objective_function
-        )
-        self.cp_solver = cp_solver
-        self.initial_solution_provider = initial_solution_provider
-        self.constraint_handler = constraint_handler
-        self.post_process_solution: PostProcessSolution
-        if post_process_solution is None:
-            self.post_process_solution = TrivialPostProcessSolution()
-        else:
-            self.post_process_solution = post_process_solution
-
-    def solve_lns(
-        self,
-        parameters_cp: ParametersCP,
-        nb_iteration_lns: int,
-        nb_iteration_no_improvement: Optional[int] = None,
-        skip_first_iteration: bool = False,
-        callbacks: Optional[List[Callback]] = None,
-        **kwargs: Any,
-    ) -> ResultStorage:
-        # wrap all callbacks in a single one
-        callbacks_list = CallbackList(callbacks=callbacks)
-        # start of solve callback
-        callbacks_list.on_solve_start(solver=self)
-
-        sense = self.params_objective_function.sense_function
-        if nb_iteration_no_improvement is None:
-            nb_iteration_no_improvement = 2 * nb_iteration_lns
-        current_nb_iteration_no_improvement = 0
-        if not skip_first_iteration:
-            store_lns = self.initial_solution_provider.get_starting_solution()
-            store_lns = self.post_process_solution.build_other_solution(store_lns)
-            init_solution, objective = store_lns.get_best_solution_fit()
-            satisfy = self.problem.satisfy(init_solution)
-            logger.debug(f"Satisfy Initial solution {satisfy}")
-            try:
-                logger.debug(
-                    f"Nb task preempted = {init_solution.get_nb_task_preemption()}"
-                )
-                logger.debug(f"Nb max preemption = {init_solution.get_max_preempted()}")
-            except:
-                pass
-            best_objective = objective
-            # end of step callback: stopping?
-            stopping = callbacks_list.on_step_end(step=0, res=store_lns, solver=self)
-        else:
-            best_objective = (
-                float("inf") if sense == ModeOptim.MINIMIZATION else -float("inf")
-            )
-            store_lns = None
-            stopping = False
-
-        result_store: ResultStorage
-        if not stopping:
-            for iteration in range(nb_iteration_lns):
-                logger.debug(
-                    f"Starting iteration n° {iteration} current objective {best_objective}"
-                )
-                if iteration == 0 and not skip_first_iteration or iteration >= 1:
-                    constraint_iterable = (
-                        self.constraint_handler.adding_constraint_from_results_store(
-                            cp_solver=self.cp_solver,
-                            child_instance=None,
-                            result_storage=store_lns,
-                            last_result_store=store_lns
-                            if iteration == 0
-                            else result_store,
-                        )
-                    )
-
-                try:
-                    if iteration == 0:
-                        p = parameters_cp.default()
-                        p.time_limit = parameters_cp.time_limit_iter0
-                        result_store = self.cp_solver.solve(parameters_cp=parameters_cp)
-                    else:
-                        result_store = self.cp_solver.solve(parameters_cp=parameters_cp)
-                    logger.debug(f"iteration n° {iteration} Solved !!!")
-                    if len(result_store.list_solution_fits) > 0:
-                        logger.debug("Solved !!!")
-                        bsol, fit = result_store.get_best_solution_fit()
-                        logger.debug(f"Fitness Before = {fit}")
-                        logger.debug(
-                            f"Satisfaction Before = {self.problem.satisfy(bsol)}"
-                        )
-                        logger.debug("Post Process..")
-                        result_store = self.post_process_solution.build_other_solution(
-                            result_store
-                        )
-                        bsol, fit = result_store.get_best_solution_fit()
-                        logger.debug(f"Satisfy after : {self.problem.satisfy(bsol)}")
-                        if sense == ModeOptim.MAXIMIZATION and fit >= best_objective:
-                            if fit > best_objective:
-                                current_nb_iteration_no_improvement = 0
-                            else:
-                                current_nb_iteration_no_improvement += 1
-                            best_objective = fit
-                        elif sense == ModeOptim.MAXIMIZATION:
-                            current_nb_iteration_no_improvement += 1
-                        elif sense == ModeOptim.MINIMIZATION and fit <= best_objective:
-                            if fit < best_objective:
-                                current_nb_iteration_no_improvement = 0
-                            else:
-                                current_nb_iteration_no_improvement += 1
-                            best_objective = fit
-                        elif sense == ModeOptim.MINIMIZATION:
-                            current_nb_iteration_no_improvement += 1
-                        if skip_first_iteration and iteration == 0:
-                            store_lns = result_store
-                        else:
-                            for s, f in list(result_store.list_solution_fits):
-                                store_lns.add_solution(solution=s, fitness=f)
-                    else:
-                        current_nb_iteration_no_improvement += 1
-                except Exception as e:
-                    current_nb_iteration_no_improvement += 1
-                    logger.warning(f"Failed ! reason : {e}")
-                logger.debug(
-                    f"{current_nb_iteration_no_improvement} / {nb_iteration_no_improvement}"
-                )
-                if current_nb_iteration_no_improvement > nb_iteration_no_improvement:
-                    logger.info("Finish LNS with maximum no improvement iteration ")
-                    break
-
-                # end of step callback: stopping?
-                if skip_first_iteration:
-                    step = iteration
-                else:
-                    step = iteration + 1
-                stopping = callbacks_list.on_step_end(
-                    step=step, res=store_lns, solver=self
-                )
-                if stopping:
-                    break
-
-        # end of solve callback
-        callbacks_list.on_solve_end(res=store_lns, solver=self)
-        return store_lns
-
-    def solve(
-        self,
-        nb_iteration_lns: int,
-        parameters_cp: Optional[ParametersCP] = None,
-        nb_iteration_no_improvement: Optional[int] = None,
-        skip_first_iteration: bool = False,
-        callbacks: Optional[List[Callback]] = None,
-        **kwargs: Any,
-    ) -> ResultStorage:
-        if parameters_cp is None:
-            parameters_cp = ParametersCP.default()
-        return self.solve_lns(
-            parameters_cp=parameters_cp,
-            nb_iteration_lns=nb_iteration_lns,
-            nb_iteration_no_improvement=nb_iteration_no_improvement,
-            skip_first_iteration=skip_first_iteration,
             callbacks=callbacks,
             **kwargs,
         )
@@ -572,11 +168,11 @@ class ConstraintStatus(TypedDict):
     name: str
 
 
-class ConstraintHandlerMix(ConstraintHandler):
+class ConstraintHandlerMix(MznConstraintHandler):
     def __init__(
         self,
         problem: Problem,
-        list_constraints_handler: List[ConstraintHandler],
+        list_constraints_handler: List[MznConstraintHandler],
         list_proba: List[float],
         update_proba: bool = True,
         tag_constraint_handler: Optional[List[str]] = None,
@@ -609,10 +205,11 @@ class ConstraintHandlerMix(ConstraintHandler):
 
     def adding_constraint_from_results_store(
         self,
-        cp_solver: CPSolver,
+        solver: MinizincCPSolver,
         child_instance: Instance,
         result_storage: ResultStorage,
         last_result_store: Optional[ResultStorage] = None,
+        **kwargs: Any,
     ) -> Iterable[Any]:
         new_fitness = result_storage.get_best_solution_fit()[1]
         if self.last_index_param is not None:
@@ -661,13 +258,14 @@ class ConstraintHandlerMix(ConstraintHandler):
         self.status[self.last_index_param]["nb_usage"] += 1
         logger.debug(f"Status {self.status}")
         return ch.adding_constraint_from_results_store(
-            cp_solver, child_instance, result_storage, last_result_store
+            solver, child_instance, result_storage, last_result_store
         )
 
     def remove_constraints_from_previous_iteration(
         self,
-        cp_solver: CPSolver,
+        solver: MinizincCPSolver,
         child_instance: Instance,
         previous_constraints: Iterable[Any],
+        **kwargs: Any,
     ) -> None:
         pass

--- a/discrete_optimization/generic_tools/lns_mip.py
+++ b/discrete_optimization/generic_tools/lns_mip.py
@@ -17,8 +17,20 @@ from discrete_optimization.generic_tools.do_problem import (
     Problem,
 )
 from discrete_optimization.generic_tools.do_solver import SolverDO
+from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
+    CategoricalHyperparameter,
+    SubBrickHyperparameter,
+    SubBrickKwargsHyperparameter,
+)
 from discrete_optimization.generic_tools.hyperparameters.hyperparametrizable import (
     Hyperparametrizable,
+)
+from discrete_optimization.generic_tools.lns_tools import (
+    BaseLNS,
+    ConstraintHandler,
+    InitialSolution,
+    PostProcessSolution,
+    TrivialPostProcessSolution,
 )
 from discrete_optimization.generic_tools.lp_tools import MilpSolver, ParametersMilp
 from discrete_optimization.generic_tools.result_storage.result_storage import (
@@ -28,201 +40,57 @@ from discrete_optimization.generic_tools.result_storage.result_storage import (
 logger = logging.getLogger(__name__)
 
 
-class ConstraintHandler(Hyperparametrizable):
-    @abstractmethod
-    def adding_constraint_from_results_store(
-        self, milp_solver: MilpSolver, result_storage: ResultStorage
-    ) -> Mapping[Hashable, Any]:
-        ...
+class LNS_MILP(BaseLNS):
+    """Large Neighborhood Search solver using a milp solver at each iteration."""
 
-    @abstractmethod
-    def remove_constraints_from_previous_iteration(
-        self, milp_solver: MilpSolver, previous_constraints: Mapping[Hashable, Any]
-    ) -> None:
-        ...
+    subsolver: MilpSolver
+    """Sub-solver used by this lns solver at each iteration."""
 
-
-class InitialSolution(Hyperparametrizable):
-    @abstractmethod
-    def get_starting_solution(self) -> ResultStorage:
-        ...
-
-
-class InitialSolutionFromSolver(InitialSolution):
-    def __init__(self, solver: SolverDO, **kwargs: Any):
-        self.solver = solver
-        self.dict = kwargs
-
-    @abstractmethod
-    def get_starting_solution(self) -> ResultStorage:
-        return self.solver.solve(**self.dict)
-
-
-class TrivialInitialSolution(InitialSolution):
-    def __init__(self, solution: ResultStorage, **kwargs: Any):
-        self.solution = solution
-        self.dict = kwargs
-
-    @abstractmethod
-    def get_starting_solution(self) -> ResultStorage:
-        return self.solution
-
-
-class PostProcessSolution(Hyperparametrizable):
-    # From solution from MIP or CP you can build other solution.
-    # Here you can have many different approaches:
-    # if solution from mip/cp are not feasible you can code a repair function
-    # you can also do mall changes (filling gap in a schedule) to try to improve the solution
-    # you can also run algorithms from the new found solution.
-    @abstractmethod
-    def build_other_solution(self, result_storage: ResultStorage) -> ResultStorage:
-        ...
-
-
-class TrivialPostProcessSolution(PostProcessSolution):
-    def __init__(self, **kwargs):
-        ...
-
-    def build_other_solution(self, result_storage: ResultStorage) -> ResultStorage:
-        return result_storage
-
-
-class LNS_MILP(SolverDO):
     def __init__(
         self,
         problem: Problem,
-        milp_solver: MilpSolver,
-        initial_solution_provider: InitialSolution,
-        constraint_handler: ConstraintHandler,
+        subsolver: Optional[MilpSolver] = None,
+        initial_solution_provider: Optional[InitialSolution] = None,
+        constraint_handler: Optional[ConstraintHandler] = None,
         post_process_solution: Optional[PostProcessSolution] = None,
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
+        **kwargs: Any,
     ):
         super().__init__(
-            problem=problem, params_objective_function=params_objective_function
+            problem=problem,
+            subsolver=subsolver,
+            initial_solution_provider=initial_solution_provider,
+            constraint_handler=constraint_handler,
+            post_process_solution=post_process_solution,
+            params_objective_function=params_objective_function,
+            **kwargs,
         )
-        self.milp_solver = milp_solver
-        self.initial_solution_provider = initial_solution_provider
-        self.constraint_handler = constraint_handler
-        self.post_process_solution: PostProcessSolution
-        if post_process_solution is None:
-            self.post_process_solution = TrivialPostProcessSolution()
-        else:
-            self.post_process_solution = post_process_solution
 
-    def solve_lns(
-        self,
-        parameters_milp: ParametersMilp,
-        nb_iteration_lns: int,
-        nb_iteration_no_improvement: Optional[int] = None,
-        skip_first_iteration: Optional[bool] = False,
-        callbacks: Optional[List[Callback]] = None,
-        **args: Any,
-    ) -> ResultStorage:
-        # wrap all callbacks in a single one
-        callbacks_list = CallbackList(callbacks=callbacks)
-        # start of solve callback
-        callbacks_list.on_solve_start(solver=self)
-
-        sense = self.params_objective_function.sense_function
-        if nb_iteration_no_improvement is None:
-            nb_iteration_no_improvement = 2 * nb_iteration_lns
-        current_nb_iteration_no_improvement = 0
-        if not skip_first_iteration:
-            store_lns = self.initial_solution_provider.get_starting_solution()
-            init_solution, objective = store_lns.get_best_solution_fit()
-            constraint_iterable = (
-                self.constraint_handler.adding_constraint_from_results_store(
-                    milp_solver=self.milp_solver, result_storage=store_lns
+    def init_model(self, **kwargs: Any) -> None:
+        if self.subsolver.model is None:
+            self.subsolver.init_model(**kwargs)
+            if self.subsolver.model is None:  # for mypy
+                raise RuntimeError(
+                    "subsolver model must not be None after calling init_model()!"
                 )
-            )
-            best_objective = objective
-            # end of step callback: stopping?
-            stopping = callbacks_list.on_step_end(step=0, res=store_lns, solver=self)
-        else:
-            best_objective = float("inf")
-            constraint_iterable = {"empty": []}
-            store_lns = None
-            stopping = False
-
-        if not stopping:
-            for iteration in range(nb_iteration_lns):
-                result_store = self.milp_solver.solve(
-                    parameters_milp=parameters_milp, **args
-                )
-                logger.debug("Solved !!!")
-                bsol, fit = result_store.get_best_solution_fit()
-                logger.debug(f"Fitness = {fit}")
-                logger.debug("Post Process..")
-                result_store = self.post_process_solution.build_other_solution(
-                    result_store
-                )
-                bsol, fit = result_store.get_best_solution_fit()
-                logger.debug(f"After postpro = {fit}")
-                if sense == ModeOptim.MAXIMIZATION and fit >= best_objective:
-                    if fit > best_objective:
-                        current_nb_iteration_no_improvement = 0
-                    else:
-                        current_nb_iteration_no_improvement += 1
-                    best_objective = fit
-                if sense == ModeOptim.MINIMIZATION and fit <= best_objective:
-                    if fit < best_objective:
-                        current_nb_iteration_no_improvement = 0
-                    else:
-                        current_nb_iteration_no_improvement += 1
-                    best_objective = fit
-                if skip_first_iteration and iteration == 0:
-                    store_lns = result_store
-                for s, f in result_store.list_solution_fits:
-                    if store_lns is None:  # for mypy, should never happen
-                        raise RuntimeError(
-                            "store_lns should have been initialized for now"
-                        )
-                    store_lns.add_solution(solution=s, fitness=f)
-                logger.debug("Removing constraint:")
-                self.constraint_handler.remove_constraints_from_previous_iteration(
-                    milp_solver=self.milp_solver,
-                    previous_constraints=constraint_iterable,
-                )
-                logger.debug("Adding constraint:")
-                constraint_iterable = (
-                    self.constraint_handler.adding_constraint_from_results_store(
-                        milp_solver=self.milp_solver, result_storage=result_store
-                    )
-                )
-                if current_nb_iteration_no_improvement > nb_iteration_no_improvement:
-                    logger.info("Finish LNS with maximum no improvement iteration ")
-                    break
-
-                # end of step callback: stopping?
-                if skip_first_iteration:
-                    step = iteration
-                else:
-                    step = iteration + 1
-                stopping = callbacks_list.on_step_end(
-                    step=step, res=store_lns, solver=self
-                )
-                if stopping:
-                    break
-
-        if store_lns is None:  # for mypy, should never happen
-            raise RuntimeError("store_lns should have been initialized for now")
-        # end of solve callback
-        callbacks_list.on_solve_end(res=store_lns, solver=self)
-        return store_lns
 
     def solve(
         self,
-        parameters_milp: ParametersMilp,
         nb_iteration_lns: int,
+        parameters_milp: Optional[ParametersMilp] = None,
         nb_iteration_no_improvement: Optional[int] = None,
         skip_first_iteration: Optional[bool] = False,
+        stop_first_iteration_if_optimal: bool = True,
         callbacks: Optional[List[Callback]] = None,
         **kwargs: Any,
     ) -> ResultStorage:
-        return self.solve_lns(
+        if parameters_milp is None:
+            parameters_milp = ParametersMilp.default()
+        return super().solve(
             parameters_milp=parameters_milp,
             nb_iteration_lns=nb_iteration_lns,
             nb_iteration_no_improvement=nb_iteration_no_improvement,
+            stop_first_iteration_if_optimal=stop_first_iteration_if_optimal,
             skip_first_iteration=skip_first_iteration,
             callbacks=callbacks,
             **kwargs,

--- a/discrete_optimization/generic_tools/lns_tools.py
+++ b/discrete_optimization/generic_tools/lns_tools.py
@@ -1,0 +1,440 @@
+#  Copyright (c) 2022 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+import contextlib
+import logging
+import time
+from abc import abstractmethod
+from typing import Any, Hashable, List, Mapping, Optional
+
+from discrete_optimization.generic_tools.callbacks.callback import (
+    Callback,
+    CallbackList,
+)
+from discrete_optimization.generic_tools.do_problem import (
+    ModeOptim,
+    ParamsObjectiveFunction,
+    Problem,
+)
+from discrete_optimization.generic_tools.do_solver import SolverDO
+from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
+    CategoricalHyperparameter,
+    SubBrickHyperparameter,
+    SubBrickKwargsHyperparameter,
+)
+from discrete_optimization.generic_tools.hyperparameters.hyperparametrizable import (
+    Hyperparametrizable,
+)
+from discrete_optimization.generic_tools.lp_tools import MilpSolver, ParametersMilp
+from discrete_optimization.generic_tools.result_storage.result_storage import (
+    ResultStorage,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ConstraintHandler(Hyperparametrizable):
+    @abstractmethod
+    def adding_constraint_from_results_store(
+        self, solver: SolverDO, result_storage: ResultStorage, **kwargs: Any
+    ) -> Mapping[Hashable, Any]:
+        ...
+
+    @abstractmethod
+    def remove_constraints_from_previous_iteration(
+        self,
+        solver: SolverDO,
+        previous_constraints: Mapping[Hashable, Any],
+        **kwargs: Any,
+    ) -> None:
+        ...
+
+
+class InitialSolution(Hyperparametrizable):
+    @abstractmethod
+    def get_starting_solution(self) -> ResultStorage:
+        ...
+
+
+class InitialSolutionFromSolver(InitialSolution):
+    def __init__(self, solver: SolverDO, **kwargs: Any):
+        self.solver = solver
+        self.dict = kwargs
+
+    @abstractmethod
+    def get_starting_solution(self) -> ResultStorage:
+        return self.solver.solve(**self.dict)
+
+
+class TrivialInitialSolution(InitialSolution):
+    def __init__(self, solution: ResultStorage, **kwargs: Any):
+        self.solution = solution
+        self.dict = kwargs
+
+    @abstractmethod
+    def get_starting_solution(self) -> ResultStorage:
+        return self.solution
+
+
+class PostProcessSolution(Hyperparametrizable):
+    # From solution from MIP or CP you can build other solution.
+    # Here you can have many different approaches:
+    # if solution from mip/cp are not feasible you can code a repair function
+    # you can also do mall changes (filling gap in a schedule) to try to improve the solution
+    # you can also run algorithms from the new found solution.
+    @abstractmethod
+    def build_other_solution(self, result_storage: ResultStorage) -> ResultStorage:
+        ...
+
+
+class TrivialPostProcessSolution(PostProcessSolution):
+    def __init__(self, **kwargs):
+        ...
+
+    def build_other_solution(self, result_storage: ResultStorage) -> ResultStorage:
+        return result_storage
+
+
+class BaseLNS(SolverDO):
+    """Base class for Large Neighborhood Search solvers."""
+
+    subsolver: SolverDO
+    """Sub-solver used by this lns solver at each iteration."""
+
+    constraint_handler: ConstraintHandler
+    initial_solution_provider: Optional[InitialSolution]
+    post_process_solution: Optional[PostProcessSolution]
+
+    hyperparameters = [
+        SubBrickHyperparameter("subsolver_cls", choices=[], default=None),
+        SubBrickKwargsHyperparameter(
+            "subsolver_kwargs", subbrick_hyperparameter="subsolver_cls"
+        ),
+        SubBrickHyperparameter(
+            "initial_solution_provider_cls", choices=[], default=None
+        ),
+        SubBrickKwargsHyperparameter(
+            "initial_solution_provider_kwargs",
+            subbrick_hyperparameter="initial_solution_provider_cls",
+        ),
+        SubBrickHyperparameter(
+            "constraint_handler_cls",
+            choices=[],
+            default=None,
+        ),
+        SubBrickKwargsHyperparameter(
+            "constraint_handler_kwargs",
+            subbrick_hyperparameter="constraint_handler_cls",
+        ),
+        SubBrickHyperparameter(
+            "post_process_solution_cls",
+            choices=[],
+            default=TrivialPostProcessSolution,
+        ),
+        SubBrickKwargsHyperparameter(
+            "post_process_solution_kwargs",
+            subbrick_hyperparameter="post_process_solution_cls",
+        ),
+        CategoricalHyperparameter(
+            name="skip_first_iteration", choices=[True, False], default=False
+        ),
+    ]
+
+    def __init__(
+        self,
+        problem: Problem,
+        subsolver: Optional[SolverDO] = None,
+        initial_solution_provider: Optional[InitialSolution] = None,
+        constraint_handler: Optional[ConstraintHandler] = None,
+        post_process_solution: Optional[PostProcessSolution] = None,
+        params_objective_function: Optional[ParamsObjectiveFunction] = None,
+        **kwargs: Any,
+    ):
+        super().__init__(
+            problem=problem, params_objective_function=params_objective_function
+        )
+        kwargs = self.complete_with_default_hyperparameters(kwargs)
+
+        if subsolver is None:
+            if kwargs["subsolver_kwargs"] is None:
+                subsolver_kwargs = kwargs
+            else:
+                subsolver_kwargs = kwargs["subsolver_kwargs"]
+            if kwargs["subsolver_cls"] is None:
+                if "build_default_subsolver" in kwargs:
+                    subsolver = kwargs["build_default_subsolver"](
+                        self.problem, **subsolver_kwargs
+                    )
+                else:
+                    raise ValueError(
+                        "`subsolver_cls` cannot be None if `subsolver` is not specified."
+                    )
+            else:
+                subsolver_cls = kwargs["subsolver_cls"]
+                subsolver = subsolver_cls(problem=self.problem, **subsolver_kwargs)
+                subsolver.init_model(**subsolver_kwargs)
+        self.subsolver = subsolver
+
+        if constraint_handler is None:
+            if kwargs["constraint_handler_kwargs"] is None:
+                constraint_handler_kwargs = kwargs
+            else:
+                constraint_handler_kwargs = kwargs["constraint_handler_kwargs"]
+            if kwargs["constraint_handler_cls"] is None:
+                if "build_default_contraint_handler" in kwargs:
+                    constraint_handler = kwargs["build_default_contraint_handler"](
+                        self.problem, **constraint_handler_kwargs
+                    )
+                else:
+                    raise ValueError(
+                        "`constraint_handler_cls` cannot be None if `constraint_handler` is not specified."
+                    )
+            else:
+                constraint_handler_cls = kwargs["constraint_handler_cls"]
+                constraint_handler = constraint_handler_cls(
+                    problem=self.problem, **constraint_handler_kwargs
+                )
+        self.constraint_handler = constraint_handler
+
+        if post_process_solution is None:
+            if kwargs["post_process_solution_kwargs"] is None:
+                post_process_solution_kwargs = kwargs
+            else:
+                post_process_solution_kwargs = kwargs["post_process_solution_kwargs"]
+            if kwargs["post_process_solution_cls"] is None:
+                if "build_default_post_process_solution" in kwargs:
+                    post_process_solution = kwargs[
+                        "build_default_post_process_solution"
+                    ](
+                        self.problem,
+                        self.params_objective_function,
+                        **post_process_solution_kwargs,
+                    )
+                else:
+                    post_process_solution = None
+            else:
+                post_process_solution_cls = kwargs["post_process_solution_cls"]
+                post_process_solution = post_process_solution_cls(
+                    problem=self.problem,
+                    params_objective_function=self.params_objective_function,
+                    **post_process_solution_kwargs,
+                )
+        self.post_process_solution = post_process_solution
+
+        if initial_solution_provider is None:
+            if kwargs["initial_solution_provider_kwargs"] is None:
+                initial_solution_provider_kwargs = kwargs
+            else:
+                initial_solution_provider_kwargs = kwargs[
+                    "initial_solution_provider_kwargs"
+                ]
+            if kwargs["initial_solution_provider_cls"] is None:
+                if "build_default_initial_solution_provider" in kwargs:
+                    initial_solution_provider = kwargs[
+                        "build_default_initial_solution_provider"
+                    ](
+                        self.problem,
+                        self.params_objective_function,
+                        **initial_solution_provider_kwargs,
+                    )
+                else:
+                    initial_solution_provider = (
+                        None  # ok if solve_lns with skip_first_iteration
+                    )
+            else:
+                initial_solution_provider_cls = kwargs["initial_solution_provider_cls"]
+                initial_solution_provider = initial_solution_provider_cls(
+                    problem=self.problem,
+                    params_objective_function=self.params_objective_function,
+                    **initial_solution_provider_kwargs,
+                )
+        self.initial_solution_provider = initial_solution_provider
+
+    def create_submodel(self) -> contextlib.AbstractContextManager:
+        return _dummy_contextmanager()
+
+    def solve_with_subsolver(
+        self, iteration: int, instance: Any, **kwargs: Any
+    ) -> ResultStorage:
+        """Solve with the subsolver.
+
+        Args:
+            iteration: current iteration number
+            instance: current instance of the model (only for minizinc)
+            **kwargs: kwargs passed to this lns solver `solve()`
+
+        Returns:
+
+        """
+        return self.subsolver.solve(**kwargs)
+
+    def solve(
+        self,
+        nb_iteration_lns: int,
+        nb_iteration_no_improvement: Optional[int] = None,
+        skip_first_iteration: bool = False,
+        stop_first_iteration_if_optimal: bool = True,
+        callbacks: Optional[List[Callback]] = None,
+        **kwargs: Any,
+    ) -> ResultStorage:
+        # wrap all callbacks in a single one
+        callbacks_list = CallbackList(callbacks=callbacks)
+        # start of solve callback
+        callbacks_list.on_solve_start(solver=self)
+
+        # manage None post_process_solution (can happen in subclasses __init__)
+        if self.post_process_solution is None:
+            self.post_process_solution = TrivialPostProcessSolution()
+
+        sense = self.params_objective_function.sense_function
+        if nb_iteration_no_improvement is None:
+            nb_iteration_no_improvement = 2 * nb_iteration_lns
+        current_nb_iteration_no_improvement = 0
+
+        self.init_model(**kwargs)
+
+        if not skip_first_iteration:
+            if self.initial_solution_provider is None:
+                raise ValueError(
+                    "self.initial_solution_provider cannot be None if not skip_first_iteration."
+                )
+            store_lns = self.initial_solution_provider.get_starting_solution()
+            store_lns = self.post_process_solution.build_other_solution(store_lns)
+            init_solution, objective = store_lns.get_best_solution_fit()
+            if init_solution is None:
+                satisfy = False
+            else:
+                satisfy = self.problem.satisfy(init_solution)
+            logger.debug(f"Satisfy Initial solution {satisfy}")
+            try:
+                logger.debug(
+                    f"Nb task preempted = {init_solution.get_nb_task_preemption()}"  # type: ignore
+                )
+                logger.debug(f"Nb max preemption = {init_solution.get_max_preempted()}")  # type: ignore
+            except:
+                pass
+            best_objective = objective
+            # end of step callback: stopping?
+            stopping = callbacks_list.on_step_end(step=0, res=store_lns, solver=self)
+        else:
+            best_objective = (
+                float("inf") if sense == ModeOptim.MINIMIZATION else -float("inf")
+            )
+            store_lns = None
+            stopping = False
+
+        result_store: ResultStorage
+        if not stopping:
+            for iteration in range(nb_iteration_lns):
+                logger.info(
+                    f"Starting iteration n° {iteration} current objective {best_objective}"
+                )
+                with self.create_submodel() as child:
+                    if iteration == 0 and not skip_first_iteration or iteration >= 1:
+                        constraint_iterable = self.constraint_handler.adding_constraint_from_results_store(
+                            solver=self.subsolver,
+                            child_instance=child,
+                            result_storage=store_lns,
+                            last_result_store=store_lns
+                            if iteration == 0
+                            else result_store,
+                        )
+                    try:
+                        result_store = self.solve_with_subsolver(
+                            iteration=0, instance=child, **kwargs
+                        )
+                        logger.info(f"iteration n° {iteration} Solved !!!")
+                        if hasattr(self.subsolver, "status_solver"):
+                            logger.info(self.subsolver.status_solver)
+                        if len(result_store.list_solution_fits) > 0:
+                            logger.debug("Solved !!!")
+                            bsol, fit = result_store.get_best_solution_fit()
+                            logger.debug(f"Fitness Before = {fit}")
+                            if bsol is not None:
+                                logger.debug(
+                                    f"Satisfaction Before = {self.problem.satisfy(bsol)}"
+                                )
+                            else:
+                                logger.debug(f"Satisfaction Before = {False}")
+                            logger.debug("Post Process..")
+                            result_store = (
+                                self.post_process_solution.build_other_solution(
+                                    result_store
+                                )
+                            )
+                            bsol, fit = result_store.get_best_solution_fit()
+                            if bsol is not None:
+                                logger.debug(
+                                    f"Satisfaction After = {self.problem.satisfy(bsol)}"
+                                )
+                            else:
+                                logger.debug(f"Satisfaction After = {False}")
+                            if (
+                                sense == ModeOptim.MAXIMIZATION
+                                and fit >= best_objective
+                            ):
+                                if fit > best_objective:
+                                    current_nb_iteration_no_improvement = 0
+                                else:
+                                    current_nb_iteration_no_improvement += 1
+                                best_objective = fit
+                            elif sense == ModeOptim.MAXIMIZATION:
+                                current_nb_iteration_no_improvement += 1
+                            elif (
+                                sense == ModeOptim.MINIMIZATION
+                                and fit <= best_objective
+                            ):
+                                if fit < best_objective:
+                                    current_nb_iteration_no_improvement = 0
+                                else:
+                                    current_nb_iteration_no_improvement += 1
+                                best_objective = fit
+                            elif sense == ModeOptim.MINIMIZATION:
+                                current_nb_iteration_no_improvement += 1
+                            if skip_first_iteration and iteration == 0:
+                                store_lns = result_store
+                            else:
+                                for s, f in list(result_store.list_solution_fits):
+                                    store_lns.add_solution(solution=s, fitness=f)
+                        else:
+                            current_nb_iteration_no_improvement += 1
+                        if (
+                            skip_first_iteration
+                            and self.subsolver.is_optimal()
+                            and iteration == 0
+                            and self.problem.satisfy(bsol)
+                            and stop_first_iteration_if_optimal
+                        ):
+                            logger.info("Finish LNS because found optimal solution")
+                            break
+                    except Exception as e:
+                        current_nb_iteration_no_improvement += 1
+                        logger.warning(f"Failed ! reason : {e}")
+                    logger.debug(
+                        f"{current_nb_iteration_no_improvement} / {nb_iteration_no_improvement}"
+                    )
+                    if (
+                        current_nb_iteration_no_improvement
+                        > nb_iteration_no_improvement
+                    ):
+                        logger.info("Finish LNS with maximum no improvement iteration ")
+                        break
+                # end of step callback: stopping?
+                if skip_first_iteration:
+                    step = iteration
+                else:
+                    step = iteration + 1
+                stopping = callbacks_list.on_step_end(
+                    step=step, res=store_lns, solver=self
+                )
+                if stopping:
+                    break
+
+        # end of solve callback
+        callbacks_list.on_solve_end(res=store_lns, solver=self)
+        return store_lns
+
+
+@contextlib.contextmanager
+def _dummy_contextmanager():
+    yield None

--- a/discrete_optimization/knapsack/solvers/knapsack_lns_cp_solver.py
+++ b/discrete_optimization/knapsack/solvers/knapsack_lns_cp_solver.py
@@ -7,11 +7,11 @@ from typing import Any, Iterable, Optional
 
 from minizinc import Instance
 
-from discrete_optimization.generic_tools.cp_tools import CPSolver
+from discrete_optimization.generic_tools.cp_tools import MinizincCPSolver
 from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
     FloatHyperparameter,
 )
-from discrete_optimization.generic_tools.lns_cp import ConstraintHandler
+from discrete_optimization.generic_tools.lns_cp import MznConstraintHandler
 from discrete_optimization.knapsack.knapsack_model import (
     KnapsackModel,
     KnapsackSolution,
@@ -20,7 +20,7 @@ from discrete_optimization.knapsack.solvers.cp_solvers import CPKnapsackMZN2
 from discrete_optimization.knapsack.solvers.greedy_solvers import ResultStorage
 
 
-class ConstraintHandlerKnapsack(ConstraintHandler):
+class ConstraintHandlerKnapsack(MznConstraintHandler):
     hyperparameters = [
         FloatHyperparameter(name="fraction_to_fix", default=0.9, low=0.0, high=1.0),
     ]
@@ -32,12 +32,13 @@ class ConstraintHandlerKnapsack(ConstraintHandler):
 
     def adding_constraint_from_results_store(
         self,
-        cp_solver: CPSolver,
+        solver: MinizincCPSolver,
         child_instance: Instance,
         result_storage: ResultStorage,
         last_result_store: Optional[ResultStorage] = None,
+        **kwargs: Any
     ) -> Iterable[Any]:
-        if not isinstance(cp_solver, CPKnapsackMZN2):
+        if not isinstance(solver, CPKnapsackMZN2):
             raise ValueError("cp_solver must a CPKnapsackMZN2 for this constraint.")
         subpart_item = set(
             random.sample(
@@ -68,10 +69,11 @@ class ConstraintHandlerKnapsack(ConstraintHandler):
 
     def remove_constraints_from_previous_iteration(
         self,
-        cp_solver: CPSolver,
+        solver: MinizincCPSolver,
         child_instance: Instance,
         previous_constraints: Iterable[Any],
+        **kwargs: Any
     ) -> None:
-        if not isinstance(cp_solver, CPKnapsackMZN2):
+        if not isinstance(solver, CPKnapsackMZN2):
             raise ValueError("cp_solver must a CPKnapsackMZN2 for this constraint.")
         pass

--- a/discrete_optimization/knapsack/solvers/knapsack_lns_solver.py
+++ b/discrete_optimization/knapsack/solvers/knapsack_lns_solver.py
@@ -81,13 +81,13 @@ class ConstraintHandlerKnapsack(ConstraintHandler):
         self.iter = 0
 
     def adding_constraint_from_results_store(
-        self, milp_solver: MilpSolver, result_storage: ResultStorage
+        self, solver: MilpSolver, result_storage: ResultStorage, **kwargs: Any
     ) -> Mapping[Hashable, Any]:
-        if not isinstance(milp_solver, LPKnapsack):
+        if not isinstance(solver, LPKnapsack):
             raise ValueError("milp_solver must a LPKnapsack for this constraint.")
-        if milp_solver.model is None:
-            milp_solver.init_model()
-            if milp_solver.model is None:
+        if solver.model is None:
+            solver.init_model()
+            if solver.model is None:
                 raise RuntimeError(
                     "milp_solver.model must be not None after calling milp_solver.init_model()"
                 )
@@ -113,30 +113,33 @@ class ConstraintHandlerKnapsack(ConstraintHandler):
             dict_f_start[c] = current_solution.list_taken[c]
             if c in subpart_item:
                 dict_f_fixed[c] = dict_f_start[c]
-        x_var = milp_solver.variable_decision["x"]
+        x_var = solver.variable_decision["x"]
         lns_constraint: Dict[Hashable, Any] = {}
         for key in x_var:
             start += [(x_var[key], dict_f_start[key])]
             if key in subpart_item:
-                lns_constraint[key] = milp_solver.model.add_constr(
+                lns_constraint[key] = solver.model.add_constr(
                     x_var[key] == dict_f_start[key], name=str(key)
                 )
-        if milp_solver.milp_solver_name == MilpSolverName.GRB:
-            milp_solver.model.solver.update()
-        milp_solver.model.start = start
+        if solver.milp_solver_name == MilpSolverName.GRB:
+            solver.model.solver.update()
+        solver.model.start = start
         return lns_constraint
 
     def remove_constraints_from_previous_iteration(
-        self, milp_solver: MilpSolver, previous_constraints: Mapping[Hashable, Any]
+        self,
+        solver: MilpSolver,
+        previous_constraints: Mapping[Hashable, Any],
+        **kwargs: Any
     ) -> None:
-        if not isinstance(milp_solver, LPKnapsack):
+        if not isinstance(solver, LPKnapsack):
             raise ValueError("milp_solver must a ColoringLP for this constraint.")
-        if milp_solver.model is None:
-            milp_solver.init_model()
-            if milp_solver.model is None:
+        if solver.model is None:
+            solver.init_model()
+            if solver.model is None:
                 raise RuntimeError(
                     "milp_solver.model must be not None after calling milp_solver.init_model()"
                 )
-        milp_solver.model.remove(list(previous_constraints.values()))
-        if milp_solver.milp_solver_name == MilpSolverName.GRB:
-            milp_solver.model.solver.update()
+        solver.model.remove(list(previous_constraints.values()))
+        if solver.milp_solver_name == MilpSolverName.GRB:
+            solver.model.solver.update()

--- a/examples/knapsack/knapsack_multidimensional.py
+++ b/examples/knapsack/knapsack_multidimensional.py
@@ -108,13 +108,13 @@ def run_cp_multidimensional_multiscenario():
     )
     lns = LNS_CP(
         problem=multiscenario_model,
-        cp_solver=solver,
+        subsolver=solver,
         initial_solution_provider=TrivialInitialSolution(res_storage),
         constraint_handler=KnapConstraintHandler(fraction_fix=0.93),
     )
     p = ParametersCP.default()
     p.time_limit = 5
-    r_lns = lns.solve_lns(
+    r_lns = lns.solve(
         parameters_cp=p,
         nb_iteration_lns=100,
         nb_iteration_no_improvement=1000,

--- a/notebooks/Knapsack tutorial.ipynb
+++ b/notebooks/Knapsack tutorial.ipynb
@@ -587,12 +587,12 @@
     "# LNS Solver.\n",
     "lns_solver = LNS_CP(\n",
     "    problem=model,\n",
-    "    cp_solver=cp_solver,\n",
+    "    subsolver=cp_solver,\n",
     "    initial_solution_provider=initial_solution_provider,\n",
     "    constraint_handler=constraint_handler,\n",
     "    params_objective_function=params_objective_function,\n",
     ")\n",
-    "result_lns = lns_solver.solve_lns(\n",
+    "result_lns = lns_solver.solve(\n",
     "    parameters_cp=params_cp, nb_iteration_lns=nb_iteration_lns, max_time_seconds=100\n",
     ")"
    ]
@@ -689,12 +689,12 @@
     "# solve\n",
     "lns_solver = LNS_CP(\n",
     "    problem=model,\n",
-    "    cp_solver=cp_solver,\n",
+    "    subsolver=cp_solver,\n",
     "    initial_solution_provider=initial_solution_provider,\n",
     "    constraint_handler=constraint_handler,\n",
     "    params_objective_function=params_objective_function,\n",
     ")\n",
-    "result_lns = lns_solver.solve_lns(\n",
+    "result_lns = lns_solver.solve(\n",
     "    parameters_cp=params_cp, nb_iteration_lns=nb_iteration_lns, max_time_seconds=100\n",
     ")"
    ]

--- a/notebooks/RCPSP tutorials/RCPSP-6 Large Neighbourhood Search .ipynb
+++ b/notebooks/RCPSP tutorials/RCPSP-6 Large Neighbourhood Search .ipynb
@@ -230,11 +230,11 @@
     "parameters_cp.time_limit = 2\n",
     "lns_solver = LNS_CP(\n",
     "    problem=rcpsp_problem,\n",
-    "    cp_solver=solver,\n",
+    "    subsolver=solver,\n",
     "    initial_solution_provider=initial_solution_provider,\n",
     "    constraint_handler=constraint_handler,\n",
     ")\n",
-    "result_store = lns_solver.solve_lns(\n",
+    "result_store = lns_solver.solve(\n",
     "    max_time_seconds=100, parameters_cp=parameters_cp, nb_iteration_lns=100\n",
     ")"
    ]
@@ -349,7 +349,7 @@
     ")\n",
     "lns_solver = LargeNeighborhoodSearchScheduling(\n",
     "    problem=rcpsp_problem,\n",
-    "    cp_solver=solver,\n",
+    "    subsolver=solver,\n",
     "    constraint_handler=constraint_handler,\n",
     "    initial_solution_provider=initial_solution_provider,\n",
     ")"

--- a/notebooks/z_Advanced/optuna.ipynb
+++ b/notebooks/z_Advanced/optuna.ipynb
@@ -777,7 +777,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.8.18"
   },
   "toc": {
    "base_numbering": 1,

--- a/tests/facility/test_facility_lp_lns.py
+++ b/tests/facility/test_facility_lp_lns.py
@@ -61,13 +61,13 @@ def test_facility_lns():
     )
     lns_solver = LNS_MILP(
         problem=facility_problem,
-        milp_solver=solver,
+        subsolver=solver,
         initial_solution_provider=initial_solution_provider,
         constraint_handler=constraint_handler,
         params_objective_function=params_objective_function,
     )
 
-    result_store = lns_solver.solve_lns(
+    result_store = lns_solver.solve(
         parameters_milp=params_milp,
         nb_iteration_lns=100,
         callbacks=[TimerStopper(total_seconds=100)],

--- a/tests/knapsack/test_knapsack_lns_cp_solver.py
+++ b/tests/knapsack/test_knapsack_lns_cp_solver.py
@@ -51,14 +51,14 @@ def test_knapsack_lns():
     constraint_handler = ConstraintHandlerKnapsack(problem=model, fraction_to_fix=0.83)
     lns_solver = LNS_CP(
         problem=model,
-        cp_solver=solver,
+        subsolver=solver,
         initial_solution_provider=initial_solution_provider,
         constraint_handler=constraint_handler,
         params_objective_function=params_objective_function,
     )
     result_store_pure_cp = solver.solve(parameters_cp=params_cp)
     solution_pure_cp = result_store_pure_cp.get_best_solution_fit()
-    result_store = lns_solver.solve_lns(
+    result_store = lns_solver.solve(
         parameters_cp=params_cp,
         nb_iteration_lns=200,
         callbacks=[TimerStopper(total_seconds=30)],
@@ -93,7 +93,7 @@ def test_knapsack_lns_timer():
     constraint_handler = ConstraintHandlerKnapsack(problem=model, fraction_to_fix=0.83)
     lns_solver = LNS_CP(
         problem=model,
-        cp_solver=solver,
+        subsolver=solver,
         initial_solution_provider=initial_solution_provider,
         constraint_handler=constraint_handler,
         params_objective_function=params_objective_function,
@@ -160,7 +160,7 @@ def test_knapsack_lns_cb_nbiter(skip_first_iteration):
     constraint_handler = ConstraintHandlerKnapsack(problem=model, fraction_to_fix=0.83)
     lns_solver = LNS_CP(
         problem=model,
-        cp_solver=solver,
+        subsolver=solver,
         initial_solution_provider=initial_solution_provider,
         constraint_handler=constraint_handler,
         params_objective_function=params_objective_function,

--- a/tests/knapsack/test_knapsack_lp_lns_solver.py
+++ b/tests/knapsack/test_knapsack_lp_lns_solver.py
@@ -44,13 +44,13 @@ def test_knapsack_lns():
     constraint_handler = ConstraintHandlerKnapsack(problem=model, fraction_to_fix=0.95)
     lns_solver = LNS_MILP(
         problem=model,
-        milp_solver=solver,
+        subsolver=solver,
         initial_solution_provider=initial_solution_provider,
         constraint_handler=constraint_handler,
         params_objective_function=params_objective_function,
     )
 
-    result_store = lns_solver.solve_lns(
+    result_store = lns_solver.solve(
         parameters_milp=params_milp,
         nb_iteration_lns=10000,
         callbacks=[TimerStopper(total_seconds=30)],

--- a/tests/rcpsp/solver/test_rcpsp_lp_lns.py
+++ b/tests/rcpsp/solver/test_rcpsp_lp_lns.py
@@ -52,12 +52,12 @@ def test_lns_sm():
     )
     lns_solver = LNS_MILP(
         problem=rcpsp_problem,
-        milp_solver=solver,
+        subsolver=solver,
         initial_solution_provider=initial_solution_provider,
         constraint_handler=constraint_handler,
         params_objective_function=params_objective_function,
     )
-    result_store = lns_solver.solve_lns(
+    result_store = lns_solver.solve(
         parameters_milp=parameters_milp, nb_iteration_lns=10
     )
     solution, fit = result_store.get_best_solution_fit()
@@ -111,12 +111,12 @@ def test_lns_mm():
     )
     lns_solver = LNS_MILP(
         problem=rcpsp_problem,
-        milp_solver=solver,
+        subsolver=solver,
         initial_solution_provider=initial_solution_provider,
         constraint_handler=constraint_handler,
         params_objective_function=params_objective_function,
     )
-    result_store = lns_solver.solve_lns(
+    result_store = lns_solver.solve(
         parameters_milp=parameters_milp,
         nb_iteration_lns=10,
         skip_first_iteration=False,

--- a/tests/rcpsp_multiskill/test_rcpsp_ms_lp_lns.py
+++ b/tests/rcpsp_multiskill/test_rcpsp_ms_lp_lns.py
@@ -79,12 +79,12 @@ def test_multiskill_imopse():
     )
     lns_solver = LNS_MILP(
         problem=model,
-        milp_solver=solver,
+        subsolver=solver,
         initial_solution_provider=initial_solution_provider,
         constraint_handler=constraint_handler,
         params_objective_function=params_objective_function,
     )
-    result_store = lns_solver.solve_lns(
+    result_store = lns_solver.solve(
         parameters_milp=parameters_milp,
         nb_iteration_lns=10,
         nb_iteration_no_improvement=10,


### PR DESCRIPTION
- `LNS_CP` and `LNS_MILP` derive from `BaseLNS` and have a common `solve()`
- constraint handlers used by `LNS_CP` are now called `MznConstraintHandler` and derive from base `ConstraintHandler` (adding `child_instance` parameter)
- `solve_lns()` is removed (replaced by `solve()`)
- `cp_solver` and `milp_solver` parameters become a common parameter `subsolver` parameter
- remove obsolete `LNS_CPlex`