### PR TITLE
Add log and step attributes to integer and float hyperparameter

### DIFF
--- a/discrete_optimization/generic_tools/hyperparameters/hyperparameter.py
+++ b/discrete_optimization/generic_tools/hyperparameters/hyperparameter.py
@@ -94,8 +94,12 @@ class IntegerHyperparameter(Hyperparameter):
     If None, the hyperparameter value has no upper bound.
 
     """
+
     step: int = 1
     """step to discretize."""
+
+    log: bool = False
+    """Whether to sample the value in a logarithmic scale."""
 
     default: Optional[int] = None
     """Default value for the hyperparameter.
@@ -129,6 +133,7 @@ class IntegerHyperparameter(Hyperparameter):
         low: Optional[int] = None,
         high: Optional[int] = None,
         step: Optional[int] = None,
+        log: Optional[bool] = None,
         prefix: str = "",
         **kwargs: Any,
     ) -> Any:
@@ -139,6 +144,7 @@ class IntegerHyperparameter(Hyperparameter):
             low: can be used to restrict lower bound
             high: can be used to restrict upper bound
             step: can be used to discretize by a given step
+            log: whether to sample the value in a logarithmic scale
             prefix: prefix to add to optuna corresponding parameter name
               (useful for disambiguating hyperparameters from subsolvers in case of meta-solvers)
             **kwargs: passed to `trial.suggest_int()`
@@ -152,7 +158,9 @@ class IntegerHyperparameter(Hyperparameter):
             high = self.high
         if step is None:
             step = self.step
-        return trial.suggest_int(name=prefix + self.name, low=low, high=high, step=step, **kwargs)  # type: ignore
+        if log is None:
+            log = self.log
+        return trial.suggest_int(name=prefix + self.name, low=low, high=high, step=step, log=log, **kwargs)  # type: ignore
 
 
 @dataclass
@@ -172,6 +180,9 @@ class FloatHyperparameter(Hyperparameter):
     If None, the hyperparameter value has no upper bound.
 
     """
+
+    log: bool = False
+    """Whether to sample the value in a logarithmic scale."""
 
     default: Optional[float] = None
     """Default value for the hyperparameter.
@@ -204,6 +215,7 @@ class FloatHyperparameter(Hyperparameter):
         trial: optuna.trial.Trial,
         low: Optional[float] = None,
         high: Optional[float] = None,
+        log: Optional[bool] = None,
         prefix: str = "",
         **kwargs: Any,
     ) -> Any:
@@ -213,6 +225,7 @@ class FloatHyperparameter(Hyperparameter):
             trial: optuna Trial used for choosing the hyperparameter value
             low: can be used to restrict lower bound
             high: can be used to restrict upper bound
+            log: whether to sample the value in a logarithmic scale
             prefix: prefix to add to optuna corresponding parameter name
               (useful for disambiguating hyperparameters from subsolvers in case of meta-solvers)
             **kwargs: passed to `trial.suggest_float()`
@@ -224,8 +237,10 @@ class FloatHyperparameter(Hyperparameter):
             low = self.low
         if high is None:
             high = self.high
+        if log is None:
+            log = self.log
         return trial.suggest_float(
-            name=prefix + self.name, low=low, high=high, **kwargs
+            name=prefix + self.name, low=low, high=high, log=log, **kwargs
         )
 
 

--- a/discrete_optimization/generic_tools/hyperparameters/hyperparameter.py
+++ b/discrete_optimization/generic_tools/hyperparameters/hyperparameter.py
@@ -181,6 +181,9 @@ class FloatHyperparameter(Hyperparameter):
 
     """
 
+    step: Optional[float] = None
+    """step to discretize if not None."""
+
     log: bool = False
     """Whether to sample the value in a logarithmic scale."""
 
@@ -226,6 +229,9 @@ class FloatHyperparameter(Hyperparameter):
             low: can be used to restrict lower bound
             high: can be used to restrict upper bound
             log: whether to sample the value in a logarithmic scale
+            step: step of discretization if specified.
+                If explicitely set to None, no discretization performed.
+                By default, use self.step (and thus default discretization only if self.step not None)
             prefix: prefix to add to optuna corresponding parameter name
               (useful for disambiguating hyperparameters from subsolvers in case of meta-solvers)
             **kwargs: passed to `trial.suggest_float()`
@@ -239,8 +245,12 @@ class FloatHyperparameter(Hyperparameter):
             high = self.high
         if log is None:
             log = self.log
+        if "step" in kwargs:
+            step = kwargs.pop("step")
+        else:
+            step = self.step
         return trial.suggest_float(
-            name=prefix + self.name, low=low, high=high, log=log, **kwargs
+            name=prefix + self.name, low=low, high=high, log=log, step=step, **kwargs  # type: ignore
         )
 
 


### PR DESCRIPTION
Will be used as default arg for `trial.suggest_integer()` and `trial.suggest_float()`.

Note: `step` already existed for integer hyperparameter only.