### PR TITLE
Make use of `depends_on` to improve existing solvers hyperparameters definition

### DIFF
--- a/discrete_optimization/coloring/solvers/coloring_cpsat_solver.py
+++ b/discrete_optimization/coloring/solvers/coloring_cpsat_solver.py
@@ -36,13 +36,22 @@ class ColoringCPSatSolver(OrtoolsCPSatSolver, SolverColoringWithStartingSolution
             name="warmstart", choices=[True, False], default=True
         ),
         CategoricalHyperparameter(
-            name="value_sequence_chain", choices=[True, False], default=False
+            name="value_sequence_chain",
+            choices=[True, False],
+            default=False,
+            depends_on=("modeling", [ModelingCPSat.INTEGER]),
         ),
         CategoricalHyperparameter(
-            name="used_variable", choices=[True, False], default=False
+            name="used_variable",
+            choices=[True, False],
+            default=False,
+            depends_on=("modeling", [ModelingCPSat.INTEGER]),
         ),
         CategoricalHyperparameter(
-            name="symmetry_on_used", choices=[True, False], default=True
+            name="symmetry_on_used",
+            choices=[True, False],
+            default=True,
+            depends_on=("modeling", [ModelingCPSat.INTEGER]),
         ),
     ] + SolverColoringWithStartingSolution.hyperparameters
 

--- a/discrete_optimization/coloring/solvers/coloring_solver_with_starting_solution.py
+++ b/discrete_optimization/coloring/solvers/coloring_solver_with_starting_solution.py
@@ -24,11 +24,12 @@ logger = logging.getLogger(__name__)
 
 class SolverColoringWithStartingSolution(SolverColoring):
     hyperparameters = [
-        CategoricalHyperparameter("greedy_start", choices=[True], default=True),
+        CategoricalHyperparameter("greedy_start", choices=[True, False], default=True),
         EnumHyperparameter(
             "greedy_method",
             enum=NXGreedyColoringMethod,
             default=NXGreedyColoringMethod.best,
+            depends_on=("greedy_start", [True]),
         ),
     ]
 

--- a/discrete_optimization/coloring/solvers/coloring_toulbar_solver.py
+++ b/discrete_optimization/coloring/solvers/coloring_toulbar_solver.py
@@ -36,9 +36,18 @@ class ToulbarColoringSolver(SolverColoringWithStartingSolution):
             name="value_sequence_chain", choices=[True, False], default=False
         ),
         CategoricalHyperparameter(
-            name="hard_value_sequence_chain", choices=[True, False], default=False
+            name="hard_value_sequence_chain",
+            choices=[True, False],
+            default=False,
+            depends_on=("value_sequence_chain", [True]),
         ),
-        IntegerHyperparameter(name="tolerance_delta_max", low=0, high=2, default=1),
+        IntegerHyperparameter(
+            name="tolerance_delta_max",
+            low=0,
+            high=2,
+            default=1,
+            depends_on=("value_sequence_chain", [True]),
+        ),
     ]
     model: Optional[pytoulbar2.CFN] = None
 

--- a/discrete_optimization/facility/solvers/facility_lp_solver.py
+++ b/discrete_optimization/facility/solvers/facility_lp_solver.py
@@ -122,8 +122,20 @@ class _LPFacilitySolverBase(MilpSolver, SolverFacility):
         CategoricalHyperparameter(
             name="use_matrix_indicator_heuristic", default=True, choices=[False, True]
         ),
