### PR TITLE
Remove unused imports

### DIFF
--- a/discrete_optimization/coloring/solvers/coloring_asp_solver.py
+++ b/discrete_optimization/coloring/solvers/coloring_asp_solver.py
@@ -3,20 +3,15 @@
 #  LICENSE file in the root directory of this source tree.
 import logging
 import os
-import time
 from typing import Any, List, Optional
 
 import clingo
-from clingo import Symbol
 
 from discrete_optimization.coloring.coloring_model import ColoringSolution
 from discrete_optimization.coloring.solvers.coloring_solver_with_starting_solution import (
     SolverColoringWithStartingSolution,
 )
 from discrete_optimization.generic_tools.asp_tools import ASPClingoSolver
-from discrete_optimization.generic_tools.result_storage.result_storage import (
-    ResultStorage,
-)
 
 cur_folder = os.path.abspath(os.path.dirname(__file__))
 logger = logging.getLogger(__name__)

--- a/discrete_optimization/coloring/solvers/coloring_cp_lns.py
+++ b/discrete_optimization/coloring/solvers/coloring_cp_lns.py
@@ -3,7 +3,7 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import List, Optional
+from typing import Optional
 
 from discrete_optimization.coloring.coloring_model import ColoringProblem
 from discrete_optimization.coloring.solvers.coloring_cp_lns_solvers import (
@@ -17,25 +17,14 @@ from discrete_optimization.coloring.solvers.coloring_cp_solvers import (
     ColoringCPModel,
 )
 from discrete_optimization.coloring.solvers.coloring_solver import SolverColoring
-from discrete_optimization.generic_tools.callbacks.callback import Callback
-from discrete_optimization.generic_tools.cp_tools import MinizincCPSolver, ParametersCP
+from discrete_optimization.generic_tools.cp_tools import MinizincCPSolver
 from discrete_optimization.generic_tools.do_problem import ParamsObjectiveFunction
-from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
-    SubBrickHyperparameter,
-    SubBrickKwargsHyperparameter,
-)
-from discrete_optimization.generic_tools.lns_cp import (
-    LNS_CP,
-    MznConstraintHandler,
-    TrivialPostProcessSolution,
-)
+from discrete_optimization.generic_tools.lns_cp import LNS_CP, MznConstraintHandler
 from discrete_optimization.generic_tools.lns_mip import (
     InitialSolution,
     PostProcessSolution,
 )
-from discrete_optimization.generic_tools.result_storage.result_storage import (
-    ResultStorage,
-)
+from discrete_optimization.generic_tools.lns_tools import TrivialPostProcessSolution
 
 
 def build_default_cp_model(coloring_model: ColoringProblem, **kwargs):

--- a/discrete_optimization/coloring/solvers/coloring_cp_solvers.py
+++ b/discrete_optimization/coloring/solvers/coloring_cp_solvers.py
@@ -10,7 +10,7 @@ CP formulation rely on minizinc models stored in coloring/minizinc folder.
 import logging
 import os
 from enum import Enum
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, Optional
 
 import networkx as nx
 import pymzn

--- a/discrete_optimization/coloring/solvers/coloring_solver_with_starting_solution.py
+++ b/discrete_optimization/coloring/solvers/coloring_solver_with_starting_solution.py
@@ -5,10 +5,7 @@
 import logging
 from typing import Any
 
