### PR TITLE
Add "name_in_kwargs" attribute to hyperparameters

### DIFF
--- a/discrete_optimization/generic_tools/hyperparameters/hyperparameter.py
+++ b/discrete_optimization/generic_tools/hyperparameters/hyperparameter.py
@@ -60,6 +60,13 @@ class Hyperparameter:
 
     """
 
+    name_in_kwargs: Optional[str] = None
+    """Corresponding key in kwargs when suggested via `solver.suggest_hyperparameters_with_optuna().`
+
+    Default to hyperparemeter name. Can be used to have several hyperparameter with different limits/types
+    depending on other hyperparameters value but supposed to share the same name in kwargs for solver initialization.
+    """
+
     def suggest_with_optuna(
         self, trial: optuna.trial.Trial, prefix: str = "", **kwargs: Any
     ) -> Any:
@@ -121,6 +128,13 @@ class IntegerHyperparameter(Hyperparameter):
         - For now, only simple dependency on a single hyperparameter, and a "set" of values is possible.
           The api could evolve to emcompass dependency on several other hyperparameters and more complex condition.
 
+    """
+
+    name_in_kwargs: Optional[str] = None
+    """Corresponding key in kwargs when suggested via `solver.suggest_hyperparameters_with_optuna().`
+
+    Default to hyperparemeter name. Can be used to have several hyperparameter with different limits/types
+    depending on other hyperparameters value but supposed to share the same name in kwargs for solver initialization.
     """
 
     def suggest_with_optuna(
@@ -199,6 +213,13 @@ class FloatHyperparameter(Hyperparameter):
 
     """
 
+    name_in_kwargs: Optional[str] = None
+    """Corresponding key in kwargs when suggested via `solver.suggest_hyperparameters_with_optuna().`
+
+    Default to hyperparemeter name. Can be used to have several hyperparameter with different limits/types
+    depending on other hyperparameters value but supposed to share the same name in kwargs for solver initialization.
+    """
+
     def suggest_with_optuna(
         self,
         trial: optuna.trial.Trial,
@@ -245,8 +266,14 @@ class CategoricalHyperparameter(Hyperparameter):
         choices: Union[Iterable[LabelType], MappingType[LabelType, Any]],
         default: Optional[Any] = None,
         depends_on: Optional[Tuple[str, Container[Any]]] = None,
+        name_in_kwargs: Optional[str] = None,
     ):
-        super().__init__(name=name, default=default, depends_on=depends_on)
+        super().__init__(
+            name=name,
+            default=default,
+            depends_on=depends_on,
+            name_in_kwargs=name_in_kwargs,
+        )
         if isinstance(choices, Mapping):
             self.choices = choices
         else:
@@ -299,12 +326,19 @@ class EnumHyperparameter(CategoricalHyperparameter):
         choices: Optional[Union[Iterable[Enum], Dict[str, Enum]]] = None,
         default: Optional[Any] = None,
         depends_on: Optional[Tuple[str, Container[Any]]] = None,
+        name_in_kwargs: Optional[str] = None,
     ):
         if choices is None:
             choices = {c.name: c for c in enum}
         elif not isinstance(choices, Mapping):
             choices = {c.name: c for c in choices}
-        super().__init__(name, choices=choices, default=default, depends_on=depends_on)
+        super().__init__(
+            name,
+            choices=choices,
+            default=default,
+            depends_on=depends_on,
+            name_in_kwargs=name_in_kwargs,
+        )
         self.enum = enum
 
     def suggest_with_optuna(
@@ -365,6 +399,7 @@ class SubBrickHyperparameter(CategoricalHyperparameter):
         ],
         default: Optional[Any] = None,
         depends_on: Optional[Tuple[str, Container[Any]]] = None,
+        name_in_kwargs: Optional[str] = None,
         include_module_in_labels: bool = False,
     ):
         if not isinstance(choices, Mapping):
@@ -373,7 +408,13 @@ class SubBrickHyperparameter(CategoricalHyperparameter):
             else:
                 choices = {c.__name__: c for c in choices}
 
-        super().__init__(name, choices=choices, default=default, depends_on=depends_on)
+        super().__init__(
+            name,
+            choices=choices,
+            default=default,
+            depends_on=depends_on,
+            name_in_kwargs=name_in_kwargs,
+        )
         self.include_module_in_labels = include_module_in_labels
 
     def suggest_with_optuna(
@@ -433,8 +474,14 @@ class SubBrickKwargsHyperparameter(Hyperparameter):
         subbrick_cls: Optional[Type[Hyperparametrizable]] = None,
         default: Optional[Dict[str, Any]] = None,
         depends_on: Optional[Tuple[str, Container[Any]]] = None,
+        name_in_kwargs: Optional[str] = None,
     ):
-        super().__init__(name=name, default=default, depends_on=depends_on)
+        super().__init__(
+            name=name,
+            default=default,
+            depends_on=depends_on,
+            name_in_kwargs=name_in_kwargs,
+        )
         self.subbrick_cls = subbrick_cls
         self.subbrick_hyperparameter = subbrick_hyperparameter
         if subbrick_cls is None and subbrick_hyperparameter is None:

--- a/discrete_optimization/generic_tools/hyperparameters/hyperparametrizable.py
+++ b/discrete_optimization/generic_tools/hyperparameters/hyperparametrizable.py
@@ -181,7 +181,9 @@ class Hyperparametrizable:
 
 
         Returns:
-            mapping between the hyperparameter name and its suggested value
+            mapping between the hyperparameter name and its suggested value.
+            If the hyperparameter has an attribute `name_in_kwargs`, this is used as the key in the mapping
+            instead of the actual hyperparameter name.
 
         kwargs_by_name[some_name] will be passed as **kwargs to suggest_hyperparameter_with_optuna(name=some_name)
 
@@ -268,8 +270,12 @@ class Hyperparametrizable:
             # NB: we filter the name only now in order to have the skip decision taken before
             # as it could have consequences on hyperparameters further in the dependency graph
             if name in names:
+                if hyperparameter.name_in_kwargs is None:
+                    key = name
+                else:
+                    key = hyperparameter.name_in_kwargs
                 suggested_and_fixed_hyperparameters[
-                    name
+                    key
                 ] = cls.suggest_hyperparameter_with_optuna(
                     trial=trial, name=name, **kwargs_for_optuna_suggestion
                 )

--- a/tests/generic_tools/hyperparameters/test_hyperparameter.py
+++ b/tests/generic_tools/hyperparameters/test_hyperparameter.py
@@ -114,6 +114,37 @@ class DummySolverWithDependencies(SolverDO):
         return ResultStorage([])
 
 
+class DummySolverWithNameInKwargs(SolverDO):
+    hyperparameters = [
+        IntegerHyperparameter("nb", low=0, high=2, default=1),
+        FloatHyperparameter(
+            "coeff_greedy",
+            name_in_kwargs="coeff",
+            low=2.0,
+            high=3.0,
+            default=2.0,
+            depends_on=("method", [Method.GREEDY]),
+        ),
+        FloatHyperparameter(
+            "coeff_dummy",
+            name_in_kwargs="coeff",
+            low=-1.0,
+            high=1.0,
+            default=1.0,
+            depends_on=("method", [Method.DUMMY]),
+        ),
+        CategoricalHyperparameter("use_it", choices=[True, False], default=True),
+        EnumHyperparameter(
+            "method", enum=Method, default=Method.GREEDY, depends_on=("use_it", [True])
+        ),
+    ]
+
+    def solve(
+        self, callbacks: Optional[List[Callback]] = None, **kwargs: Any
+    ) -> ResultStorage:
+        return ResultStorage([])
+
+
 class DummySolver2(SolverDO):
     hyperparameters = [
         CategoricalHyperparameter("nb", choices=[0, 1, 2, 3], default=1),
@@ -345,6 +376,39 @@ def test_suggest_with_optuna_with_dependencies():
     study.optimize(objective)
 
     assert len(study.trials) == 2 * (1 + (1 + 5))
+
+
+def test_suggest_with_optuna_with_name_in_kwargs():
+    def objective(trial: optuna.Trial) -> float:
+        # hyperparameters for the chosen solver
+        suggested_hyperparameters_kwargs = (
+            DummySolverWithNameInKwargs.suggest_hyperparameters_with_optuna(
+                trial=trial,
+                kwargs_by_name={
+                    "coeff_greedy": dict(step=0.5),
+                    "coeff_dummy": dict(step=1.0),
+                    "nb": dict(high=1),
+                },
+            )
+        )
+        if suggested_hyperparameters_kwargs["use_it"]:
+            assert len(suggested_hyperparameters_kwargs) == 4
+            assert "coeff" in suggested_hyperparameters_kwargs
+            if suggested_hyperparameters_kwargs["method"] == Method.GREEDY:
+                assert suggested_hyperparameters_kwargs["coeff"] >= 2.0
+            else:
+                assert suggested_hyperparameters_kwargs["coeff"] <= 1.0
+        else:
+            assert len(suggested_hyperparameters_kwargs) == 2
+
+        return 0.0
+
+    study = optuna.create_study(
+        sampler=optuna.samplers.BruteForceSampler(),
+    )
+    study.optimize(objective)
+
+    assert len(study.trials) == 2 * (1 + (3 + 3))
 
 
 def test_suggest_with_optuna_with_dependencies_and_fixed_hyperparameters():


### PR DESCRIPTION
If `None`, nothing changes.
Else the `name_in_kwargs` is used as the key for the hyperparameter in the dictionary generated by `solver.suggest_hyperparameters_with_optuna()`.

This is useful when several hyperparameters are defined with different characteristics, are depending on others so that only one is suggested at a time among them, and are all expected to have the same name in `solver.__init__`. For instance if they are the parameters of a submethod which is not controlled by the library and happen to share names.