-        IntegerHyperparameter(name="n_shortest", default=10, low=0, high=100),
-        IntegerHyperparameter(name="n_cheapest", default=10, low=0, high=100),
+        IntegerHyperparameter(
+            name="n_shortest",
+            default=10,
+            low=0,
+            high=100,
+            depends_on=("use_matrix_indicator_heuristic", [True]),
+        ),
+        IntegerHyperparameter(
+            name="n_cheapest",
+            default=10,
+            low=0,
+            high=100,
+            depends_on=("use_matrix_indicator_heuristic", [True]),
+        ),
     ]
 
     def __init__(

--- a/discrete_optimization/generic_rcpsp_tools/large_neighborhood_search_scheduling.py
+++ b/discrete_optimization/generic_rcpsp_tools/large_neighborhood_search_scheduling.py
@@ -489,11 +489,33 @@ class LargeNeighborhoodSearchScheduling(LNS_CP, SolverGenericRCPSP):
             default=ConstraintHandlerType.MIX_SUBPROBLEMS,
         ),
         FloatHyperparameter(
-            name="fraction_subproblem", default=0.05, low=0.0, high=1.0
+            name="fraction_subproblem",
+            default=0.05,
+            low=0.0,
+            high=1.0,
+            depends_on=(
+                "constraint_handler_type",
+                [ConstraintHandlerType.MIX_SUBPROBLEMS],
+            ),
         ),
-        IntegerHyperparameter(name="nb_cut_part", default=10, low=0, high=100),
+        IntegerHyperparameter(
+            name="nb_cut_part",
+            default=10,
+            low=0,
+            high=100,
+            depends_on=(
+                "constraint_handler_type",
+                [ConstraintHandlerType.MIX_SUBPROBLEMS],
+            ),
+        ),
         CategoricalHyperparameter(
-            name="use_makespan_of_subtasks", choices=[True, False], default=False
+            name="use_makespan_of_subtasks",
+            choices=[True, False],
+            default=False,
+            depends_on=(
+                "constraint_handler_type",
+                [ConstraintHandlerType.MIX_SUBPROBLEMS],
+            ),
         ),
         SubBrickHyperparameter(
             name="params_0_cls",

--- a/discrete_optimization/generic_rcpsp_tools/ls_solver.py
+++ b/discrete_optimization/generic_rcpsp_tools/ls_solver.py
@@ -58,7 +58,13 @@ class LS_RCPSP_Solver(SolverGenericRCPSP):
             name="init_solution_process", choices=[True, False], default=False
         ),
         EnumHyperparameter(name="ls_solver", enum=LS_SOLVER, default=LS_SOLVER.SA),
-        FloatHyperparameter(name="temperature", low=0.01, high=10, default=3),
+        FloatHyperparameter(
+            name="temperature",
+            low=0.01,
+            high=10,
+            default=3,
+            depends_on=("ls_solver", [LS_SOLVER.SA]),
+        ),
         IntegerHyperparameter(
             name="nb_iteration_no_improvement", low=10, high=2000, default=200
         ),

--- a/discrete_optimization/generic_rcpsp_tools/neighbor_tools_rcpsp.py
+++ b/discrete_optimization/generic_rcpsp_tools/neighbor_tools_rcpsp.py
@@ -90,6 +90,7 @@ class ParamsConstraintBuilder(Hyperparametrizable):
             name="except_assigned_multiskill_primary_set",
             choices=[True, False],
             default=False,
+            depends_on=("first_method_multiskill", [True]),
         ),
         CategoricalHyperparameter(
             name="first_method_multiskill", choices=[True, False], default=True

--- a/discrete_optimization/generic_tools/lns_tools.py
+++ b/discrete_optimization/generic_tools/lns_tools.py
@@ -111,7 +111,10 @@ class BaseLNS(SolverDO):
             "subsolver_kwargs", subbrick_hyperparameter="subsolver_cls"
         ),
         SubBrickHyperparameter(
-            "initial_solution_provider_cls", choices=[], default=None
+            "initial_solution_provider_cls",
+            choices=[],
+            default=None,
+            depends_on=("skip_first_iteration", [False]),
         ),
         SubBrickKwargsHyperparameter(
             "initial_solution_provider_kwargs",


### PR DESCRIPTION
We specify the dependencies between some hyperparameters to avoid having optuna suggest algorithmically identical trials, whenever the simple `depends_on` current syntax (a single parent hyperparameter with a set of possible values) is sufficient.