-from discrete_optimization.coloring.coloring_model import (
-    ColoringProblem,
-    ColoringSolution,
-)
+from discrete_optimization.coloring.coloring_model import ColoringSolution
 from discrete_optimization.coloring.solvers.coloring_solver import SolverColoring
 from discrete_optimization.coloring.solvers.greedy_coloring import (
     GreedyColoring,

--- a/discrete_optimization/facility/facility_model.py
+++ b/discrete_optimization/facility/facility_model.py
@@ -12,7 +12,6 @@ capacity of the facility.
 
 import math
 from abc import abstractmethod
-from collections import namedtuple
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Type

--- a/discrete_optimization/facility/facility_parser.py
+++ b/discrete_optimization/facility/facility_parser.py
@@ -9,7 +9,6 @@ from discrete_optimization.datasets import get_data_home
 from discrete_optimization.facility.facility_model import (
     Customer,
     Facility,
-    FacilityProblem,
     FacilityProblem2DPoints,
     Point,
 )

--- a/discrete_optimization/facility/solvers/facility_cp_solvers.py
+++ b/discrete_optimization/facility/solvers/facility_cp_solvers.py
@@ -7,7 +7,6 @@ import os
 from enum import Enum
 from typing import Any, Optional
 
-from deprecation import deprecated
 from minizinc import Instance, Model, Solver
 
 from discrete_optimization.facility.facility_model import (
@@ -18,9 +17,6 @@ from discrete_optimization.facility.solvers.facility_lp_solver import (
     compute_length_matrix,
 )
 from discrete_optimization.facility.solvers.facility_solver import SolverFacility
-from discrete_optimization.facility.solvers.greedy_solvers import (
-    GreedySolverDistanceBased,
-)
 from discrete_optimization.generic_tools.cp_tools import (
     CPSolverName,
     MinizincCPSolver,

--- a/discrete_optimization/facility/solvers/facility_lp_solver.py
+++ b/discrete_optimization/facility/solvers/facility_lp_solver.py
@@ -20,7 +20,6 @@ from discrete_optimization.facility.solvers.facility_solver import SolverFacilit
 from discrete_optimization.generic_tools.do_problem import ParamsObjectiveFunction
 from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
     CategoricalHyperparameter,
-    EnumHyperparameter,
     IntegerHyperparameter,
 )
 from discrete_optimization.generic_tools.lp_tools import (

--- a/discrete_optimization/facility/solvers/greedy_solvers.py
+++ b/discrete_optimization/facility/solvers/greedy_solvers.py
@@ -2,7 +2,7 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Any, Optional, Sequence
+from typing import Any, Optional
 
 import numpy as np
 import numpy.typing as npt

--- a/discrete_optimization/generic_rcpsp_tools/generic_rcpsp_solver.py
+++ b/discrete_optimization/generic_rcpsp_tools/generic_rcpsp_solver.py
@@ -2,7 +2,6 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Any
 
 from discrete_optimization.generic_rcpsp_tools.typing import ANY_RCPSP
 from discrete_optimization.generic_tools.do_solver import SolverDO

--- a/discrete_optimization/generic_tools/asp_tools.py
+++ b/discrete_optimization/generic_tools/asp_tools.py
@@ -7,7 +7,6 @@ from abc import abstractmethod
 from typing import Any, List, Optional
 
 import clingo
-from clingo import Symbol
 
 from discrete_optimization.generic_tools.callbacks.callback import (
     Callback,

--- a/discrete_optimization/generic_tools/callbacks/backup.py
+++ b/discrete_optimization/generic_tools/callbacks/backup.py
@@ -4,7 +4,6 @@
 
 import logging
 import pickle
-from datetime import datetime
 from typing import Optional
 
 from discrete_optimization.generic_tools.callbacks.callback import Callback

--- a/discrete_optimization/generic_tools/callbacks/loggers.py
+++ b/discrete_optimization/generic_tools/callbacks/loggers.py
@@ -3,7 +3,6 @@
 #  LICENSE file in the root directory of this source tree.
 
 import logging
-from datetime import datetime
 from typing import Optional
 
 from discrete_optimization.generic_tools.callbacks.callback import Callback

--- a/discrete_optimization/generic_tools/cp_tools.py
+++ b/discrete_optimization/generic_tools/cp_tools.py
@@ -16,7 +16,7 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Type, Union
 
 import minizinc
-from minizinc import Instance, Result, Status
+from minizinc import Instance, Status
 
 from discrete_optimization.generic_tools.callbacks.callback import (
     Callback,

--- a/discrete_optimization/generic_tools/do_problem.py
+++ b/discrete_optimization/generic_tools/do_problem.py
@@ -18,7 +18,6 @@ from typing import (
     Sequence,
     Tuple,
     Type,
-    TypeVar,
     Union,
 )
 

--- a/discrete_optimization/generic_tools/do_solver.py
+++ b/discrete_optimization/generic_tools/do_solver.py
@@ -67,7 +67,7 @@ class SolverDO(Hyperparametrizable):
         Can initialize a ortools, milp, gurobi, ... model.
 
         """
-        pass
+        ...
 
     def is_optimal(self) -> Optional[bool]:
         """Tell if found solution is supposed to be optimal.

--- a/discrete_optimization/generic_tools/ea/ga.py
+++ b/discrete_optimization/generic_tools/ea/ga.py
@@ -5,7 +5,7 @@
 import logging
 import random
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 from deap import algorithms, base, creator, tools

--- a/discrete_optimization/generic_tools/ea/nsga.py
+++ b/discrete_optimization/generic_tools/ea/nsga.py
@@ -22,11 +22,7 @@ from discrete_optimization.generic_tools.do_problem import (
 )
 from discrete_optimization.generic_tools.do_solver import SolverDO
 from discrete_optimization.generic_tools.ea.deap_wrappers import generic_mutate_wrapper
-from discrete_optimization.generic_tools.ea.ga import (
-    DeapCrossover,
-    DeapMutation,
-    DeapSelection,
-)
+from discrete_optimization.generic_tools.ea.ga import DeapCrossover, DeapMutation
 from discrete_optimization.generic_tools.result_storage.result_storage import (
     ResultStorage,
     TupleFitness,

--- a/discrete_optimization/generic_tools/lns_cp.py
+++ b/discrete_optimization/generic_tools/lns_cp.py
@@ -11,37 +11,17 @@ from typing import Any, Dict, Iterable, List, Optional
 import numpy as np
 from minizinc import Instance
 
-from discrete_optimization.generic_tools.callbacks.callback import (
-    Callback,
-    CallbackList,
-)
-from discrete_optimization.generic_tools.cp_tools import (
-    CPSolver,
-    MinizincCPSolver,
-    ParametersCP,
-    StatusSolver,
-)
+from discrete_optimization.generic_tools.callbacks.callback import Callback
+from discrete_optimization.generic_tools.cp_tools import MinizincCPSolver, ParametersCP
 from discrete_optimization.generic_tools.do_problem import (
-    ModeOptim,
     ParamsObjectiveFunction,
     Problem,
-)
-from discrete_optimization.generic_tools.do_solver import SolverDO
-from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
-    CategoricalHyperparameter,
-    IntegerHyperparameter,
-    SubBrickHyperparameter,
-    SubBrickKwargsHyperparameter,
-)
-from discrete_optimization.generic_tools.hyperparameters.hyperparametrizable import (
-    Hyperparametrizable,
 )
 from discrete_optimization.generic_tools.lns_tools import (
     BaseLNS,
     ConstraintHandler,
     InitialSolution,
     PostProcessSolution,
-    TrivialPostProcessSolution,
 )
 from discrete_optimization.generic_tools.result_storage.result_storage import (
     ResultStorage,

--- a/discrete_optimization/generic_tools/lns_mip.py
+++ b/discrete_optimization/generic_tools/lns_mip.py
@@ -3,34 +3,18 @@
 #  LICENSE file in the root directory of this source tree.
 
 import logging
-import time
-from abc import abstractmethod
-from typing import Any, Hashable, List, Mapping, Optional
+from typing import Any, List, Optional
 
-from discrete_optimization.generic_tools.callbacks.callback import (
-    Callback,
-    CallbackList,
-)
+from discrete_optimization.generic_tools.callbacks.callback import Callback
 from discrete_optimization.generic_tools.do_problem import (
-    ModeOptim,
     ParamsObjectiveFunction,
     Problem,
-)
-from discrete_optimization.generic_tools.do_solver import SolverDO
-from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
-    CategoricalHyperparameter,
-    SubBrickHyperparameter,
-    SubBrickKwargsHyperparameter,
-)
-from discrete_optimization.generic_tools.hyperparameters.hyperparametrizable import (
-    Hyperparametrizable,
 )
 from discrete_optimization.generic_tools.lns_tools import (
     BaseLNS,
     ConstraintHandler,
     InitialSolution,
     PostProcessSolution,
-    TrivialPostProcessSolution,
 )
 from discrete_optimization.generic_tools.lp_tools import MilpSolver, ParametersMilp
 from discrete_optimization.generic_tools.result_storage.result_storage import (

--- a/discrete_optimization/generic_tools/lns_tools.py
+++ b/discrete_optimization/generic_tools/lns_tools.py
@@ -3,7 +3,6 @@
 #  LICENSE file in the root directory of this source tree.
 import contextlib
 import logging
-import time
 from abc import abstractmethod
 from typing import Any, Hashable, List, Mapping, Optional
 
@@ -25,7 +24,6 @@ from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
 from discrete_optimization.generic_tools.hyperparameters.hyperparametrizable import (
     Hyperparametrizable,
 )
-from discrete_optimization.generic_tools.lp_tools import MilpSolver, ParametersMilp
 from discrete_optimization.generic_tools.result_storage.result_storage import (
     ResultStorage,
 )

--- a/discrete_optimization/generic_tools/lp_tools.py
+++ b/discrete_optimization/generic_tools/lp_tools.py
@@ -33,9 +33,6 @@ else:
 
 try:
     import docplex
-    from docplex.mp.constr import LinearConstraint
-    from docplex.mp.dvar import Var
-    from docplex.mp.model import Model
     from docplex.mp.progress import SolutionListener
     from docplex.mp.solution import SolveSolution
 except ImportError:
@@ -177,18 +174,15 @@ class MilpSolver(SolverDO):
     @abstractmethod
     def get_var_value_for_ith_solution(self, var: Any, i: int) -> float:
         """Get value for i-th solution of a given variable."""
-        pass
 
     @abstractmethod
     def get_obj_value_for_ith_solution(self, i: int) -> float:
         """Get objective value for i-th solution."""
-        pass
 
     @property
     @abstractmethod
     def nb_solutions(self) -> int:
         """Number of solutions found by the solver."""
-        pass
 
 
 class PymipMilpSolver(MilpSolver):

--- a/discrete_optimization/generic_tools/ls/hill_climber.py
+++ b/discrete_optimization/generic_tools/ls/hill_climber.py
@@ -3,8 +3,6 @@
 #  LICENSE file in the root directory of this source tree.
 
 import logging
-import pickle
-import time
 from typing import Any, List, Optional
 
 from discrete_optimization.generic_tools.callbacks.callback import (
@@ -17,7 +15,6 @@ from discrete_optimization.generic_tools.do_problem import (
     ParamsObjectiveFunction,
     Problem,
     Solution,
-    build_evaluate_function_aggregated,
 )
 from discrete_optimization.generic_tools.do_solver import SolverDO
 from discrete_optimization.generic_tools.ls.local_search import (

--- a/discrete_optimization/generic_tools/ls/simulated_annealing.py
+++ b/discrete_optimization/generic_tools/ls/simulated_annealing.py
@@ -3,9 +3,7 @@
 #  LICENSE file in the root directory of this source tree.
 
 import logging
-import pickle
 import random
-import time
 from abc import abstractmethod
 from typing import Any, Callable, Dict, List, Optional
 

--- a/discrete_optimization/generic_tools/pytools/timeout_decorator.py
+++ b/discrete_optimization/generic_tools/pytools/timeout_decorator.py
@@ -9,9 +9,7 @@
 from __future__ import print_function
 
 import logging
-import sys
 import threading
-from time import sleep
 
 try:
     import thread

--- a/discrete_optimization/knapsack/mutation/mutation_knapsack.py
+++ b/discrete_optimization/knapsack/mutation/mutation_knapsack.py
@@ -3,7 +3,7 @@
 #  LICENSE file in the root directory of this source tree.
 
 import random
-from typing import Dict, List, Optional, Tuple, cast
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 

--- a/discrete_optimization/knapsack/solvers/cp_solvers.py
+++ b/discrete_optimization/knapsack/solvers/cp_solvers.py
@@ -364,4 +364,3 @@ class KnapConstraintHandler(MznConstraintHandler):
             raise ValueError(
                 "cp_solver must a CPMultidimensionalMultiScenarioSolver for this constraint."
             )
-        pass

--- a/discrete_optimization/knapsack/solvers/dyn_prog_knapsack.py
+++ b/discrete_optimization/knapsack/solvers/dyn_prog_knapsack.py
@@ -4,11 +4,10 @@
 
 import logging
 import time
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 import numpy as np
 
-from discrete_optimization.generic_tools.callbacks.callback import Callback
 from discrete_optimization.generic_tools.do_problem import ParamsObjectiveFunction
 from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
     CategoricalHyperparameter,

--- a/discrete_optimization/knapsack/solvers/gphh_knapsack.py
+++ b/discrete_optimization/knapsack/solvers/gphh_knapsack.py
@@ -9,12 +9,10 @@ from typing import Any, Callable, Dict, List, Optional, Union
 import matplotlib.pyplot as plt
 import networkx as nx
 import numpy as np
-import numpy.typing as npt
 from deap import algorithms, creator, gp, tools
 from deap.base import Fitness, Toolbox
 from deap.gp import (
     Primitive,
-    PrimitiveSet,
     PrimitiveSetTyped,
     PrimitiveTree,
     Terminal,

--- a/discrete_optimization/knapsack/solvers/knapsack_asp_solver.py
+++ b/discrete_optimization/knapsack/solvers/knapsack_asp_solver.py
@@ -3,16 +3,11 @@
 #  LICENSE file in the root directory of this source tree.
 import logging
 import os
-import time
-from typing import Any, List, Optional
+from typing import Any
 
 import clingo
-from clingo import Symbol
 
 from discrete_optimization.generic_tools.asp_tools import ASPClingoSolver
-from discrete_optimization.generic_tools.result_storage.result_storage import (
-    ResultStorage,
-)
 from discrete_optimization.knapsack.knapsack_model import KnapsackSolution
 from discrete_optimization.knapsack.solvers.knapsack_solver import SolverKnapsack
 

--- a/discrete_optimization/knapsack/solvers/knapsack_lns_cp_solver.py
+++ b/discrete_optimization/knapsack/solvers/knapsack_lns_cp_solver.py
@@ -76,4 +76,3 @@ class ConstraintHandlerKnapsack(MznConstraintHandler):
     ) -> None:
         if not isinstance(solver, CPKnapsackMZN2):
             raise ValueError("cp_solver must a CPKnapsackMZN2 for this constraint.")
-        pass

--- a/discrete_optimization/pickup_vrp/gpdp.py
+++ b/discrete_optimization/pickup_vrp/gpdp.py
@@ -7,18 +7,7 @@
 # February 1995 Transportation Science 29(1):17-29
 # https://www.researchgate.net/publication/239063487_The_General_Pickup_and_Delivery_Problem
 import logging
-from typing import (
-    Any,
-    Dict,
-    Hashable,
-    KeysView,
-    List,
-    Optional,
-    Set,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import Any, Dict, Hashable, KeysView, List, Optional, Set, Tuple, Type
 
 import networkx as nx
 import numpy as np

--- a/discrete_optimization/pickup_vrp/solver/lp_solver.py
+++ b/discrete_optimization/pickup_vrp/solver/lp_solver.py
@@ -21,7 +21,6 @@ from typing import (
     cast,
 )
 
-import matplotlib.pyplot as plt
 import networkx as nx
 
 from discrete_optimization.generic_tools.callbacks.callback import (

--- a/discrete_optimization/pickup_vrp/solver/lp_solver_pymip.py
+++ b/discrete_optimization/pickup_vrp/solver/lp_solver_pymip.py
@@ -34,7 +34,7 @@ from discrete_optimization.generic_tools.result_storage.result_storage import (
     ResultStorage,
     TupleFitness,
 )
-from discrete_optimization.pickup_vrp.gpdp import GPDP, Edge, GPDPSolution, Node
+from discrete_optimization.pickup_vrp.gpdp import GPDP, Edge, Node
 from discrete_optimization.pickup_vrp.solver.lp_solver import (
     TemporaryResult,
     build_graph_solution,

--- a/discrete_optimization/rcpsp/fast_function_rcpsp.py
+++ b/discrete_optimization/rcpsp/fast_function_rcpsp.py
@@ -1228,7 +1228,6 @@ def sgs_fast_partial_schedule_preemptive_minduration(
                         )
                     ):
                         logger.debug("passed")
-                        pass
                     else:
                         starts.append(current_min_time)
                         ends.append(reached_t + 1)

--- a/discrete_optimization/rcpsp/rcpsp_utils.py
+++ b/discrete_optimization/rcpsp/rcpsp_utils.py
@@ -20,8 +20,6 @@ from typing import (
     Union,
 )
 
-import matplotlib
-import matplotlib.cm
 import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
@@ -646,7 +644,6 @@ def get_start_bounds_from_additional_constraint(
                     ub = min(ub, ubs - min_duration)
     if ub < 0:
         print(ub)
-        pass
     return int(lb), int(ub)
 
 

--- a/discrete_optimization/rcpsp/robust_rcpsp.py
+++ b/discrete_optimization/rcpsp/robust_rcpsp.py
@@ -12,7 +12,6 @@ from scipy.stats import poisson, randint, rv_discrete
 from discrete_optimization.generic_tools.do_problem import (
     MethodAggregating,
     RobustProblem,
-    Solution,
 )
 from discrete_optimization.rcpsp import RCPSPModel
 from discrete_optimization.rcpsp.rcpsp_solution import RCPSPSolution

--- a/discrete_optimization/rcpsp/solver/cp_solvers.py
+++ b/discrete_optimization/rcpsp/solver/cp_solvers.py
@@ -22,10 +22,6 @@ from discrete_optimization.generic_tools.do_problem import (
     ParamsObjectiveFunction,
     build_aggreg_function_and_params_objective,
 )
-from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
-    CategoricalHyperparameter,
-    EnumHyperparameter,
-)
 from discrete_optimization.rcpsp.rcpsp_model import RCPSPModel
 from discrete_optimization.rcpsp.rcpsp_model_preemptive import (
     RCPSPModelPreemptive,

--- a/discrete_optimization/rcpsp/solver/cp_solvers_multiscenario.py
+++ b/discrete_optimization/rcpsp/solver/cp_solvers_multiscenario.py
@@ -4,7 +4,7 @@
 
 import logging
 import os
-from typing import Any, List, Optional, Union
+from typing import Any, Optional, Union
 
 from minizinc import Instance, Model, Solver
 

--- a/discrete_optimization/rcpsp/solver/rcpsp_lp_solver_gantt.py
+++ b/discrete_optimization/rcpsp/solver/rcpsp_lp_solver_gantt.py
@@ -12,7 +12,6 @@ from mip import BINARY, MINIMIZE, Model, xsum
 from discrete_optimization.generic_tools.do_problem import (
     ModeOptim,
     ParamsObjectiveFunction,
-    Solution,
 )
 from discrete_optimization.generic_tools.lp_tools import (
     GurobiMilpSolver,

--- a/discrete_optimization/rcpsp/specialized_rcpsp/rcpsp_specialized_constraints.py
+++ b/discrete_optimization/rcpsp/specialized_rcpsp/rcpsp_specialized_constraints.py
@@ -26,7 +26,6 @@ from discrete_optimization.rcpsp.fast_function_rcpsp import (
     sgs_fast_preemptive_minduration,
     sgs_fast_preemptive_some_special_constraints,
 )
-from discrete_optimization.rcpsp.rcpsp_model import RCPSPModel
 from discrete_optimization.rcpsp.rcpsp_model_preemptive import (
     RCPSPModelPreemptive,
     RCPSPSolutionPreemptive,

--- a/discrete_optimization/rcpsp_multiskill/solvers/cp_solver_mspsp_instlib.py
+++ b/discrete_optimization/rcpsp_multiskill/solvers/cp_solver_mspsp_instlib.py
@@ -7,7 +7,7 @@
 
 import logging
 import os
-from typing import Any, Dict, Hashable, Optional, Set
+from typing import Any, Hashable, Optional, Set
 
 from minizinc import Instance, Model, Solver
 

--- a/discrete_optimization/rcpsp_multiskill/solvers/cp_solvers.py
+++ b/discrete_optimization/rcpsp_multiskill/solvers/cp_solvers.py
@@ -9,7 +9,7 @@ from datetime import timedelta
 from enum import Enum
 from typing import Any, Dict, Hashable, List, Optional, Set, Tuple, Union
 
-from minizinc import Instance, Model, Solver, Status
+from minizinc import Instance, Model, Solver
 
 from discrete_optimization.generic_rcpsp_tools.graph_tools_rcpsp import (
     build_graph_rcpsp_object,

--- a/discrete_optimization/tsp/mutation/mutation_tsp.py
+++ b/discrete_optimization/tsp/mutation/mutation_tsp.py
@@ -11,7 +11,6 @@ from discrete_optimization.generic_tools.do_mutation import (
     Mutation,
 )
 from discrete_optimization.tsp.tsp_model import (
-    Point,
     Point2D,
     SolutionTSP,
     TSPModel,

--- a/discrete_optimization/tsp/tsp_model.py
+++ b/discrete_optimization/tsp/tsp_model.py
@@ -5,7 +5,6 @@
 import math
 import random
 from abc import abstractmethod
-from copy import deepcopy
 from dataclasses import dataclass
 from functools import partial
 from typing import (

--- a/discrete_optimization/tsp/tsp_solvers.py
+++ b/discrete_optimization/tsp/tsp_solvers.py
@@ -2,7 +2,7 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, List, Sequence, Tuple, Type
+from typing import Any, Dict, List, Tuple, Type
 
 from discrete_optimization.generic_tools.cp_tools import CPSolverName
 from discrete_optimization.generic_tools.do_problem import Problem

--- a/discrete_optimization/vrp/solver/greedy_vrp.py
+++ b/discrete_optimization/vrp/solver/greedy_vrp.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from discrete_optimization.generic_tools.do_solver import ResultStorage
 from discrete_optimization.vrp.solver.vrp_solver import SolverVrp
-from discrete_optimization.vrp.vrp_model import VrpProblem, trivial_solution
+from discrete_optimization.vrp.vrp_model import trivial_solution
 
 
 class GreedyVRPSolver(SolverVrp):

--- a/discrete_optimization/vrp/solver/lp_vrp_iterative_pymip.py
+++ b/discrete_optimization/vrp/solver/lp_vrp_iterative_pymip.py
@@ -15,7 +15,6 @@ from discrete_optimization.generic_tools.do_solver import ResultStorage
 from discrete_optimization.generic_tools.mip.pymip_tools import MyModelMilp
 from discrete_optimization.vrp.solver.lp_vrp_iterative import (
     build_graph_pruned_vrp,
-    build_the_cycles,
     build_warm_edges_and_update_graph,
     compute_start_end_flows_info,
     plot_solve,

--- a/discrete_optimization/vrp/solver/solver_ortools.py
+++ b/discrete_optimization/vrp/solver/solver_ortools.py
@@ -13,7 +13,7 @@ from ortools.constraint_solver import pywrapcp, routing_enums_pb2
 
 from discrete_optimization.generic_tools.do_solver import ResultStorage
 from discrete_optimization.vrp.solver.vrp_solver import SolverVrp
-from discrete_optimization.vrp.vrp_model import VrpProblem, VrpSolution
+from discrete_optimization.vrp.vrp_model import VrpSolution
 from discrete_optimization.vrp.vrp_toolbox import build_graph
 
 logger = logging.getLogger(__name__)

--- a/discrete_optimization/vrp/vrp_toolbox.py
+++ b/discrete_optimization/vrp/vrp_toolbox.py
@@ -3,7 +3,6 @@
 #  LICENSE file in the root directory of this source tree.
 
 import logging
-from collections import namedtuple
 from typing import Tuple
 
 import networkx as nx


### PR DESCRIPTION
We pass the command

```shell
autoflake -r  --remove-all-unused-imports --in-place  discrete_optimization
```

And then revert some changes to keep import like :

```python
try:
    import gurobipy
except ImportError:
    gurobi_available = False
else:
    gurobi_available = True
    from gurobipy import GRB, LinExpr, Model
```

And change imports when it was not from the direct source: `from discrete_optimization.generic_tools.lns_cp import TrivialPostProcessSolution` -> `from discrete_optimization.generic_tools.lns_tools import TrivialPostProcessSolution`