### PR TITLE
Add Optuna utilities to generate and run studies on single problem instance and multiple problem instances 

### DIFF
--- a/discrete_optimization/generic_rcpsp_tools/large_neighborhood_search_scheduling.py
+++ b/discrete_optimization/generic_rcpsp_tools/large_neighborhood_search_scheduling.py
@@ -327,9 +327,8 @@ def build_constraint_handler(rcpsp_problem: ANY_RCPSP, graph, **kwargs):
                     constraint_max_time_to_current_solution=False,
                 )
             else:
-                params_0_cls = kwargs["params_0_cls"]
                 params_0_kwargs = kwargs["params_0_kwargs"]
-                params_0 = params_0_cls(**params_0_kwargs)
+                params_0 = ParamsConstraintBuilder(**params_0_kwargs)
             if kwargs["params_1_kwargs"] is None:
                 params_1 = ParamsConstraintBuilder(
                     minus_delta_primary=6000,
@@ -339,9 +338,8 @@ def build_constraint_handler(rcpsp_problem: ANY_RCPSP, graph, **kwargs):
                     constraint_max_time_to_current_solution=False,
                 )
             else:
-                params_1_cls = kwargs["params_1_cls"]
                 params_1_kwargs = kwargs["params_1_kwargs"]
-                params_1 = params_1_cls(**params_1_kwargs)
+                params_1 = ParamsConstraintBuilder(**params_1_kwargs)
             params_list = [params_0, params_1]
         constraint_handler = ConstraintHandlerScheduling(
             problem=rcpsp_problem,
@@ -362,9 +360,8 @@ def build_constraint_handler(rcpsp_problem: ANY_RCPSP, graph, **kwargs):
                     constraint_max_time_to_current_solution=False,
                 )
             else:
-                params_0_cls = kwargs["params_0_cls"]
                 params_0_kwargs = kwargs["params_0_kwargs"]
-                params_0 = params_0_cls(**params_0_kwargs)
+                params_0 = ParamsConstraintBuilder(**params_0_kwargs)
             if kwargs["params_1_kwargs"] is None:
                 params_1 = ParamsConstraintBuilder(
                     minus_delta_primary=5000,
@@ -374,9 +371,8 @@ def build_constraint_handler(rcpsp_problem: ANY_RCPSP, graph, **kwargs):
                     constraint_max_time_to_current_solution=False,
                 )
             else:
-                params_1_cls = kwargs["params_1_cls"]
                 params_1_kwargs = kwargs["params_1_kwargs"]
-                params_1 = params_1_cls(**params_1_kwargs)
+                params_1 = ParamsConstraintBuilder(**params_1_kwargs)
             params_list = [params_0, params_1]
         constraint_handler = NeighborRepairProblems(
             problem=rcpsp_problem, params_list=params_list
@@ -517,21 +513,11 @@ class LargeNeighborhoodSearchScheduling(LNS_CP, SolverGenericRCPSP):
                 [ConstraintHandlerType.MIX_SUBPROBLEMS],
             ),
         ),
-        SubBrickHyperparameter(
-            name="params_0_cls",
-            choices=[ParamsConstraintBuilder],
-            default=ParamsConstraintBuilder,
+        SubBrickKwargsHyperparameter(
+            name="params_0_kwargs", subbrick_cls=ParamsConstraintBuilder
         ),
         SubBrickKwargsHyperparameter(
-            name="params_0_kwargs", subbrick_hyperparameter="params_0_cls"
-        ),
-        SubBrickHyperparameter(
-            name="params_1_cls",
-            choices=[ParamsConstraintBuilder],
-            default=ParamsConstraintBuilder,
-        ),
-        SubBrickKwargsHyperparameter(
-            name="params_1_kwargs", subbrick_hyperparameter="params_1_cls"
+            name="params_1_kwargs", subbrick_cls=ParamsConstraintBuilder
         ),
     ]
 

