### PR TITLE
More robust satisfy function for rcpsp

### DIFF
--- a/discrete_optimization/generic_tools/hyperparameters/hyperparameter.py
+++ b/discrete_optimization/generic_tools/hyperparameters/hyperparameter.py
@@ -292,6 +292,7 @@ class EnumHyperparameter(CategoricalHyperparameter):
 
     Args:
         enum: enumeration used to create the hyperparameter
+        choices: subset of the enumeration allowed. By default, the whole enumeration.
 
     """
 
@@ -299,12 +300,13 @@ class EnumHyperparameter(CategoricalHyperparameter):
         self,
         name: str,
         enum: Type[Enum],
+        choices: Optional[Iterable[Enum]] = None,
         default: Optional[Any] = None,
         depends_on: Optional[Tuple[str, Container[Any]]] = None,
     ):
-        super().__init__(
-            name, choices=list(enum), default=default, depends_on=depends_on
-        )
+        if choices is None:
+            choices = list(enum)
+        super().__init__(name, choices=choices, default=default, depends_on=depends_on)
         self.enum = enum
 
     def suggest_with_optuna(

--- a/discrete_optimization/rcpsp/rcpsp_model.py
+++ b/discrete_optimization/rcpsp/rcpsp_model.py
@@ -373,7 +373,8 @@ class RCPSPModel(Problem):
         if rcpsp_sol.rcpsp_schedule_feasible is False:
             logger.debug("Schedule flagged as infeasible when generated")
             return False
-
+        if len(rcpsp_sol.rcpsp_schedule) != self.n_jobs:
+            logger.debug("Missing task in schedule")
         if self.do_special_constraints:
             if not check_solution_with_special_constraints(
                 problem=self,

--- a/discrete_optimization/rcpsp/solver/rcpsp_ga_solver.py
+++ b/discrete_optimization/rcpsp/solver/rcpsp_ga_solver.py
@@ -6,6 +6,7 @@ from typing import Optional
 from discrete_optimization.generic_tools.ea.alternating_ga import AlternatingGa
 from discrete_optimization.generic_tools.ea.ga import Ga
 from discrete_optimization.generic_tools.ea.ga_tools import (
+    DeapCrossover,
     ParametersAltGa,
     ParametersGa,
 )
@@ -15,7 +16,16 @@ from discrete_optimization.rcpsp.solver.rcpsp_solver import SolverRCPSP
 
 class GA_RCPSP_Solver(SolverRCPSP):
     problem: RCPSPModel
-    hyperparameters = Ga.hyperparameters
+    hyperparameters = Ga.copy_and_update_hyperparameters(
+        crossover=dict(
+            choices=[
+                DeapCrossover.CX_UNIFORM_PARTIALY_MATCHED,
+                DeapCrossover.CX_ORDERED,
+                DeapCrossover.CX_PARTIALY_MATCHED,
+            ]
+        )
+    )
+    # RCPSP needs permutation encoding, not all crossover are available.
 
     def solve(self, parameters_ga: Optional[ParametersGa] = None, **args):
         if parameters_ga is None:


### PR DESCRIPTION
a "glitch" was found by running GA_RCPSP solver with a crossover operator that was changing the permutation vector to a non permutation vector. Evaluation function of rcpsp was still functionning because the final task was still scheduled for some hard-to-guess reason. In this PR we try to remove those potentials problems by : 
- insure all task are scheduled in the satisfy function of RCPSP
- reduce the set of hyperparameter value for the crossover operator (but in practice a user can still run the solver with a wrong setting)