### PR TITLE
Fix issue with subsolvers whose hyperparameters share names but not types

### DIFF
--- a/discrete_optimization/generic_tools/hyperparameters/hyperparametrizable.py
+++ b/discrete_optimization/generic_tools/hyperparameters/hyperparametrizable.py
@@ -248,9 +248,10 @@ class Hyperparametrizable:
                     ] = suggested_and_fixed_hyperparameters[
                         hyperparameter.subbrick_hyperparameter
                     ]
-                    kwargs_for_optuna_suggestion[
-                        "prefix"
-                    ] = f"{prefix}{hyperparameter.subbrick_hyperparameter}."
+                    kwargs_for_optuna_suggestion["prefix"] = (
+                        f"{prefix}{hyperparameter.subbrick_hyperparameter}."
+                        f"{suggested_and_fixed_hyperparameters[hyperparameter.subbrick_hyperparameter].__name__}."
+                    )
                 elif hyperparameter.subbrick_hyperparameter in skipped_hyperparameters:
                     # subbrick_kwargs must be skipped if subbrick itself is skipped
                     skipped_hyperparameters.add(name)

--- a/tests/generic_tools/hyperparameters/test_hyperparameter.py
+++ b/tests/generic_tools/hyperparameters/test_hyperparameter.py
@@ -62,7 +62,7 @@ class DummySolverWithDependencies(SolverDO):
 
 class DummySolver2(SolverDO):
     hyperparameters = [
-        IntegerHyperparameter("nb", low=0, high=3, default=1),
+        CategoricalHyperparameter("nb", choices=[0, 1, 2, 3], default=1),
         FloatHyperparameter("coeff2", low=-1.0, high=1.0, default=1.0),
         FloatHyperparameter("coeff3", low=-1.0, high=1.0, default=1.0),
     ]
@@ -280,9 +280,17 @@ def test_suggest_with_optuna_meta_solver():
         assert "nb" in suggested_hyperparameters_kwargs
         assert "nb" in suggested_hyperparameters_kwargs["kwargs_subsolver"]
         assert "nb" in trial.params
-        assert "subsolver.nb" in trial.params
         assert (
-            trial.params["subsolver.nb"]
+            "subsolver.DummySolver.nb" in trial.params
+            or "subsolver.DummySolver2.nb" in trial.params
+        )
+        if "subsolver.DummySolver.nb" in trial.params:
+            param_name = "subsolver.DummySolver.nb"
+        else:
+            param_name = "subsolver.DummySolver2.nb"
+
+        assert (
+            trial.params[param_name]
             == suggested_hyperparameters_kwargs["kwargs_subsolver"]["nb"]
         )
 
@@ -325,14 +333,20 @@ def test_suggest_with_optuna_meta_solver_level2():
             in suggested_hyperparameters_kwargs["kwargs_subsolver"]["kwargs_subsolver"]
         )
         assert "nb" in trial.params
-        assert "subsolver.nb" in trial.params
-        assert "subsolver.subsolver.nb" in trial.params
+        assert "subsolver.MetaSolver.nb" in trial.params
         assert (
-            trial.params["subsolver.nb"]
-            == suggested_hyperparameters_kwargs["kwargs_subsolver"]["nb"]
+            "subsolver.MetaSolver.subsolver.DummySolver.nb" in trial.params
+            or "subsolver.MetaSolver.subsolver.DummySolver2.nb" in trial.params
         )
         assert (
-            trial.params["subsolver.subsolver.nb"]
+            trial.params["subsolver.MetaSolver.nb"]
+            == suggested_hyperparameters_kwargs["kwargs_subsolver"]["nb"]
+        )
+        param_name = "subsolver.MetaSolver.subsolver.DummySolver.nb"
+        if param_name not in trial.params:
+            param_name = "subsolver.MetaSolver.subsolver.DummySolver2.nb"
+        assert (
+            trial.params[param_name]
             == suggested_hyperparameters_kwargs["kwargs_subsolver"]["kwargs_subsolver"][
                 "nb"
             ]
@@ -389,9 +403,9 @@ def test_suggest_with_optuna_meta_solver_fixed_subsolver():
         assert "nb" in suggested_hyperparameters_kwargs
         assert "nb" in suggested_hyperparameters_kwargs["kwargs_subsolver"]
         assert "nb" in trial.params
-        assert "subsolver.nb" in trial.params
+        assert "subsolver.DummySolver.nb" in trial.params
         assert (
-            trial.params["subsolver.nb"]
+            trial.params["subsolver.DummySolver.nb"]
             == suggested_hyperparameters_kwargs["kwargs_subsolver"]["nb"]
         )
 


### PR DESCRIPTION
Optuna suggestion could raise error when a subbrick could take 2 different classes that have both an hyperparameter with same name but of a different kind. (For instance one being an `IntegerHyperparameter`, the other being a `CategoricalHyperparameter`).

To avoid this issue, we update the hyperparameter prefix when seen as a parameter of an optuna trial to include the actual class name of the chosen subbrick.

For example,

```python
class MySolver(SolverDO):
    hyperparameters = [
        SubBrickHyperparameter("subsolver", choices=[LPSolver, CPSolver]),
        SubBrickKwargsHyperparameter(
            "kwargs_subsolver", subbrick_hyperparameter="subsolver"
        ),
    ]

    ...

class LPSolver(SolverDO):
    hyperparameters = [
        CategoricalHyperparameter("hp", choices=[True, False]),
    ]
    ...

class CPSolver(SolverDO):
    hyperparameters = [
        IntegerHyperparameter("hp", low=0, high=10),
        FloatHyperparameter("coeff", low=0., high=1.),
    ]
    ...
```

Here the trial params will be

- first trial: `(subsolver, subsolver.LPSolver.hp)`
- second trial: `(subsolver, subsolver.CPSolver.hp, subsolver.CPSolver.coeff)`

We modify `DummySolver2` in test_hyperparameters.py so that the issue raised in the tests before the fix and the tests are ok with it.

NB: The issue could still arise if a subbrick could be of two different classes with same name (but from different modules) that also share same hyperparameter name of different type. This is higly unlikely to happen and could not justify having the whole path including the module to be inserted in the prefix. This would lead to a very unreadable parameter name in optuna trial.