--- a/discrete_optimization/generic_rcpsp_tools/neighbor_tools_rcpsp.py
+++ b/discrete_optimization/generic_rcpsp_tools/neighbor_tools_rcpsp.py
@@ -70,14 +70,22 @@ def get_max_time_solution(solution: ANY_SOLUTION):
 
 class ParamsConstraintBuilder(Hyperparametrizable):
     hyperparameters = [
-        IntegerHyperparameter(name="minus_delta_primary", low=0, default=100),
-        IntegerHyperparameter(name="plus_delta_primary", low=0, default=100),
-        IntegerHyperparameter(name="minus_delta_secondary", low=0, default=0),
-        IntegerHyperparameter(name="plus_delta_secondary", low=0, default=0),
-        IntegerHyperparameter(name="minus_delta_primary_duration", default=5, low=0),
-        IntegerHyperparameter(name="plus_delta_primary_duration", default=5, low=0),
-        IntegerHyperparameter(name="minus_delta_secondary_duration", default=5, low=0),
-        IntegerHyperparameter(name="plus_delta_secondary_duration", default=5, low=0),
+        IntegerHyperparameter(name="minus_delta_primary", low=0, default=100, high=200),
+        IntegerHyperparameter(name="plus_delta_primary", low=0, default=100, high=200),
+        IntegerHyperparameter(name="minus_delta_secondary", low=0, default=0, high=10),
+        IntegerHyperparameter(name="plus_delta_secondary", low=0, default=0, high=10),
+        IntegerHyperparameter(
+            name="minus_delta_primary_duration", default=5, low=0, high=10
+        ),
+        IntegerHyperparameter(
+            name="plus_delta_primary_duration", default=5, low=0, high=10
+        ),
+        IntegerHyperparameter(
+            name="minus_delta_secondary_duration", default=5, low=0, high=10
+        ),
+        IntegerHyperparameter(
+            name="plus_delta_secondary_duration", default=5, low=0, high=10
+        ),
         CategoricalHyperparameter(
             name="constraint_max_time_to_current_solution",
             choices=[True, False],

--- a/discrete_optimization/generic_tools/optuna/timed_percentile_pruner.py
+++ b/discrete_optimization/generic_tools/optuna/timed_percentile_pruner.py
@@ -20,6 +20,11 @@ try:
     import optuna
 except ImportError:
     logger.warning("You should install optuna to use TimedPercentilePruner for optuna.")
+
+    class TimedPercentilePruner:
+        def __init__(self, **kwargs):
+            raise RuntimeError("Cannot be instantiated if optuna is not installed.")
+
 else:
     from optuna.pruners import BasePruner
     from optuna.study._study_direction import StudyDirection

--- a/discrete_optimization/generic_tools/optuna/utils.py
+++ b/discrete_optimization/generic_tools/optuna/utils.py
@@ -201,12 +201,7 @@ def generic_optuna_experiment_monoproblem(
 
         try:
             # solver init
-            if solver_class.__name__ == "GPHH":
-                solver = solver_class(
-                    problem=problem, training_domains=[problem], **kwargs
-                )
-            else:
-                solver = solver_class(problem=problem, **kwargs)
+            solver = solver_class(problem=problem, **kwargs)
             solver.init_model(**kwargs)
 
             # init timer
@@ -456,12 +451,7 @@ def generic_optuna_experiment_multiproblem(
 
             try:
                 # solver init
-                if solver_class.__name__ == "GPHH":
-                    solver = solver_class(
-                        problem=problem, training_domains=[problem], **kwargs
-                    )
-                else:
-                    solver = solver_class(problem=problem, **kwargs)
+                solver = solver_class(problem=problem, **kwargs)
                 solver.init_model(**kwargs)
 
                 # solve

--- a/discrete_optimization/generic_tools/optuna/utils.py
+++ b/discrete_optimization/generic_tools/optuna/utils.py
@@ -511,16 +511,10 @@ def generic_optuna_experiment_multiproblem(
                     trial.set_user_attr(
                         "Error", f"Pruned by pruner at problem instance #{instance_id}."
                     )
-                    if report_cumulated_fitness:
-                        return cumulated_fitness
-                    else:
-                        return current_average
+                    return current_average
 
         trial.set_user_attr("pruned", False)
-        if report_cumulated_fitness:
-            return cumulated_fitness
-        else:
-            return sum(fitnesses) / len(fitnesses)
+        return sum(fitnesses) / len(fitnesses)
 
     # create study + database to store it
     storage = JournalStorage(JournalFileStorage(storage_path))

--- a/discrete_optimization/generic_tools/optuna/utils.py
+++ b/discrete_optimization/generic_tools/optuna/utils.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import time
 from collections import defaultdict
 from typing import Any, Dict, List, Optional, Type
@@ -43,6 +44,7 @@ def generic_optuna_experiment_monoproblem(
         Dict[Type[SolverDO], Dict[str, Dict[str, Any]]]
     ] = None,
     n_trials: int = 150,
+    check_satisfy: bool = True,
     computation_time_in_study: bool = True,
     study_basename: str = "study",
     create_another_study: bool = True,
@@ -53,7 +55,7 @@ def generic_optuna_experiment_monoproblem(
     seed: Optional[int] = None,
     min_time_per_solver: int = 5,
     callbacks: Optional[List[Callback]] = None,
-) -> None:
+) -> optuna.Study:
     """Create and run an optuna study to tune solvers hyperparameters on a given problem.
 
     The optuna study will choose a solver and its hyperparameters in order to optimize the fitness
@@ -79,6 +81,8 @@ def generic_optuna_experiment_monoproblem(
         suggest_optuna_kwargs_by_name_by_solver: kwargs_by_name passed to solvers' suggest_with_optuna().
             Useful to restrict or specify choices, step, high, ...
         n_trials: Number of trials to be run in the optuna study
+        check_satisfy: Decide wether checking if solution found satisfies the problem. If not satisfying,
+            we consider the trial as failed and prune it without reporting the value.
         computation_time_in_study: if `True` the intermediate reporting and pruning will be labelled according to elapsed time
             instead of solver internal iteration number.
         study_basename: Base name of the study generated.
@@ -223,6 +227,7 @@ def generic_optuna_experiment_monoproblem(
                 callbacks=callbacks_for_optuna,
                 **kwargs,
             )
+
         except Exception as e:
             if isinstance(e, optuna.TrialPruned):
                 raise e  # pruning error managed directly by optuna
@@ -238,7 +243,18 @@ def generic_optuna_experiment_monoproblem(
 
         # store result for this instance and report it as an intermediate value (=> dashboard + pruning)
         if len(res.list_solution_fits) != 0:
-            _, fit = res.get_best_solution_fit()
+            sol, fit = res.get_best_solution_fit()
+            # satisfy?
+            try:
+                if check_satisfy and not (problem.satisfy(sol)):
+                    msg = f"Solution found does not satisfy the problem."
+                    trial.set_user_attr("Error", msg)
+                    raise optuna.TrialPruned(msg)  # show failed
+            except Exception as e:
+                # Store exception message as trial user attribute
+                msg = f"{e.__class__}: {e}"
+                trial.set_user_attr("Error", msg)
+                raise optuna.TrialPruned(msg)  # show failed
         else:
             msg = f"No solution found."
             trial.set_user_attr("Error", msg)
@@ -262,6 +278,7 @@ def generic_optuna_experiment_monoproblem(
         load_if_exists=not overwrite_study,
     )
     study.optimize(objective, n_trials=n_trials)
+    return study
 
 
 def generic_optuna_experiment_multiproblem(
@@ -272,6 +289,7 @@ def generic_optuna_experiment_multiproblem(
         Dict[Type[SolverDO], Dict[str, Dict[str, Any]]]
     ] = None,
     n_trials: int = 150,
+    check_satisfy: bool = True,
     study_basename: str = "study",
     create_another_study: bool = True,
     overwrite_study=False,
@@ -279,8 +297,11 @@ def generic_optuna_experiment_multiproblem(
     sampler: Optional[BaseSampler] = None,
     pruner: Optional[BasePruner] = None,
     seed: Optional[int] = None,
+    prop_startup_instances: float = 0.2,
+    randomize_instances: bool = True,
+    report_cumulated_fitness: bool = False,
     callbacks: Optional[List[Callback]] = None,
-) -> None:
+) -> optuna.Study:
     """Create and run an optuna study to tune solvers hyperparameters on several instances of a problem.
 
     The optuna study will choose a solver and its hyperparameters in order to optimize the average fitness
@@ -303,6 +324,8 @@ def generic_optuna_experiment_multiproblem(
         suggest_optuna_kwargs_by_name_by_solver: kwargs_by_name passed to solvers' suggest_with_optuna().
             Useful to restrict or specify choices, step, high, ...
         n_trials: Number of trials to be run in the optuna study
+        check_satisfy: Decide wether checking if solution found satisfies the problem. If not satisfying,
+            we consider the trial as failed and prune it without reporting the value.
         study_basename: Base name of the study generated.
             If `create_another_study` is True, a timestamp will be added to this base name.
         create_another_study: if `True` a timestamp prefix will be added to the study base name in order to avoid
@@ -315,6 +338,11 @@ def generic_optuna_experiment_multiproblem(
         pruner: pruner used by the optuna study. If None, a WilcoxonPruner is used.
         seed: used to create the sampler if `sampler` is None. Should be set to an integer if one wants to ensure
             reproducible results.
+        prop_startup_instances: used if Pruner is None. Proportion of instances used to startup before allowing pruning.
+        randomize_instances: whether randomizing instances order when running a trial.
+            Should probably set to False if report_cumulated_fitness is set to True.
+        report_cumulated_fitness: whether reporting cumulated fitness instead of individual fitness for each problem instance.
+            Should be set to False when using WilcoxonPruner.
         callbacks: list of callbacks to plug in solvers' solve(). By default, use
             `ObjectiveLogger(step_verbosity_level=logging.INFO, end_verbosity_level=logging.INFO)`
 
@@ -329,7 +357,10 @@ def generic_optuna_experiment_multiproblem(
     if sampler is None:
         sampler = optuna.samplers.TPESampler(seed=seed)
     if pruner is None:
-        pruner = optuna.pruners.WilcoxonPruner(p_threshold=0.1)
+        n_startup_steps = math.ceil(prop_startup_instances * len(problems))
+        pruner = optuna.pruners.WilcoxonPruner(
+            p_threshold=0.1, n_startup_steps=n_startup_steps
+        )
     if callbacks is None:
         callbacks = [
             ObjectiveLogger(
@@ -337,6 +368,12 @@ def generic_optuna_experiment_multiproblem(
                 end_verbosity_level=logging.INFO,
             )
         ]
+
+    # cumulative fitness + Wilcoxon = incompatible
+    if isinstance(pruner, optuna.pruners.WilcoxonPruner) and report_cumulated_fitness:
+        raise ValueError(
+            "`report_cumulated_fitness` cannot be true when using a WilcoxonPruner."
+        )
 
     # study name
     suffix = f"-{time.time()}" if create_another_study else ""
@@ -406,8 +443,13 @@ def generic_optuna_experiment_multiproblem(
 
         # loop on problem instances
         fitnesses = []
+        cumulated_fitness = 0.0
+        i_cumulated_fitness = 0
         # For best results, shuffle the evaluation order in each trial.
-        instance_ids = np.random.permutation(len(problems))
+        if randomize_instances:
+            instance_ids = np.random.permutation(len(problems))
+        else:
+            instance_ids = list(range(len(problems)))
         for instance_id in instance_ids:
             instance_id = int(instance_id)  # convert np.int64 into python int
             problem = problems[instance_id]
@@ -436,9 +478,28 @@ def generic_optuna_experiment_multiproblem(
 
             # store result for this instance and report it as an intermediate value (=> dashboard + pruning)
             if len(res.list_solution_fits) != 0:
-                _, fit = res.get_best_solution_fit()
+                sol, fit = res.get_best_solution_fit()
+                # satisfy?
+                try:
+                    if check_satisfy and not (problem.satisfy(sol)):
+                        msg = f"Solution found for problem #{instance_id} does not satisfy the problem."
+                        trial.set_user_attr("Error", msg)
+                        trial.set_user_attr("pruned", True)
+                        raise optuna.TrialPruned(msg)  # show failed
+                except Exception as e:
+                    # Store exception message as trial user attribute
+                    msg = f"{e.__class__}: {e}"
+                    trial.set_user_attr("Error", msg)
+                    trial.set_user_attr("pruned", True)
+                    raise optuna.TrialPruned(msg)  # show failed
+
                 fitnesses.append(fit)
-                trial.report(fit, instance_id)
+                if report_cumulated_fitness:
+                    cumulated_fitness += fit
+                    trial.report(cumulated_fitness, i_cumulated_fitness)
+                    i_cumulated_fitness += 1
+                else:
+                    trial.report(fit, instance_id)
                 current_average = sum(fitnesses) / len(fitnesses)
                 trial.set_user_attr("current_fitness_average", current_average)
                 if trial.should_prune():
@@ -446,7 +507,10 @@ def generic_optuna_experiment_multiproblem(
                     # else optuna dashboard thinks that last intermediate fitness is the value for the trial
                     trial.set_user_attr("pruned", True)
                     trial.set_user_attr("Error", "Pruned by pruner.")
-                    return current_average
+                    if report_cumulated_fitness:
+                        return cumulated_fitness
+                    else:
+                        return current_average
 
             else:
                 trial.set_user_attr("pruned", True)
@@ -455,7 +519,10 @@ def generic_optuna_experiment_multiproblem(
                 raise optuna.TrialPruned(msg)  # show failed
 
         trial.set_user_attr("pruned", False)
-        return sum(fitnesses) / len(fitnesses)
+        if report_cumulated_fitness:
+            return cumulated_fitness
+        else:
+            return sum(fitnesses) / len(fitnesses)
 
     # create study + database to store it
     storage = JournalStorage(JournalFileStorage(storage_path))
@@ -473,3 +540,5 @@ def generic_optuna_experiment_multiproblem(
         load_if_exists=not overwrite_study,
     )
     study.optimize(objective, n_trials=n_trials)
+
+    return study

--- a/discrete_optimization/generic_tools/optuna/utils.py
+++ b/discrete_optimization/generic_tools/optuna/utils.py
@@ -1,0 +1,475 @@
+#  Copyright (c) 2024 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+"""Utilities for optuna."""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections import defaultdict
+from typing import Any, Dict, List, Optional, Type
+
+import numpy as np
+
+from discrete_optimization.generic_tools.callbacks.callback import Callback
+from discrete_optimization.generic_tools.callbacks.loggers import ObjectiveLogger
+from discrete_optimization.generic_tools.callbacks.optuna import OptunaCallback
+from discrete_optimization.generic_tools.do_problem import Problem
+from discrete_optimization.generic_tools.do_solver import SolverDO
+from discrete_optimization.generic_tools.optuna.timed_percentile_pruner import (
+    TimedPercentilePruner,
+)
+
+logger = logging.getLogger(__name__)
+
+
+try:
+    import optuna
+except ImportError:
+    logger.warning("You should install optuna to use this module.")
+else:
+    from optuna.pruners import BasePruner, MedianPruner
+    from optuna.samplers import BaseSampler
+    from optuna.storages import JournalFileStorage, JournalStorage
+    from optuna.trial import Trial, TrialState
+
+
+def generic_optuna_experiment_monoproblem(
+    problem: Problem,
+    solvers_to_test: List[Type[SolverDO]],
+    kwargs_fixed_by_solver: Optional[Dict[Type[SolverDO], Dict[str, Any]]] = None,
+    suggest_optuna_kwargs_by_name_by_solver: Optional[
+        Dict[Type[SolverDO], Dict[str, Dict[str, Any]]]
+    ] = None,
+    n_trials: int = 150,
+    computation_time_in_study: bool = True,
+    study_basename: str = "study",
+    create_another_study: bool = True,
+    overwrite_study=False,
+    storage_path: str = "./optuna-journal.log",
+    sampler: Optional[BaseSampler] = None,
+    pruner: Optional[BasePruner] = None,
+    seed: Optional[int] = None,
+    min_time_per_solver: int = 5,
+    callbacks: Optional[List[Callback]] = None,
+) -> None:
+    """Create and run an optuna study to tune solvers hyperparameters on a given problem.
+
+    The optuna study will choose a solver and its hyperparameters in order to optimize the fitness
+    on the given problem.
+
+    Pruning is potentially done at each optimization step thanks to dedicated callback.
+    This can be done
+    - either according to the optimization step number (but this is meaningful only when considering
+      a single solver or at least solvers of a same family so that comparing step number can be done),
+    - or according to the elapsed time (which should be more meaningful when comparing several types of solvers).
+
+    The optuna study can be monitored with optuna-dashboard with
+
+        optuna-dashboard optuna-journal.log
+
+    (or the relevant path set by `storage_path`)
+
+    Args:
+        problem: problem to consider
+        solvers_to_test: list of solvers to consider
+        kwargs_fixed_by_solver: fixed hyperparameters by solver.
+            Can also be other parameters needed by solvers' __init__(), init_model(), and solve() methods
+        suggest_optuna_kwargs_by_name_by_solver: kwargs_by_name passed to solvers' suggest_with_optuna().
+            Useful to restrict or specify choices, step, high, ...
+        n_trials: Number of trials to be run in the optuna study
+        computation_time_in_study: if `True` the intermediate reporting and pruning will be labelled according to elapsed time
+            instead of solver internal iteration number.
+        study_basename: Base name of the study generated.
+            If `create_another_study` is True, a timestamp will be added to this base name.
+        create_another_study: if `True` a timestamp prefix will be added to the study base name in order to avoid
+            overwritting or continuing a previously created study.
+            Should be False, if one wants to add trials to an existing study.
+        overwrite_study: if True, any study with the same name as the one generated here will be deleted before starting the optuna study.
+            Should be False, if one wants to add trials to an existing study.
+        storage_path: path to the journal used by optuna used to log the study. Can be a NFS path to allow parallelized optuna studies.
+        sampler: sampler used by the optuna study. If None, a TPESampler is used with the provided `seed`.
+        pruner: pruner used by the optuna study.
+            If None,
+              - if computation_time_in_study is True: TimedPercentilePruner(percentile=50, n_warmup_steps=min_time_per_solver)
+              - else: MedianPruner()
+            is used
+        seed: used to create the sampler if `sampler` is None. Should be set to an integer if one wants to ensure
+            reproducible results.
+        min_time_per_solver: if no pruner is defined, and computation_time_in_study is True,
+            we wait for these many seconds before allowing pruning.
+        callbacks: list of callbacks to plug in solvers' solve(). By default, use
+            `ObjectiveLogger(step_verbosity_level=logging.INFO, end_verbosity_level=logging.INFO)`
+            Moreover a `OptunaCallback` will be added to report intermediate values and prune accordingly.
+
+    Returns:
+
+    """
+    # default parameters
+    if kwargs_fixed_by_solver is None:
+        kwargs_fixed_by_solver = defaultdict(dict)
+    if suggest_optuna_kwargs_by_name_by_solver is None:
+        suggest_optuna_kwargs_by_name_by_solver = defaultdict(dict)
+    if sampler is None:
+        sampler = optuna.samplers.TPESampler(seed=seed)
+    if pruner is None:
+        if computation_time_in_study:
+            pruner = TimedPercentilePruner(  # intermediate values interpolated at same "step"
+                percentile=50,  # median pruner
+                n_warmup_steps=min_time_per_solver,  # no pruning during first seconds
+            )
+        else:
+            pruner = MedianPruner()
+    if callbacks is None:
+        callbacks = [
+            ObjectiveLogger(
+                step_verbosity_level=logging.INFO,
+                end_verbosity_level=logging.INFO,
+            )
+        ]
+
+    elapsed_time_attr = "elapsed_time"
+
+    # study name
+    suffix = f"-{time.time()}" if create_another_study else ""
+    study_name = f"{study_basename}{suffix}"
+
+    # we need to map the classes to a unique string, to be seen as a categorical hyperparameter by optuna
+    # by default, we use the class name, but if there are identical names, f"{cls.__module__}.{cls.__name__}" could be used.
+    solvers_by_name: Dict[str, Type[SolverDO]] = {
+        cls.__name__: cls for cls in solvers_to_test
+    }
+
+    # sense of optimization
+    direction = problem.get_optuna_study_direction()
+
+    # objective definition
+    def objective(trial: Trial):
+        # hyperparameters to test
+
+        # first parameter: solver choice
+        solver_name: str = trial.suggest_categorical("solver", choices=solvers_by_name)
+        solver_class = solvers_by_name[solver_name]
+
+        # hyperparameters for the chosen solver
+        suggested_hyperparameters_kwargs = (
+            solver_class.suggest_hyperparameters_with_optuna(
+                trial=trial,
+                prefix=solver_name + ".",
+                kwargs_by_name=suggest_optuna_kwargs_by_name_by_solver[
+                    solver_class
+                ],  # options to restrict the choices of some hyperparameter
+                fixed_hyperparameters=kwargs_fixed_by_solver[solver_class],
+            )
+        )
+
+        # use existing value if corresponding to a previous complete trial (it may happen that the sampler repropose same params)
+        states_to_consider = (TrialState.COMPLETE,)
+        trials_to_consider = trial.study.get_trials(
+            deepcopy=False, states=states_to_consider
+        )
+        for t in reversed(trials_to_consider):
+            if trial.params == t.params:
+                msg = "Trial with same hyperparameters as a previous complete trial: returning previous fit."
+                logger.warning(msg)
+                trial.set_user_attr("Error", msg)
+                return t.value
+
+        # prune if corresponding to a previous failed trial
+        states_to_consider = (TrialState.FAIL,)
+        trials_to_consider = trial.study.get_trials(
+            deepcopy=False, states=states_to_consider
+        )
+        for t in reversed(trials_to_consider):
+            if trial.params == t.params:
+                msg = "Pruning trial identical to a previous failed trial."
+                trial.set_user_attr("Error", msg)
+                raise optuna.TrialPruned(msg)
+
+        logger.info(f"Launching trial {trial.number} with parameters: {trial.params}")
+
+        # construct kwargs for __init__, init_model, and solve
+        kwargs = dict(
+            kwargs_fixed_by_solver[solver_class]
+        )  # copy the frozen kwargs dict
+        kwargs.update(suggested_hyperparameters_kwargs)
+
+        try:
+            # solver init
+            if solver_class.__name__ == "GPHH":
+                solver = solver_class(
+                    problem=problem, training_domains=[problem], **kwargs
+                )
+            else:
+                solver = solver_class(problem=problem, **kwargs)
+            solver.init_model(**kwargs)
+
+            # init timer
+            starting_time = time.perf_counter()
+
+            # add optuna callbacks
+            optuna_callback = OptunaCallback(
+                trial=trial,
+                starting_time=starting_time,
+                elapsed_time_attr=elapsed_time_attr,
+                report_time=computation_time_in_study,
+                # report intermediate values according to elapsed time instead of iteration number?
+            )
+            callbacks_for_optuna = callbacks + [optuna_callback]
+
+            # solve
+            res = solver.solve(
+                callbacks=callbacks_for_optuna,
+                **kwargs,
+            )
+        except Exception as e:
+            if isinstance(e, optuna.TrialPruned):
+                raise e  # pruning error managed directly by optuna
+            else:
+                # Store exception message as trial user attribute
+                msg = f"{e.__class__}: {e}"
+                trial.set_user_attr("Error", msg)
+                raise optuna.TrialPruned(msg)  # show failed
+
+        # store elapsed time
+        elapsed_time = time.perf_counter() - starting_time
+        trial.set_user_attr(elapsed_time_attr, elapsed_time)
+
+        # store result for this instance and report it as an intermediate value (=> dashboard + pruning)
+        if len(res.list_solution_fits) != 0:
+            _, fit = res.get_best_solution_fit()
+        else:
+            msg = f"No solution found."
+            trial.set_user_attr("Error", msg)
+            raise optuna.TrialPruned(msg)  # show failed
+
+        return fit
+
+    # create study + database to store it
+    storage = JournalStorage(JournalFileStorage(storage_path))
+    if overwrite_study:
+        try:
+            optuna.delete_study(study_name=study_name, storage=storage)
+        except:
+            pass
+    study = optuna.create_study(
+        study_name=study_name,
+        direction=direction,
+        sampler=sampler,
+        pruner=pruner,
+        storage=storage,
+        load_if_exists=not overwrite_study,
+    )
+    study.optimize(objective, n_trials=n_trials)
+
+
+def generic_optuna_experiment_multiproblem(
+    problems: List[Problem],
+    solvers_to_test: List[Type[SolverDO]],
+    kwargs_fixed_by_solver: Optional[Dict[Type[SolverDO], Dict[str, Any]]] = None,
+    suggest_optuna_kwargs_by_name_by_solver: Optional[
+        Dict[Type[SolverDO], Dict[str, Dict[str, Any]]]
+    ] = None,
+    n_trials: int = 150,
+    study_basename: str = "study",
+    create_another_study: bool = True,
+    overwrite_study=False,
+    storage_path: str = "./optuna-journal.log",
+    sampler: Optional[BaseSampler] = None,
+    pruner: Optional[BasePruner] = None,
+    seed: Optional[int] = None,
+    callbacks: Optional[List[Callback]] = None,
+) -> None:
+    """Create and run an optuna study to tune solvers hyperparameters on several instances of a problem.
+
+    The optuna study will choose a solver and its hyperparameters in order to optimize the average fitness
+    on given problem instances.
+
+    Pruning is potentially made after each instance is solved based on how previous solvers performed
+    on this same instance.
+
+    The optuna study can be monitored with optuna-dashboard with
+
+        optuna-dashboard optuna-journal.log
+
+    (or the relevant path set by `storage_path`)
+
+    Args:
+        problems: list of problem instances to consider
+        solvers_to_test: list of solvers to consider
+        kwargs_fixed_by_solver: fixed hyperparameters by solver.
+            Can also be other parameters needed by solvers' __init__(), init_model(), and solve() methods
+        suggest_optuna_kwargs_by_name_by_solver: kwargs_by_name passed to solvers' suggest_with_optuna().
+            Useful to restrict or specify choices, step, high, ...
+        n_trials: Number of trials to be run in the optuna study
+        study_basename: Base name of the study generated.
+            If `create_another_study` is True, a timestamp will be added to this base name.
+        create_another_study: if `True` a timestamp prefix will be added to the study base name in order to avoid
+            overwritting or continuing a previously created study.
+            Should be False, if one wants to add trials to an existing study.
+        overwrite_study: if True, any study with the same name as the one generated here will be deleted before starting the optuna study.
+            Should be False, if one wants to add trials to an existing study.
+        storage_path: path to the journal used by optuna used to log the study. Can be a NFS path to allow parallelized optuna studies.
+        sampler: sampler used by the optuna study. If None, a TPESampler is used with the provided `seed`.
+        pruner: pruner used by the optuna study. If None, a WilcoxonPruner is used.
+        seed: used to create the sampler if `sampler` is None. Should be set to an integer if one wants to ensure
+            reproducible results.
+        callbacks: list of callbacks to plug in solvers' solve(). By default, use
+            `ObjectiveLogger(step_verbosity_level=logging.INFO, end_verbosity_level=logging.INFO)`
+
+    Returns:
+
+    """
+    # default parameters
+    if kwargs_fixed_by_solver is None:
+        kwargs_fixed_by_solver = defaultdict(dict)
+    if suggest_optuna_kwargs_by_name_by_solver is None:
+        suggest_optuna_kwargs_by_name_by_solver = defaultdict(dict)
+    if sampler is None:
+        sampler = optuna.samplers.TPESampler(seed=seed)
+    if pruner is None:
+        pruner = optuna.pruners.WilcoxonPruner(p_threshold=0.1)
+    if callbacks is None:
+        callbacks = [
+            ObjectiveLogger(
+                step_verbosity_level=logging.INFO,
+                end_verbosity_level=logging.INFO,
+            )
+        ]
+
+    # study name
+    suffix = f"-{time.time()}" if create_another_study else ""
+    study_name = f"{study_basename}{suffix}"
+
+    # we need to map the classes to a unique string, to be seen as a categorical hyperparameter by optuna
+    # by default, we use the class name, but if there are identical names, f"{cls.__module__}.{cls.__name__}" could be used.
+    solvers_by_name: Dict[str, Type[SolverDO]] = {
+        cls.__name__: cls for cls in solvers_to_test
+    }
+
+    # sense of optimization
+    direction = problems[0].get_optuna_study_direction()
+
+    # objective definition
+    def objective(trial: Trial):
+        # hyperparameters to test
+
+        # first parameter: solver choice
+        solver_name: str = trial.suggest_categorical("solver", choices=solvers_by_name)
+        solver_class = solvers_by_name[solver_name]
+
+        # hyperparameters for the chosen solver
+        suggested_hyperparameters_kwargs = (
+            solver_class.suggest_hyperparameters_with_optuna(
+                trial=trial,
+                prefix=solver_name + ".",
+                kwargs_by_name=suggest_optuna_kwargs_by_name_by_solver[
+                    solver_class
+                ],  # options to restrict the choices of some hyperparameter
+                fixed_hyperparameters=kwargs_fixed_by_solver[solver_class],
+            )
+        )
+
+        # use existing value if corresponding to a previous complete trial (it may happen that the sampler repropose same params)
+        states_to_consider = (TrialState.COMPLETE,)
+        trials_to_consider = trial.study.get_trials(
+            deepcopy=False, states=states_to_consider
+        )
+        for t in reversed(trials_to_consider):
+            if trial.params == t.params:
+                msg = "Trial with same hyperparameters as a previous complete trial: returning previous fit."
+                logger.warning(msg)
+                trial.set_user_attr("Error", msg)
+                trial.set_user_attr("pruned", True)
+                return t.value
+
+        # prune if corresponding to a previous failed trial
+        states_to_consider = (TrialState.FAIL,)
+        trials_to_consider = trial.study.get_trials(
+            deepcopy=False, states=states_to_consider
+        )
+        for t in reversed(trials_to_consider):
+            if trial.params == t.params:
+                msg = "Pruning trial identical to a previous failed trial."
+                trial.set_user_attr("Error", msg)
+                trial.set_user_attr("pruned", True)
+                raise optuna.TrialPruned(msg)
+
+        logger.info(f"Launching trial {trial.number} with parameters: {trial.params}")
+
+        # construct kwargs for __init__, init_model, and solve
+        kwargs = dict(
+            kwargs_fixed_by_solver[solver_class]
+        )  # copy the frozen kwargs dict
+        kwargs.update(suggested_hyperparameters_kwargs)
+
+        # loop on problem instances
+        fitnesses = []
+        # For best results, shuffle the evaluation order in each trial.
+        instance_ids = np.random.permutation(len(problems))
+        for instance_id in instance_ids:
+            instance_id = int(instance_id)  # convert np.int64 into python int
+            problem = problems[instance_id]
+
+            try:
+                # solver init
+                if solver_class.__name__ == "GPHH":
+                    solver = solver_class(
+                        problem=problem, training_domains=[problem], **kwargs
+                    )
+                else:
+                    solver = solver_class(problem=problem, **kwargs)
+                solver.init_model(**kwargs)
+
+                # solve
+                res = solver.solve(
+                    callbacks=callbacks,
+                    **kwargs,
+                )
+            except Exception as e:
+                # Store exception message as trial user attribute
+                msg = f"{e.__class__}: {e}"
+                trial.set_user_attr("Error", msg)
+                trial.set_user_attr("pruned", True)
+                raise optuna.TrialPruned(msg)  # show failed
+
+            # store result for this instance and report it as an intermediate value (=> dashboard + pruning)
+            if len(res.list_solution_fits) != 0:
+                _, fit = res.get_best_solution_fit()
+                fitnesses.append(fit)
+                trial.report(fit, instance_id)
+                current_average = sum(fitnesses) / len(fitnesses)
+                trial.set_user_attr("current_fitness_average", current_average)
+                if trial.should_prune():
+                    # return current average instead of raising TrialPruned,
+                    # else optuna dashboard thinks that last intermediate fitness is the value for the trial
+                    trial.set_user_attr("pruned", True)
+                    trial.set_user_attr("Error", "Pruned by pruner.")
+                    return current_average
+
+            else:
+                trial.set_user_attr("pruned", True)
+                msg = f"No solution found for problem #{instance_id}."
+                trial.set_user_attr("Error", msg)
+                raise optuna.TrialPruned(msg)  # show failed
+
+        trial.set_user_attr("pruned", False)
+        return sum(fitnesses) / len(fitnesses)
+
+    # create study + database to store it
+    storage = JournalStorage(JournalFileStorage(storage_path))
+    if overwrite_study:
+        try:
+            optuna.delete_study(study_name=study_name, storage=storage)
+        except:
+            pass
+    study = optuna.create_study(
+        study_name=study_name,
+        direction=direction,
+        sampler=sampler,
+        pruner=pruner,
+        storage=storage,
+        load_if_exists=not overwrite_study,
+    )
+    study.optimize(objective, n_trials=n_trials)

--- a/discrete_optimization/generic_tools/result_storage/result_storage.py
+++ b/discrete_optimization/generic_tools/result_storage/result_storage.py
@@ -117,12 +117,21 @@ class ResultStorage:
         self.heap = sorted(self.heap, reverse=self.maximize)
 
     def get_best_solution_fit(
-        self,
+        self, satisfying: Optional[Problem] = None
     ) -> Union[Tuple[Solution, fitness_class], Tuple[None, None]]:
         if len(self.list_solution_fits) == 0:
             return None, None
-        f = max if self.maximize else min
-        return f(self.list_solution_fits, key=lambda x: x[1])
+        if satisfying is None:
+            f = max if self.maximize else min
+            return f(self.list_solution_fits, key=lambda x: x[1])
+        else:
+            sorted_solution_fits = sorted(
+                self.list_solution_fits, key=lambda x: x[1], reverse=self.maximize
+            )
+            for sol, fit in sorted_solution_fits:
+                if satisfying.satisfy(sol):
+                    return sol, fit
+            return None, None
 
     def get_last_best_solution(self) -> Tuple[Solution, fitness_class]:
         f = max if self.maximize else min

--- a/examples/coloring/optuna_full_example_all_solvers_timed_pruning.py
+++ b/examples/coloring/optuna_full_example_all_solvers_timed_pruning.py
@@ -16,13 +16,8 @@ Results can be viewed on optuna-dashboard with:
 
 """
 import logging
-import time
 from collections import defaultdict
 from typing import Any, Dict, List, Type
-
-import optuna
-from optuna.storages import JournalFileStorage, JournalStorage
-from optuna.trial import Trial, TrialState
 
 from discrete_optimization.coloring.coloring_parser import (
     get_data_available,
@@ -46,14 +41,11 @@ from discrete_optimization.coloring.solvers.coloring_toulbar_solver import (
 from discrete_optimization.coloring.solvers.greedy_coloring import (
     NXGreedyColoringMethod,
 )
-from discrete_optimization.generic_tools.callbacks.loggers import ObjectiveLogger
-from discrete_optimization.generic_tools.callbacks.optuna import OptunaCallback
 from discrete_optimization.generic_tools.cp_tools import ParametersCP
-from discrete_optimization.generic_tools.do_problem import ModeOptim
 from discrete_optimization.generic_tools.do_solver import SolverDO
 from discrete_optimization.generic_tools.lp_tools import gurobi_available
-from discrete_optimization.generic_tools.optuna.timed_percentile_pruner import (
-    TimedPercentilePruner,
+from discrete_optimization.generic_tools.optuna.utils import (
+    generic_optuna_experiment_monoproblem,
 )
 
 logger = logging.getLogger(__name__)
@@ -61,19 +53,15 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s:%(levelname)s:%(mess
 
 
 seed = 42  # set this to an integer to get reproducible results, else to None
-optuna_nb_trials = 100  # number of trials to launch
+n_trials = 100  # number of trials to launch
 gurobi_full_license_available = False  # is the installed gurobi having a full license? (contrary to the license installed by `pip install gurobipy`)
 create_another_study = True  # True: generate a study name with timestamp to avoid overwriting previous study, False: keep same study name
-overwrite = False  # True: delete previous studies with same name (in particular, if create_another_study=False), False: keep the study and add trials to the existing ones
 max_time_per_solver = 20  # max duration per solver (seconds)
 min_time_per_solver = 5  # min duration before pruning a solver (seconds)
 
 modelfilename = "gc_70_9"  # filename of the model used
 
-suffix = f"-{time.time()}" if create_another_study else ""
-study_name = f"coloring_all_solvers-auto-pruning-{modelfilename}{suffix}"
-storage_path = "./optuna-journal.log"  # NFS path for distributed optimization
-elapsed_time_attr = "elapsed_time"  # name of the user attribute used to store duration of trials (updated during intermediate reports)
+study_basename = f"coloring_all_solvers-auto-pruning-{modelfilename}"
 
 # solvers to test
 solvers_to_remove = {ColoringLP_MIP, ColoringCP}
@@ -120,130 +108,21 @@ suggest_optuna_kwargs_by_name_by_solver: Dict[
     },
 )
 
-# we need to map the classes to a unique string, to be seen as a categorical hyperparameter by optuna
-# by default, we use the class name, but if there are identical names, f"{cls.__module__}.{cls.__name__}" could be used.
-solvers_by_name: Dict[str, Type[SolverDO]] = {
-    cls.__name__: cls for cls in solvers_to_test
-}
 
 # problem definition
 file = [f for f in get_data_available() if "gc_70_9" in f][0]
 problem = parse_file(file)
 
-# sense of optimization
-objective_register = problem.get_objective_register()
-if objective_register.objective_sense == ModeOptim.MINIMIZATION:
-    direction = "minimize"
-else:
-    direction = "maximize"
-
-# objective names
-objs, weights = objective_register.get_list_objective_and_default_weight()
-
-
-# objective definition
-def objective(trial: Trial):
-    # hyperparameters to test
-
-    # first parameter: solver choice
-    solver_name: str = trial.suggest_categorical("solver", choices=solvers_by_name)
-    solver_class = solvers_by_name[solver_name]
-
-    # hyperparameters for the chosen solver  (only those not already fixed)
-    hyperparameters_names = [
-        h
-        for h in solver_class.get_hyperparameters_names()
-        if h not in kwargs_fixed_by_solver[solver_class]
-    ]
-    suggested_hyperparameters_kwargs = solver_class.suggest_hyperparameters_with_optuna(
-        names=hyperparameters_names,
-        trial=trial,
-        prefix=solver_name + ".",
-        kwargs_by_name=suggest_optuna_kwargs_by_name_by_solver[
-            solver_class
-        ],  # options to restrict the choices of some hyperparameter
-    )
-
-    # use existing value if corresponding to a previous complete trial (it may happen that the sampler repropose same params)
-    states_to_consider = (TrialState.COMPLETE,)
-    trials_to_consider = trial.study.get_trials(
-        deepcopy=False, states=states_to_consider
-    )
-    for t in reversed(trials_to_consider):
-        if trial.params == t.params:
-            logger.warning(
-                "Trial with same hyperparameters as a previous complete trial: returning previous fit."
-            )
-            return t.value
-
-    # prune if corresponding to a previous failed trial
-    states_to_consider = (TrialState.FAIL,)
-    trials_to_consider = trial.study.get_trials(
-        deepcopy=False, states=states_to_consider
-    )
-    for t in reversed(trials_to_consider):
-        if trial.params == t.params:
-            raise optuna.TrialPruned(
-                "Pruning trial identical to a previous failed trial."
-            )
-
-    logger.info(f"Launching trial {trial.number} with parameters: {trial.params}")
-
-    # construct kwargs for __init__, init_model, and solve
-    kwargs = dict(kwargs_fixed_by_solver[solver_class])  # copy the frozen kwargs dict
-    kwargs.update(suggested_hyperparameters_kwargs)
-
-    # solver init
-    solver = solver_class(problem=problem, **kwargs)
-    solver.init_model(**kwargs)
-
-    # init timer
-    starting_time = time.perf_counter()
-
-    # solve
-    res = solver.solve(
-        callbacks=[
-            OptunaCallback(
-                trial=trial,
-                starting_time=starting_time,
-                elapsed_time_attr=elapsed_time_attr,
-                report_time=True,  # report intermediate values according to elapsed time instead of iteration number
-            ),
-            ObjectiveLogger(
-                step_verbosity_level=logging.INFO, end_verbosity_level=logging.INFO
-            ),
-        ],
-        **kwargs,
-    )
-
-    # store elapsed time
-    elapsed_time = time.perf_counter() - starting_time
-    trial.set_user_attr(elapsed_time_attr, elapsed_time)
-
-    if len(res.list_solution_fits) != 0:
-        _, fit = res.get_best_solution_fit()
-        return fit
-    else:
-        raise optuna.TrialPruned("Pruned because failed")  # show failed
-
-
-# create study + database to store it
-storage = JournalStorage(JournalFileStorage(storage_path))
-if overwrite:
-    try:
-        optuna.delete_study(study_name=study_name, storage=storage)
-    except:
-        pass
-study = optuna.create_study(
-    study_name=study_name,
-    direction=direction,
-    sampler=optuna.samplers.TPESampler(seed=seed),
-    pruner=TimedPercentilePruner(  # intermediate values interpolated at same "step"
-        percentile=50,  # median pruner
-        n_warmup_steps=min_time_per_solver,  # no pruning during first seconds
-    ),
-    storage=storage,
-    load_if_exists=not overwrite,
+# generate and launch the optuna study
+generic_optuna_experiment_monoproblem(
+    problem=problem,
+    solvers_to_test=solvers_to_test,
+    kwargs_fixed_by_solver=kwargs_fixed_by_solver,
+    suggest_optuna_kwargs_by_name_by_solver=suggest_optuna_kwargs_by_name_by_solver,
+    n_trials=n_trials,
+    computation_time_in_study=True,
+    study_basename=study_basename,
+    create_another_study=create_another_study,
+    seed=seed,
+    min_time_per_solver=min_time_per_solver,
 )
-study.set_metric_names(["nb_colors"])
-study.optimize(objective, n_trials=optuna_nb_trials)

--- a/examples/rcpsp/optuna_all_solvers_multiple_instances.py
+++ b/examples/rcpsp/optuna_all_solvers_multiple_instances.py
@@ -1,25 +1,32 @@
+#  Copyright (c) 2024 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+"""Example using OPTUNA to choose a solving method and tune its hyperparameters on multiple rcpsp instances.
+
+Results can be viewed on optuna-dashboard with:
+
+    optuna-dashboard optuna-journal.log
+
+"""
+
 import logging
 import re
-import time
 from collections import defaultdict
 from os.path import basename
 from typing import Any, Dict, Type
 
-import numpy as np
-import optuna
-from optuna.storages import JournalFileStorage, JournalStorage
-from optuna.trial import Trial, TrialState
-
 from discrete_optimization.generic_rcpsp_tools.large_neighborhood_search_scheduling import (
     LargeNeighborhoodSearchScheduling,
 )
-from discrete_optimization.generic_tools.callbacks.loggers import ObjectiveLogger
 from discrete_optimization.generic_tools.cp_tools import ParametersCP
 from discrete_optimization.generic_tools.do_solver import SolverDO
 from discrete_optimization.generic_tools.lp_tools import (
     MilpSolverName,
     ParametersMilp,
     gurobi_available,
+)
+from discrete_optimization.generic_tools.optuna.utils import (
+    generic_optuna_experiment_multiproblem,
 )
 from discrete_optimization.rcpsp.rcpsp_parser import get_data_available, parse_file
 from discrete_optimization.rcpsp.rcpsp_solvers import look_for_solver
@@ -29,34 +36,32 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format="%(asctime)s:%(levelname)s:%(message)s")
 
 seed = 42  # set this to an integer to get reproducible results, else to None
-optuna_nb_trials = 100  # number of trials to launch
+n_trials = 100  # number of trials to launch
 gurobi_full_license_available = False  # is the installed gurobi having a full license? (contrary to the license installed by `pip install gurobipy`)
 create_another_study = True  # True: generate a study name with timestamp to avoid overwriting previous study, False: keep same study name
-overwrite = False  # True: delete previous studies with same name (in particular, if create_another_study=False), False: keep the study and add trials to the existing ones
 max_time_per_solver = 20  # max duration per solver (seconds)
 
 problem_pattern = "j301_.*\.sm"
-nb_problems = 10
-study_basename = f"rcpsp_multiple_instances-{problem_pattern}-{nb_problems}"
+nb_max_problems = 10
+study_basename = f"rcpsp_multiple_instances-{problem_pattern}-{nb_max_problems}"
+
+
 problems_files = [
     f for f in get_data_available() if re.match(problem_pattern, basename(f))
 ]
-if nb_problems > 0:
-    problems_files = problems_files[:nb_problems]
+if nb_max_problems > 0:
+    problems_files = problems_files[:nb_max_problems]
 problems = [parse_file(f) for f in problems_files]
+
 
 solvers_to_test = look_for_solver(problems[0])
 
-suffix = f"-{time.time()}" if create_another_study else ""
-study_name = f"{study_basename}{suffix}"
-storage_path = "./optuna-journal.log"  # NFS path for distributed optimization
-
+# Fixed parameters
 parameters_cp = ParametersCP.default_cpsat()
 parameters_cp.nb_process = 6
 parameters_cp.time_limit = max_time_per_solver
 parameters_milp = ParametersMilp.default()
 parameters_milp.time_limit = max_time_per_solver
-
 kwargs_fixed_by_solver: Dict[Type[SolverDO], Dict[str, Any]] = defaultdict(
     dict,  # default kwargs for unspecified solvers
     {
@@ -68,7 +73,7 @@ kwargs_fixed_by_solver: Dict[Type[SolverDO], Dict[str, Any]] = defaultdict(
     },
 )
 
-# restrict some hyperparameters choices, for some solvers (making use of `kwargs_by_name` of `suggest_with_optuna`)
+# Restrict some hyperparameters choices, for some solvers (making use of `kwargs_by_name` of `suggest_with_optuna`)
 suggest_optuna_kwargs_by_name_by_solver: Dict[
     Type[SolverDO], Dict[str, Dict[str, Any]]
 ] = defaultdict(
@@ -84,136 +89,14 @@ if not gurobi_available or not gurobi_full_license_available:
         {"lp_solver": dict(choices=[MilpSolverName.CBC])}
     )
 
-# we need to map the classes to a unique string, to be seen as a categorical hyperparameter by optuna
-# by default, we use the class name, but if there are identical names, f"{cls.__module__}.{cls.__name__}" could be used.
-solvers_by_name: Dict[str, Type[SolverDO]] = {
-    cls.__name__: cls for cls in solvers_to_test
-}
-
-# sense of optimization
-direction = problems[0].get_optuna_study_direction()
-
-# objective definition
-def objective(trial: Trial):
-    # hyperparameters to test
-
-    # first parameter: solver choice
-    solver_name: str = trial.suggest_categorical("solver", choices=solvers_by_name)
-    solver_class = solvers_by_name[solver_name]
-
-    # hyperparameters for the chosen solver
-    suggested_hyperparameters_kwargs = solver_class.suggest_hyperparameters_with_optuna(
-        trial=trial,
-        prefix=solver_name + ".",
-        kwargs_by_name=suggest_optuna_kwargs_by_name_by_solver[
-            solver_class
-        ],  # options to restrict the choices of some hyperparameter
-        fixed_hyperparameters=kwargs_fixed_by_solver[solver_class],
-    )
-
-    # use existing value if corresponding to a previous complete trial (it may happen that the sampler repropose same params)
-    states_to_consider = (TrialState.COMPLETE,)
-    trials_to_consider = trial.study.get_trials(
-        deepcopy=False, states=states_to_consider
-    )
-    for t in reversed(trials_to_consider):
-        if trial.params == t.params:
-            msg = "Trial with same hyperparameters as a previous complete trial: returning previous fit."
-            logger.warning(msg)
-            trial.set_user_attr("Error", msg)
-            trial.set_user_attr("pruned", True)
-            return t.value
-
-    # prune if corresponding to a previous failed trial
-    states_to_consider = (TrialState.FAIL,)
-    trials_to_consider = trial.study.get_trials(
-        deepcopy=False, states=states_to_consider
-    )
-    for t in reversed(trials_to_consider):
-        if trial.params == t.params:
-            msg = "Pruning trial identical to a previous failed trial."
-            trial.set_user_attr("Error", msg)
-            trial.set_user_attr("pruned", True)
-            raise optuna.TrialPruned(msg)
-
-    logger.info(f"Launching trial {trial.number} with parameters: {trial.params}")
-
-    # construct kwargs for __init__, init_model, and solve
-    kwargs = dict(kwargs_fixed_by_solver[solver_class])  # copy the frozen kwargs dict
-    kwargs.update(suggested_hyperparameters_kwargs)
-
-    # loop on problem instances
-    fitnesses = []
-    # For best results, shuffle the evaluation order in each trial.
-    instance_ids = np.random.permutation(len(problems))
-    for instance_id in instance_ids:
-        instance_id = int(instance_id)  # convert np.int64 into python int
-        problem = problems[instance_id]
-
-        try:
-            # solver init
-            if solver_class.__name__ == "GPHH":
-                solver = solver_class(
-                    problem=problem, training_domains=[problem], **kwargs
-                )
-            else:
-                solver = solver_class(problem=problem, **kwargs)
-            solver.init_model(**kwargs)
-
-            # solve
-            res = solver.solve(
-                callbacks=[
-                    ObjectiveLogger(
-                        step_verbosity_level=logging.INFO,
-                        end_verbosity_level=logging.INFO,
-                    ),
-                ],
-                **kwargs,
-            )
-        except Exception as e:
-            # Store exception message as trial user attribute
-            msg = f"{e.__class__}: {e}"
-            trial.set_user_attr("Error", msg)
-            trial.set_user_attr("pruned", True)
-            raise optuna.TrialPruned(msg)  # show failed
-
-        # store result for this instance and report it as an intermediate value (=> dashboard + pruning)
-        if len(res.list_solution_fits) != 0:
-            _, fit = res.get_best_solution_fit()
-            fitnesses.append(fit)
-            trial.report(fit, instance_id)
-            current_average = sum(fitnesses) / len(fitnesses)
-            trial.set_user_attr("current_fitness_average", current_average)
-            if trial.should_prune():
-                # return current average instead of raising TrialPruned,
-                # else optuna dashboard thinks that last intermediate fitness is the value for the trial
-                trial.set_user_attr("pruned", True)
-                trial.set_user_attr("Error", "Pruned by pruner.")
-                return current_average
-
-        else:
-            trial.set_user_attr("pruned", True)
-            msg = f"No solution found for problem #{instance_id}."
-            trial.set_user_attr("Error", msg)
-            raise optuna.TrialPruned(msg)  # show failed
-
-    trial.set_user_attr("pruned", False)
-    return sum(fitnesses) / len(fitnesses)
-
-
-# create study + database to store it
-storage = JournalStorage(JournalFileStorage(storage_path))
-if overwrite:
-    try:
-        optuna.delete_study(study_name=study_name, storage=storage)
-    except:
-        pass
-study = optuna.create_study(
-    study_name=study_name,
-    direction=direction,
-    sampler=optuna.samplers.TPESampler(seed=seed),
-    pruner=optuna.pruners.WilcoxonPruner(p_threshold=0.1),
-    storage=storage,
-    load_if_exists=not overwrite,
+# Generate and launch the optuna study
+generic_optuna_experiment_multiproblem(
+    problems=problems,
+    solvers_to_test=solvers_to_test,
+    kwargs_fixed_by_solver=kwargs_fixed_by_solver,
+    suggest_optuna_kwargs_by_name_by_solver=suggest_optuna_kwargs_by_name_by_solver,
+    n_trials=n_trials,
+    study_basename=study_basename,
+    create_another_study=create_another_study,
+    seed=seed,
 )
-study.optimize(objective, n_trials=optuna_nb_trials)

--- a/examples/rcpsp/optuna_all_solvers_multiple_instances.py
+++ b/examples/rcpsp/optuna_all_solvers_multiple_instances.py
@@ -1,0 +1,219 @@
+import logging
+import re
+import time
+from collections import defaultdict
+from os.path import basename
+from typing import Any, Dict, Type
+
+import numpy as np
+import optuna
+from optuna.storages import JournalFileStorage, JournalStorage
+from optuna.trial import Trial, TrialState
+
+from discrete_optimization.generic_rcpsp_tools.large_neighborhood_search_scheduling import (
+    LargeNeighborhoodSearchScheduling,
+)
+from discrete_optimization.generic_tools.callbacks.loggers import ObjectiveLogger
+from discrete_optimization.generic_tools.cp_tools import ParametersCP
+from discrete_optimization.generic_tools.do_solver import SolverDO
+from discrete_optimization.generic_tools.lp_tools import (
+    MilpSolverName,
+    ParametersMilp,
+    gurobi_available,
+)
+from discrete_optimization.rcpsp.rcpsp_parser import get_data_available, parse_file
+from discrete_optimization.rcpsp.rcpsp_solvers import look_for_solver
+from discrete_optimization.rcpsp.solver.rcpsp_lp_solver import LP_MRCPSP, LP_RCPSP
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s:%(levelname)s:%(message)s")
+
+seed = 42  # set this to an integer to get reproducible results, else to None
+optuna_nb_trials = 100  # number of trials to launch
+gurobi_full_license_available = False  # is the installed gurobi having a full license? (contrary to the license installed by `pip install gurobipy`)
+create_another_study = True  # True: generate a study name with timestamp to avoid overwriting previous study, False: keep same study name
+overwrite = False  # True: delete previous studies with same name (in particular, if create_another_study=False), False: keep the study and add trials to the existing ones
+max_time_per_solver = 20  # max duration per solver (seconds)
+
+problem_pattern = "j301_.*\.sm"
+nb_problems = 10
+study_basename = f"rcpsp_multiple_instances-{problem_pattern}-{nb_problems}"
+problems_files = [
+    f for f in get_data_available() if re.match(problem_pattern, basename(f))
+]
+if nb_problems > 0:
+    problems_files = problems_files[:nb_problems]
+problems = [parse_file(f) for f in problems_files]
+
+solvers_to_test = look_for_solver(problems[0])
+
+suffix = f"-{time.time()}" if create_another_study else ""
+study_name = f"{study_basename}{suffix}"
+storage_path = "./optuna-journal.log"  # NFS path for distributed optimization
+
+parameters_cp = ParametersCP.default_cpsat()
+parameters_cp.nb_process = 6
+parameters_cp.time_limit = max_time_per_solver
+parameters_milp = ParametersMilp.default()
+parameters_milp.time_limit = max_time_per_solver
+
+kwargs_fixed_by_solver: Dict[Type[SolverDO], Dict[str, Any]] = defaultdict(
+    dict,  # default kwargs for unspecified solvers
+    {
+        LargeNeighborhoodSearchScheduling: dict(
+            nb_iteration_lns=10, parameters_cp=parameters_cp
+        ),
+        LP_RCPSP: dict(parameters_milp=parameters_milp),
+        LP_MRCPSP: dict(parameters_milp=parameters_milp),
+    },
+)
+
+# restrict some hyperparameters choices, for some solvers (making use of `kwargs_by_name` of `suggest_with_optuna`)
+suggest_optuna_kwargs_by_name_by_solver: Dict[
+    Type[SolverDO], Dict[str, Dict[str, Any]]
+] = defaultdict(
+    dict,  # default kwargs_by_name for unspecified solvers
+    {},
+)
+if not gurobi_available or not gurobi_full_license_available:
+    # Remove possibility for gurobi if not available
+    suggest_optuna_kwargs_by_name_by_solver[LP_RCPSP].update(
+        {"lp_solver": dict(choices=[MilpSolverName.CBC])}
+    )
+    suggest_optuna_kwargs_by_name_by_solver[LP_MRCPSP].update(
+        {"lp_solver": dict(choices=[MilpSolverName.CBC])}
+    )
+
+# we need to map the classes to a unique string, to be seen as a categorical hyperparameter by optuna
+# by default, we use the class name, but if there are identical names, f"{cls.__module__}.{cls.__name__}" could be used.
+solvers_by_name: Dict[str, Type[SolverDO]] = {
+    cls.__name__: cls for cls in solvers_to_test
+}
+
+# sense of optimization
+direction = problems[0].get_optuna_study_direction()
+
+# objective definition
+def objective(trial: Trial):
+    # hyperparameters to test
+
+    # first parameter: solver choice
+    solver_name: str = trial.suggest_categorical("solver", choices=solvers_by_name)
+    solver_class = solvers_by_name[solver_name]
+
+    # hyperparameters for the chosen solver
+    suggested_hyperparameters_kwargs = solver_class.suggest_hyperparameters_with_optuna(
+        trial=trial,
+        prefix=solver_name + ".",
+        kwargs_by_name=suggest_optuna_kwargs_by_name_by_solver[
+            solver_class
+        ],  # options to restrict the choices of some hyperparameter
+        fixed_hyperparameters=kwargs_fixed_by_solver[solver_class],
+    )
+
+    # use existing value if corresponding to a previous complete trial (it may happen that the sampler repropose same params)
+    states_to_consider = (TrialState.COMPLETE,)
+    trials_to_consider = trial.study.get_trials(
+        deepcopy=False, states=states_to_consider
+    )
+    for t in reversed(trials_to_consider):
+        if trial.params == t.params:
+            msg = "Trial with same hyperparameters as a previous complete trial: returning previous fit."
+            logger.warning(msg)
+            trial.set_user_attr("Error", msg)
+            trial.set_user_attr("pruned", True)
+            return t.value
+
+    # prune if corresponding to a previous failed trial
+    states_to_consider = (TrialState.FAIL,)
+    trials_to_consider = trial.study.get_trials(
+        deepcopy=False, states=states_to_consider
+    )
+    for t in reversed(trials_to_consider):
+        if trial.params == t.params:
+            msg = "Pruning trial identical to a previous failed trial."
+            trial.set_user_attr("Error", msg)
+            trial.set_user_attr("pruned", True)
+            raise optuna.TrialPruned(msg)
+
+    logger.info(f"Launching trial {trial.number} with parameters: {trial.params}")
+
+    # construct kwargs for __init__, init_model, and solve
+    kwargs = dict(kwargs_fixed_by_solver[solver_class])  # copy the frozen kwargs dict
+    kwargs.update(suggested_hyperparameters_kwargs)
+
+    # loop on problem instances
+    fitnesses = []
+    # For best results, shuffle the evaluation order in each trial.
+    instance_ids = np.random.permutation(len(problems))
+    for instance_id in instance_ids:
+        instance_id = int(instance_id)  # convert np.int64 into python int
+        problem = problems[instance_id]
+
+        try:
+            # solver init
+            if solver_class.__name__ == "GPHH":
+                solver = solver_class(
+                    problem=problem, training_domains=[problem], **kwargs
+                )
+            else:
+                solver = solver_class(problem=problem, **kwargs)
+            solver.init_model(**kwargs)
+
+            # solve
+            res = solver.solve(
+                callbacks=[
+                    ObjectiveLogger(
+                        step_verbosity_level=logging.INFO,
+                        end_verbosity_level=logging.INFO,
+                    ),
+                ],
+                **kwargs,
+            )
+        except Exception as e:
+            # Store exception message as trial user attribute
+            msg = f"{e.__class__}: {e}"
+            trial.set_user_attr("Error", msg)
+            trial.set_user_attr("pruned", True)
+            raise optuna.TrialPruned(msg)  # show failed
+
+        # store result for this instance and report it as an intermediate value (=> dashboard + pruning)
+        if len(res.list_solution_fits) != 0:
+            _, fit = res.get_best_solution_fit()
+            fitnesses.append(fit)
+            trial.report(fit, instance_id)
+            current_average = sum(fitnesses) / len(fitnesses)
+            trial.set_user_attr("current_fitness_average", current_average)
+            if trial.should_prune():
+                # return current average instead of raising TrialPruned,
+                # else optuna dashboard thinks that last intermediate fitness is the value for the trial
+                trial.set_user_attr("pruned", True)
+                trial.set_user_attr("Error", "Pruned by pruner.")
+                return current_average
+
+        else:
+            trial.set_user_attr("pruned", True)
+            msg = f"No solution found for problem #{instance_id}."
+            trial.set_user_attr("Error", msg)
+            raise optuna.TrialPruned(msg)  # show failed
+
+    trial.set_user_attr("pruned", False)
+    return sum(fitnesses) / len(fitnesses)
+
+
+# create study + database to store it
+storage = JournalStorage(JournalFileStorage(storage_path))
+if overwrite:
+    try:
+        optuna.delete_study(study_name=study_name, storage=storage)
+    except:
+        pass
+study = optuna.create_study(
+    study_name=study_name,
+    direction=direction,
+    sampler=optuna.samplers.TPESampler(seed=seed),
+    pruner=optuna.pruners.WilcoxonPruner(p_threshold=0.1),
+    storage=storage,
+    load_if_exists=not overwrite,
+)
+study.optimize(objective, n_trials=optuna_nb_trials)

--- a/tests/generic_tools/optuna/test_optuna_utils.py
+++ b/tests/generic_tools/optuna/test_optuna_utils.py
@@ -1,0 +1,148 @@
+#  Copyright (c) 2024 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+
+import random
+from time import sleep
+from typing import Any, List, Optional
+
+import numpy as np
+import pytest
+
+from discrete_optimization.coloring.coloring_model import ColoringSolution
+from discrete_optimization.coloring.coloring_parser import (
+    get_data_available,
+    parse_file,
+)
+from discrete_optimization.generic_tools.callbacks.callback import (
+    Callback,
+    CallbackList,
+)
+from discrete_optimization.generic_tools.callbacks.optuna import OptunaCallback
+from discrete_optimization.generic_tools.do_solver import SolverDO
+from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
+    IntegerHyperparameter,
+)
+from discrete_optimization.generic_tools.optuna.utils import (
+    generic_optuna_experiment_monoproblem,
+    generic_optuna_experiment_multiproblem,
+)
+from discrete_optimization.generic_tools.result_storage.result_storage import (
+    ResultStorage,
+)
+
+try:
+    import optuna
+except ImportError:
+    optuna_available = False
+else:
+    optuna_available = True
+    from discrete_optimization.generic_tools.optuna.timed_percentile_pruner import (
+        TimedPercentilePruner,
+    )
+
+SEED = 42
+
+
+@pytest.fixture()
+def random_seed():
+    random.seed(SEED)
+    np.random.seed(SEED)
+    return SEED
+
+
+class FakeSolver(SolverDO):
+    hyperparameters = [IntegerHyperparameter("param", low=1, high=4, default=1)]
+
+    nb_colors_series = [100 - i for i in range(96)]
+
+    def solve(
+        self, callbacks: Optional[List[Callback]] = None, **kwargs: Any
+    ) -> ResultStorage:
+        kwargs = self.complete_with_default_hyperparameters(kwargs)
+        param = kwargs["param"]
+
+        res = ResultStorage(
+            list_solution_fits=[],
+            mode_optim=self.params_objective_function.sense_function,
+        )
+        callbacks_list = CallbackList(callbacks=callbacks)
+        callbacks_list.on_solve_start(solver=self)
+        for step, nb_colors in enumerate(self.nb_colors_series):
+            solution = ColoringSolution(
+                problem=self.problem, nb_color=nb_colors, nb_violations=0
+            )
+            fit = self.aggreg_from_dict(self.problem.evaluate(solution))
+            res.list_solution_fits.append((solution, fit))
+            # end of step callback: stopping?
+            stopping = callbacks_list.on_step_end(step=step, res=res, solver=self)
+            if stopping:
+                break
+
+        callbacks_list.on_solve_end(res=res, solver=self)
+        return res
+
+
+class FakeSolver2(SolverDO):
+    hyperparameters = [IntegerHyperparameter("param2", low=1, high=3, default=1)]
+
+    nb_colors_series = [100 - i for i in range(96)]
+
+    def solve(
+        self, callbacks: Optional[List[Callback]] = None, **kwargs: Any
+    ) -> ResultStorage:
+        kwargs = self.complete_with_default_hyperparameters(kwargs)
+        param = kwargs["param2"]
+
+        res = ResultStorage(
+            list_solution_fits=[],
+            mode_optim=self.params_objective_function.sense_function,
+        )
+        callbacks_list = CallbackList(callbacks=callbacks)
+        callbacks_list.on_solve_start(solver=self)
+        for step, nb_colors in enumerate(self.nb_colors_series):
+            solution = ColoringSolution(
+                problem=self.problem, nb_color=nb_colors - param, nb_violations=0
+            )
+            fit = self.aggreg_from_dict(self.problem.evaluate(solution))
+            res.list_solution_fits.append((solution, fit))
+            # end of step callback: stopping?
+            stopping = callbacks_list.on_step_end(step=step, res=res, solver=self)
+            if stopping:
+                break
+
+        callbacks_list.on_solve_end(res=res, solver=self)
+        return res
+
+
+@pytest.mark.skipif(
+    not optuna_available, reason="You need Optuna to test this callback."
+)
+def test_generic_optuna_experiment_monoproblem(random_seed):
+    # classic pruner on steps => no pruning (as solver always return same fitnesses sequence)
+    files = get_data_available()
+    files = [f for f in files if "gc_70_9" in f]  # Multi mode RCPSP
+    file_path = files[0]
+    problem = parse_file(file_path)
+
+    solvers_to_test = [FakeSolver, FakeSolver2]
+
+    generic_optuna_experiment_monoproblem(
+        problem=problem, solvers_to_test=solvers_to_test, n_trials=10
+    )
+
+
+@pytest.mark.skipif(
+    not optuna_available, reason="You need Optuna to test this callback."
+)
+def test_generic_optuna_experiment_multiproblem(random_seed):
+    # classic pruner on steps => no pruning (as solver always return same fitnesses sequence)
+    files = get_data_available()
+    files = [f for f in files if "gc_70_" in f]  # Multi mode RCPSP
+    problems = [parse_file(file_path) for file_path in files]
+
+    solvers_to_test = [FakeSolver, FakeSolver2]
+
+    generic_optuna_experiment_multiproblem(
+        problems=problems, solvers_to_test=solvers_to_test, n_trials=10
+    )

--- a/tests/generic_tools/optuna/test_optuna_utils.py
+++ b/tests/generic_tools/optuna/test_optuna_utils.py
@@ -197,7 +197,7 @@ def test_generic_optuna_experiment_multiproblem_cumulative(random_seed):
         seed=random_seed,
         check_satisfy=False,
     )
-    assert study.best_value == -len(problems)
+    assert study.best_value == -2.0
 
 
 @pytest.mark.skipif(

--- a/tests/generic_tools/test_resultstorage.py
+++ b/tests/generic_tools/test_resultstorage.py
@@ -1,0 +1,44 @@
+#  Copyright (c) 2024 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+
+
+from discrete_optimization.coloring.coloring_model import (
+    ColoringProblem,
+    ColoringSolution,
+)
+from discrete_optimization.generic_tools.do_problem import ModeOptim
+from discrete_optimization.generic_tools.graph_api import Graph
+from discrete_optimization.generic_tools.result_storage.result_storage import (
+    ResultStorage,
+)
+
+
+def test_get_best_solution_fit():
+    nodes = [(i, {}) for i in range(4)]
+    edges = [(0, 1, {}), (0, 2, {}), (1, 3, {}), (2, 3, {})]
+    problem = ColoringProblem(graph=Graph(nodes=nodes, edges=edges))
+
+    list_solution_fits = [
+        (ColoringSolution(colors=[0, 0, 0, 0], problem=problem), 1),
+        (ColoringSolution(colors=[0, 1, 2, 3, 4], problem=problem), 5),
+        (ColoringSolution(colors=[0, 1, 1, 0, 0], problem=problem), 2),
+    ]
+    res = ResultStorage(
+        list_solution_fits=list_solution_fits,
+        mode_optim=ModeOptim.MINIMIZATION,
+    )
+    assert res.get_best_solution_fit(satisfying=problem)[1] == 2
+    assert res.get_best_solution_fit()[1] == 1
+
+    list_solution_fits = [
+        (ColoringSolution(colors=[0, 0, 0, 0], problem=problem), -1),
+        (ColoringSolution(colors=[0, 1, 2, 3, 4], problem=problem), -5),
+        (ColoringSolution(colors=[0, 1, 1, 0, 0], problem=problem), -2),
+    ]
+    res = ResultStorage(
+        list_solution_fits=list_solution_fits,
+        mode_optim=ModeOptim.MAXIMIZATION,
+    )
+    assert res.get_best_solution_fit(satisfying=problem)[1] == -2
+    assert res.get_best_solution_fit()[1] == -1


### PR DESCRIPTION
We provide generic functions to help create and run optuna studies
- on a single problem, with ` generic_optuna_experiment_monoproblem()`: this takes into account the latest examples added to examples/, and allow the possibility to report/prune according to elapsed time (meaningful when dealing with several unrelated solvers) or internal optimization step number
- on several problems, with `generic_optuna_experiment_multiproblem()`: as the [example](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.pruners.WilcoxonPruner.html#optuna.pruners.WilcoxonPruner) provided in optuna doc for WilcoxonPruner, we report intermediate values and potentially prune after each instance resolution

These generic functions set default values for study name, journal log, ... and one should write its own script in order to have more control on all details.