### PR TITLE
Allow SubBrickKwargsHyperparameter to directly specify a subbrick class

### DIFF
--- a/discrete_optimization/generic_tools/ea/ga_tools.py
+++ b/discrete_optimization/generic_tools/ea/ga_tools.py
@@ -11,9 +11,28 @@ from discrete_optimization.generic_tools.ea.ga import (
     DeapSelection,
     ObjectiveHandling,
 )
+from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
+    EnumHyperparameter,
+    FloatHyperparameter,
+    IntegerHyperparameter,
+)
+from discrete_optimization.generic_tools.hyperparameters.hyperparametrizable import (
+    Hyperparametrizable,
+)
 
 
-class ParametersGa:
+class ParametersGa(Hyperparametrizable):
+    hyperparameters = [
+        EnumHyperparameter(name="crossover", enum=DeapCrossover, default=None),
+        EnumHyperparameter(
+            name="selection", enum=DeapSelection, default=DeapSelection.SEL_TOURNAMENT
+        ),
+        IntegerHyperparameter(name="pop_size", low=1, high=1000, default=100),
+        FloatHyperparameter(name="mut_rate", low=0, high=0.9, default=0.1),
+        FloatHyperparameter(name="crossover_rate", low=0, high=1, default=0.9),
+        FloatHyperparameter(name="tournament_size", low=0, high=1, default=0.2),
+    ]
+
     def __init__(
         self,
         mutation: Union[Mutation, DeapMutation],

--- a/discrete_optimization/generic_tools/hyperparameters/hyperparametrizable.py
+++ b/discrete_optimization/generic_tools/hyperparameters/hyperparametrizable.py
@@ -213,23 +213,31 @@ class Hyperparametrizable:
         }
         for hyperparameter in subsolvers_kwargs_hyperparameters:
             kwargs_for_optuna_suggestion = kwargs_by_name.get(hyperparameter.name, {})
-            if hyperparameter.subbrick_hyperparameter in names:
-                kwargs_for_optuna_suggestion["subbrick"] = suggested_hyperparameters[
-                    hyperparameter.subbrick_hyperparameter
-                ]
-            elif hyperparameter.subbrick_hyperparameter in fixed_hyperparameters:
-                kwargs_for_optuna_suggestion["subbrick"] = fixed_hyperparameters[
-                    hyperparameter.subbrick_hyperparameter
-                ]
+            if hyperparameter.subbrick_hyperparameter is None:
+                kwargs_for_optuna_suggestion["subbrick"] = hyperparameter.subbrick_cls
+                kwargs_for_optuna_suggestion[
+                    "prefix"
+                ] = f"{prefix}{hyperparameter.name}."
             else:
-                raise ValueError(
-                    f"The choice of '{hyperparameter.subbrick_hyperparameter}' should be "
-                    "either suggested by this method with `names` containing it or being None "
-                    "or given via `fixed_hyperparameters`."
-                )
-            kwargs_for_optuna_suggestion[
-                "prefix"
-            ] = f"{prefix}{hyperparameter.subbrick_hyperparameter}."
+                if hyperparameter.subbrick_hyperparameter in names:
+                    kwargs_for_optuna_suggestion[
+                        "subbrick"
+                    ] = suggested_hyperparameters[
+                        hyperparameter.subbrick_hyperparameter
+                    ]
+                elif hyperparameter.subbrick_hyperparameter in fixed_hyperparameters:
+                    kwargs_for_optuna_suggestion["subbrick"] = fixed_hyperparameters[
+                        hyperparameter.subbrick_hyperparameter
+                    ]
+                else:
+                    raise ValueError(
+                        f"The choice of '{hyperparameter.subbrick_hyperparameter}' should be "
+                        "either suggested by this method with `names` containing it or being None "
+                        "or given via `fixed_hyperparameters`."
+                    )
+                kwargs_for_optuna_suggestion[
+                    "prefix"
+                ] = f"{prefix}{hyperparameter.subbrick_hyperparameter}."
             suggested_hyperparameters[
                 hyperparameter.name
             ] = cls.suggest_hyperparameter_with_optuna(

--- a/discrete_optimization/rcpsp/solver/rcpsp_ga_solver.py
+++ b/discrete_optimization/rcpsp/solver/rcpsp_ga_solver.py
@@ -9,20 +9,28 @@ from discrete_optimization.generic_tools.ea.ga_tools import (
     ParametersAltGa,
     ParametersGa,
 )
+from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
+    SubBrickKwargsHyperparameter,
+)
 from discrete_optimization.rcpsp.rcpsp_model import RCPSPModel
 from discrete_optimization.rcpsp.solver.rcpsp_solver import SolverRCPSP
 
 
 class GA_RCPSP_Solver(SolverRCPSP):
     problem: RCPSPModel
-    hyperparameters = Ga.hyperparameters
+    hyperparameters = [
+        SubBrickKwargsHyperparameter(
+            name="parameters_ga_kwargs", subbrick_cls=ParametersGa
+        )
+    ]
 
-    def solve(self, parameters_ga: Optional[ParametersGa] = None, **args):
+    def solve(self, parameters_ga: Optional[ParametersGa] = None, **kwargs):
         if parameters_ga is None:
             parameters_ga = ParametersGa.default_rcpsp()
-            args = self.complete_with_default_hyperparameters(args)
-        for key in args:
-            setattr(parameters_ga, key, args[key])
+        kwargs = self.complete_with_default_hyperparameters(kwargs)
+        if kwargs["parameters_ga_kwargs"] is not None:
+            for key in kwargs["parameters_ga_kwargs"]:
+                setattr(parameters_ga, key, kwargs["parameters_ga_kwargs"][key])
         ga_solver = Ga(
             problem=self.problem,
             encoding=parameters_ga.encoding,


### PR DESCRIPTION
When only one class is possible, instead of having a dedicated hyperparameter with only 1 choice, we directly specify the class in the SubBrickKwargsHyperparameter.

We implement that with GA_RCPSP_Solver and ParametersGa.