### PR TITLE
Fix lns solve() and unify contraint handlers api

### DIFF
--- a/discrete_optimization/coloring/solvers/coloring_cp_lns_solvers.py
+++ b/discrete_optimization/coloring/solvers/coloring_cp_lns_solvers.py
@@ -113,15 +113,6 @@ class ConstraintHandlerFixColorsCP(MznConstraintHandler):
         self.problem = problem
         self.fraction_to_fix = fraction_to_fix
 
-    def remove_constraints_from_previous_iteration(
-        self,
-        solver: MinizincCPSolver,
-        child_instance: Instance,
-        previous_constraints: Iterable[Any],
-        **kwargs: Any
-    ) -> None:
-        pass
-
     def adding_constraint_from_results_store(
         self,
         solver: MinizincCPSolver,

--- a/discrete_optimization/coloring/solvers/coloring_lp_solvers.py
+++ b/discrete_optimization/coloring/solvers/coloring_lp_solvers.py
@@ -21,7 +21,10 @@ from discrete_optimization.coloring.solvers.greedy_coloring import (
     GreedyColoring,
     NXGreedyColoringMethod,
 )
-from discrete_optimization.generic_tools.do_problem import ParamsObjectiveFunction
+from discrete_optimization.generic_tools.do_problem import (
+    ParamsObjectiveFunction,
+    Problem,
+)
 from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
     CategoricalHyperparameter,
 )
@@ -30,7 +33,6 @@ from discrete_optimization.generic_tools.lp_tools import (
     MilpSolver,
     MilpSolverName,
     PymipMilpSolver,
-    map_solver,
 )
 
 try:
@@ -149,7 +151,7 @@ class ColoringLP(GurobiMilpSolver, _BaseColoringLP):
     """Coloring LP solver based on gurobipy library.
 
     Attributes:
-        coloring_model (ColoringProblem): coloring problem instance to solve
+        problem (ColoringProblem): coloring problem instance to solve
         params_objective_function (ParamsObjectiveFunction): objective function parameters
                 (however this is just used for the ResultStorage creation, not in the optimisation)
 
@@ -321,6 +323,8 @@ class ColoringLP_MIP(PymipMilpSolver, _BaseColoringLP):
 
     hyperparameters = _BaseColoringLP.hyperparameters
 
+    problem: ColoringProblem
+
     def __init__(
         self,
         problem: ColoringProblem,
@@ -328,13 +332,13 @@ class ColoringLP_MIP(PymipMilpSolver, _BaseColoringLP):
         milp_solver_name: MilpSolverName = MilpSolverName.CBC,
         **kwargs: Any,
     ):
-        super().__init__(
+        _BaseColoringLP.__init__(
+            self,
             problem=problem,
             params_objective_function=params_objective_function,
             **kwargs,
         )
-        self.milp_solver_name = milp_solver_name
-        self.solver_name = map_solver[milp_solver_name]
+        self.set_milp_solver_name(milp_solver_name=milp_solver_name)
 
     def init_model(self, **kwargs: Any) -> None:
         kwargs = self.complete_with_default_hyperparameters(kwargs)

--- a/discrete_optimization/facility/solvers/facility_lp_lns_solver.py
+++ b/discrete_optimization/facility/solvers/facility_lp_lns_solver.py
@@ -5,7 +5,7 @@
 import logging
 import random
 from enum import Enum
-from typing import Any, Dict, Hashable, Mapping
+from typing import Any, Iterable
 
 import mip
 
@@ -15,7 +15,6 @@ from discrete_optimization.facility.facility_model import (
 )
 from discrete_optimization.facility.solvers.facility_lp_solver import (
     LP_Facility_Solver_PyMip,
-    MilpSolver,
     MilpSolverName,
 )
 from discrete_optimization.facility.solvers.greedy_solvers import (
@@ -30,9 +29,10 @@ from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
     EnumHyperparameter,
 )
 from discrete_optimization.generic_tools.lns_mip import (
-    ConstraintHandler,
     InitialSolution,
+    PymipConstraintHandler,
 )
+from discrete_optimization.generic_tools.lp_tools import PymipMilpSolver
 
 logger = logging.getLogger(__name__)
 
@@ -89,7 +89,7 @@ class InitialFacilitySolution(InitialSolution):
             )
 
 
-class ConstraintHandlerFacility(ConstraintHandler):
+class ConstraintHandlerFacility(PymipConstraintHandler):
     """Constraint builder used in LNS+LP for coloring problem.
 
     This constraint handler is pretty basic, it fixes a fraction_to_fix proportion of allocation of customer to
@@ -112,8 +112,8 @@ class ConstraintHandlerFacility(ConstraintHandler):
         self.skip_first_iter = skip_first_iter
 
     def adding_constraint_from_results_store(
-        self, solver: MilpSolver, result_storage: ResultStorage, **kwargs: Any
-    ) -> Mapping[Hashable, Any]:
+        self, solver: PymipMilpSolver, result_storage: ResultStorage, **kwargs: Any
+    ) -> Iterable[Any]:
         if not isinstance(solver, LP_Facility_Solver_PyMip):
             raise ValueError(
                 "milp_solver must a LP_Facility_Solver_PyMip for this constraint."
@@ -153,7 +153,7 @@ class ConstraintHandlerFacility(ConstraintHandler):
             if c in subpart_customer:
                 dict_f_fixed[c] = dict_f_start[c]
         x_var = solver.variable_decision["x"]
-        lns_constraint: Dict[Hashable, Any] = {}
+        lns_constraint = []
         for key in x_var:
             f, c = key
             if f == dict_f_start[c]:
@@ -165,35 +165,15 @@ class ConstraintHandlerFacility(ConstraintHandler):
             if c in dict_f_fixed:
                 if f == dict_f_fixed[c]:
                     if isinstance(x_var[f, c], mip.Var):
-                        lns_constraint[(f, c)] = solver.model.add_constr(
-                            x_var[key] == 1, name=str((f, c))
+                        lns_constraint.append(
+                            solver.model.add_constr(x_var[key] == 1, name=str((f, c)))
                         )
                 else:
                     if isinstance(x_var[f, c], mip.Var):
-                        lns_constraint[(f, c)] = solver.model.add_constr(
-                            x_var[key] == 0, name=str((f, c))
+                        lns_constraint.append(
+                            solver.model.add_constr(x_var[key] == 0, name=str((f, c)))
                         )
         if solver.milp_solver_name == MilpSolverName.GRB:
             solver.model.solver.update()
         solver.model.start = start
         return lns_constraint
-
-    def remove_constraints_from_previous_iteration(
-        self,
-        solver: MilpSolver,
-        previous_constraints: Mapping[Hashable, Any],
-        **kwargs: Any,
-    ) -> None:
-        if not isinstance(solver, LP_Facility_Solver_PyMip):
-            raise ValueError(
-                "milp_solver must a LP_Facility_Solver_PyMip for this constraint."
-            )
-        if solver.model is None:  # for mypy
-            solver.init_model()
-            if solver.model is None:
-                raise RuntimeError(
-                    "milp_solver.model must be not None after calling milp_solver.init_model()."
-                )
-        solver.model.remove(list(previous_constraints.values()))
-        if solver.milp_solver_name == MilpSolverName.GRB:
-            solver.model.solver.update()

--- a/discrete_optimization/facility/solvers/facility_lp_solver.py
+++ b/discrete_optimization/facility/solvers/facility_lp_solver.py
@@ -17,7 +17,10 @@ from discrete_optimization.facility.facility_model import (
     FacilitySolution,
 )
 from discrete_optimization.facility.solvers.facility_solver import SolverFacility
-from discrete_optimization.generic_tools.do_problem import ParamsObjectiveFunction
+from discrete_optimization.generic_tools.do_problem import (
+    ParamsObjectiveFunction,
+    Problem,
+)
 from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
     CategoricalHyperparameter,
     IntegerHyperparameter,
@@ -28,7 +31,6 @@ from discrete_optimization.generic_tools.lp_tools import (
     MilpSolverName,
     ParametersMilp,
     PymipMilpSolver,
-    map_solver,
 )
 from discrete_optimization.generic_tools.result_storage.result_storage import (
     ResultStorage,
@@ -448,20 +450,22 @@ class LP_Facility_Solver_PyMip(PymipMilpSolver, _LPFacilitySolverBase):
 
     """
 
+    problem: FacilityProblem
+
     def __init__(
         self,
         problem: FacilityProblem,
-        milp_solver_name: MilpSolverName,
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
+        milp_solver_name: MilpSolverName = MilpSolverName.CBC,
         **kwargs: Any,
     ):
-        super().__init__(
+        _LPFacilitySolverBase.__init__(
+            self,
             problem=problem,
             params_objective_function=params_objective_function,
             **kwargs,
         )
-        self.milp_solver_name = milp_solver_name
-        self.solver_name = map_solver[milp_solver_name]
+        self.set_milp_solver_name(milp_solver_name=milp_solver_name)
 
     def init_model(self, **kwargs: Any) -> None:
         nb_facilities = self.problem.facility_count

--- a/discrete_optimization/generic_rcpsp_tools/neighbor_tools_rcpsp.py
+++ b/discrete_optimization/generic_rcpsp_tools/neighbor_tools_rcpsp.py
@@ -1524,15 +1524,6 @@ class ConstraintHandlerScheduling(MznConstraintHandler):
             list_strings += [s]
         return list_strings
 
-    def remove_constraints_from_previous_iteration(
-        self,
-        solver: ANY_CP_SOLVER,
-        child_instance,
-        previous_constraints: Iterable[Any],
-        **kwargs: Any,
-    ):
-        pass
-
 
 class ConstraintHandlerMultiskillAllocation(MznConstraintHandler):
     def __init__(
@@ -1607,26 +1598,8 @@ class ConstraintHandlerMultiskillAllocation(MznConstraintHandler):
         child_instance.add_string("constraint sec_objective==max(res_load);\n")
         return list_strings
 
-    def remove_constraints_from_previous_iteration(
-        self,
-        solver: ANY_CP_SOLVER,
-        child_instance,
-        previous_constraints: Iterable[Any],
-        **kwargs: Any,
-    ):
-        pass
-
 
 class EquilibrateMultiskillAllocationNonPreemptive(MznConstraintHandler):
-    def remove_constraints_from_previous_iteration(
-        self,
-        solver: ANY_CP_SOLVER,
-        child_instance,
-        previous_constraints: Iterable[Any],
-        **kwargs: Any,
-    ):
-        pass
-
     def __init__(
         self,
         problem: ANY_MSRCPSP,
@@ -1714,15 +1687,6 @@ class EquilibrateMultiskillAllocationNonPreemptive(MznConstraintHandler):
 
 
 class EquilibrateMultiskillAllocation(MznConstraintHandler):
-    def remove_constraints_from_previous_iteration(
-        self,
-        solver: ANY_CP_SOLVER,
-        child_instance,
-        previous_constraints: Iterable[Any],
-        **kwargs: Any,
-    ):
-        pass
-
     def __init__(
         self,
         problem: ANY_MSRCPSP,

--- a/discrete_optimization/generic_rcpsp_tools/solution_repair.py
+++ b/discrete_optimization/generic_rcpsp_tools/solution_repair.py
@@ -539,16 +539,3 @@ class NeighborRepairProblems(MznConstraintHandler):
             child_instance.add_string(s)
             list_strings += [s]
         return list_strings
-
-    def remove_constraints_from_previous_iteration(
-        self,
-        solver: Union[
-            CP_RCPSP_MZN_PREEMPTIVE,
-            CP_MS_MRCPSP_MZN_PREEMPTIVE,
-            CP_MRCPSP_MZN_PREEMPTIVE,
-        ],
-        child_instance,
-        previous_constraints: Iterable[Any],
-        **kwargs: Any,
-    ):
-        pass

--- a/discrete_optimization/generic_tools/lns_cp.py
+++ b/discrete_optimization/generic_tools/lns_cp.py
@@ -17,6 +17,7 @@ from discrete_optimization.generic_tools.do_problem import (
     ParamsObjectiveFunction,
     Problem,
 )
+from discrete_optimization.generic_tools.do_solver import SolverDO
 from discrete_optimization.generic_tools.lns_tools import (
     BaseLNS,
     ConstraintHandler,
@@ -49,15 +50,18 @@ class MznConstraintHandler(ConstraintHandler):
     ) -> Iterable[Any]:
         ...
 
-    @abstractmethod
     def remove_constraints_from_previous_iteration(
         self,
-        solver: MinizincCPSolver,
-        child_instance: Instance,
+        solver: SolverDO,
         previous_constraints: Iterable[Any],
         **kwargs: Any,
     ) -> None:
-        ...
+        """Remove previous constraints.
+
+        Nothing to do for minizinc solvers as the constraints were added only to the child instance.
+
+        """
+        pass
 
 
 class LNS_CP(BaseLNS):
@@ -240,12 +244,3 @@ class ConstraintHandlerMix(MznConstraintHandler):
         return ch.adding_constraint_from_results_store(
             solver, child_instance, result_storage, last_result_store
         )
-
-    def remove_constraints_from_previous_iteration(
-        self,
-        solver: MinizincCPSolver,
-        child_instance: Instance,
-        previous_constraints: Iterable[Any],
-        **kwargs: Any,
-    ) -> None:
-        pass

--- a/discrete_optimization/generic_tools/lns_mip.py
+++ b/discrete_optimization/generic_tools/lns_mip.py
@@ -3,7 +3,7 @@
 #  LICENSE file in the root directory of this source tree.
 
 import logging
-from typing import Any, List, Optional
+from typing import Any, Iterable, List, Optional
 
 from discrete_optimization.generic_tools.callbacks.callback import Callback
 from discrete_optimization.generic_tools.do_problem import (
@@ -16,12 +16,41 @@ from discrete_optimization.generic_tools.lns_tools import (
     InitialSolution,
     PostProcessSolution,
 )
-from discrete_optimization.generic_tools.lp_tools import MilpSolver, ParametersMilp
+from discrete_optimization.generic_tools.lp_tools import (
+    GurobiMilpSolver,
+    MilpSolver,
+    MilpSolverName,
+    ParametersMilp,
+    PymipMilpSolver,
+)
 from discrete_optimization.generic_tools.result_storage.result_storage import (
     ResultStorage,
 )
 
 logger = logging.getLogger(__name__)
+
+
+class GurobiConstraintHandler(ConstraintHandler):
+    def remove_constraints_from_previous_iteration(
+        self,
+        solver: GurobiMilpSolver,
+        previous_constraints: Iterable[Any],
+        **kwargs: Any,
+    ) -> None:
+        solver.model.remove(list(previous_constraints))
+        solver.model.update()
+
+
+class PymipConstraintHandler(ConstraintHandler):
+    def remove_constraints_from_previous_iteration(
+        self,
+        solver: PymipMilpSolver,
+        previous_constraints: Iterable[Any],
+        **kwargs: Any,
+    ) -> None:
+        solver.model.remove(list(previous_constraints))
+        if solver.milp_solver_name == MilpSolverName.GRB:
+            solver.model.solver.update()
 
 
 class LNS_MILP(BaseLNS):

--- a/discrete_optimization/generic_tools/lp_tools.py
+++ b/discrete_optimization/generic_tools/lp_tools.py
@@ -13,7 +13,11 @@ from discrete_optimization.generic_tools.callbacks.callback import (
     Callback,
     CallbackList,
 )
-from discrete_optimization.generic_tools.do_problem import Solution
+from discrete_optimization.generic_tools.do_problem import (
+    ParamsObjectiveFunction,
+    Problem,
+    Solution,
+)
 from discrete_optimization.generic_tools.do_solver import SolverDO
 from discrete_optimization.generic_tools.exceptions import SolveEarlyStop
 from discrete_optimization.generic_tools.result_storage.multiobj_utils import (
@@ -189,6 +193,26 @@ class PymipMilpSolver(MilpSolver):
     """Milp solver wrapping a solver from pymip library."""
 
     model: Optional[mip.Model] = None
+    milp_solver_name: MilpSolverName
+    solver_name: str
+
+    def __init__(
+        self,
+        problem: Problem,
+        params_objective_function: Optional[ParamsObjectiveFunction] = None,
+        milp_solver_name: MilpSolverName = MilpSolverName.CBC,
+        **kwargs: Any,
+    ):
+        super().__init__(
+            problem=problem,
+            params_objective_function=params_objective_function,
+            **kwargs,
+        )
+        self.set_milp_solver_name(milp_solver_name=milp_solver_name)
+
+    def set_milp_solver_name(self, milp_solver_name: MilpSolverName):
+        self.milp_solver_name = milp_solver_name
+        self.solver_name = map_solver[milp_solver_name]
 
     def solve(
         self, parameters_milp: Optional[ParametersMilp] = None, **kwargs: Any

--- a/discrete_optimization/knapsack/solvers/cp_solvers.py
+++ b/discrete_optimization/knapsack/solvers/cp_solvers.py
@@ -352,15 +352,3 @@ class KnapConstraintHandler(MznConstraintHandler):
                 ]
                 child_instance.add_string(strings[-1])
         return strings
-
-    def remove_constraints_from_previous_iteration(
-        self,
-        solver: MinizincCPSolver,
-        child_instance: Instance,
-        previous_constraints: Iterable[Any],
-        **kwargs: Any,
-    ) -> None:
-        if not isinstance(solver, CPMultidimensionalMultiScenarioSolver):
-            raise ValueError(
-                "cp_solver must a CPMultidimensionalMultiScenarioSolver for this constraint."
-            )

--- a/discrete_optimization/knapsack/solvers/knapsack_lns_cp_solver.py
+++ b/discrete_optimization/knapsack/solvers/knapsack_lns_cp_solver.py
@@ -66,13 +66,3 @@ class ConstraintHandlerKnapsack(MznConstraintHandler):
             ]
             child_instance.add_string(list_strings[-1])
         return list_strings
-
-    def remove_constraints_from_previous_iteration(
-        self,
-        solver: MinizincCPSolver,
-        child_instance: Instance,
-        previous_constraints: Iterable[Any],
-        **kwargs: Any
-    ) -> None:
-        if not isinstance(solver, CPKnapsackMZN2):
-            raise ValueError("cp_solver must a CPKnapsackMZN2 for this constraint.")

--- a/discrete_optimization/knapsack/solvers/knapsack_lns_solver.py
+++ b/discrete_optimization/knapsack/solvers/knapsack_lns_solver.py
@@ -4,7 +4,7 @@
 
 import random
 from enum import Enum
-from typing import Any, Dict, Hashable, Mapping
+from typing import Any, Iterable
 
 from discrete_optimization.generic_tools.do_problem import (
     ParamsObjectiveFunction,
@@ -14,10 +14,10 @@ from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
     EnumHyperparameter,
 )
 from discrete_optimization.generic_tools.lns_mip import (
-    ConstraintHandler,
     InitialSolution,
+    PymipConstraintHandler,
 )
-from discrete_optimization.generic_tools.lp_tools import MilpSolver, MilpSolverName
+from discrete_optimization.generic_tools.lp_tools import MilpSolverName, PymipMilpSolver
 from discrete_optimization.knapsack.knapsack_model import (
     KnapsackModel,
     KnapsackSolution,
@@ -74,15 +74,15 @@ class InitialKnapsackSolution(InitialSolution):
             )
 
 
-class ConstraintHandlerKnapsack(ConstraintHandler):
+class ConstraintHandlerKnapsack(PymipConstraintHandler):
     def __init__(self, problem: KnapsackModel, fraction_to_fix: float = 0.9):
         self.problem = problem
         self.fraction_to_fix = fraction_to_fix
         self.iter = 0
 
     def adding_constraint_from_results_store(
-        self, solver: MilpSolver, result_storage: ResultStorage, **kwargs: Any
-    ) -> Mapping[Hashable, Any]:
+        self, solver: PymipMilpSolver, result_storage: ResultStorage, **kwargs: Any
+    ) -> Iterable[Any]:
         if not isinstance(solver, LPKnapsack):
             raise ValueError("milp_solver must a LPKnapsack for this constraint.")
         if solver.model is None:
@@ -114,32 +114,16 @@ class ConstraintHandlerKnapsack(ConstraintHandler):
             if c in subpart_item:
                 dict_f_fixed[c] = dict_f_start[c]
         x_var = solver.variable_decision["x"]
-        lns_constraint: Dict[Hashable, Any] = {}
+        lns_constraint = []
         for key in x_var:
             start += [(x_var[key], dict_f_start[key])]
             if key in subpart_item:
-                lns_constraint[key] = solver.model.add_constr(
-                    x_var[key] == dict_f_start[key], name=str(key)
+                lns_constraint.append(
+                    solver.model.add_constr(
+                        x_var[key] == dict_f_start[key], name=str(key)
+                    )
                 )
         if solver.milp_solver_name == MilpSolverName.GRB:
             solver.model.solver.update()
         solver.model.start = start
         return lns_constraint
-
-    def remove_constraints_from_previous_iteration(
-        self,
-        solver: MilpSolver,
-        previous_constraints: Mapping[Hashable, Any],
-        **kwargs: Any
-    ) -> None:
-        if not isinstance(solver, LPKnapsack):
-            raise ValueError("milp_solver must a ColoringLP for this constraint.")
-        if solver.model is None:
-            solver.init_model()
-            if solver.model is None:
-                raise RuntimeError(
-                    "milp_solver.model must be not None after calling milp_solver.init_model()"
-                )
-        solver.model.remove(list(previous_constraints.values()))
-        if solver.milp_solver_name == MilpSolverName.GRB:
-            solver.model.solver.update()

--- a/discrete_optimization/knapsack/solvers/lp_solvers.py
+++ b/discrete_optimization/knapsack/solvers/lp_solvers.py
@@ -17,7 +17,6 @@ from discrete_optimization.generic_tools.lp_tools import (
     MilpSolver,
     MilpSolverName,
     PymipMilpSolver,
-    map_solver,
 )
 from discrete_optimization.generic_tools.mip.pymip_tools import MyModelMilp
 from discrete_optimization.knapsack.knapsack_model import (
@@ -227,20 +226,22 @@ class LPKnapsackCBC(SolverKnapsack):
 
 # Can use GRB or CBC
 class LPKnapsack(PymipMilpSolver, _BaseLPKnapsack):
+    problem: KnapsackModel
+
     def __init__(
         self,
         problem: KnapsackModel,
-        milp_solver_name: MilpSolverName = MilpSolverName.CBC,
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
+        milp_solver_name: MilpSolverName = MilpSolverName.CBC,
         **kwargs: Any,
     ):
-        super().__init__(
+        _BaseLPKnapsack.__init__(
+            self,
             problem=problem,
             params_objective_function=params_objective_function,
             **kwargs,
         )
-        self.milp_solver_name = milp_solver_name
-        self.solver_name = map_solver[milp_solver_name]
+        self.set_milp_solver_name(milp_solver_name=milp_solver_name)
 
     def init_model(self, **kwargs: Any) -> None:
         warm_start = kwargs.get("warm_start", {})

--- a/discrete_optimization/pickup_vrp/solver/lp_solver_pymip.py
+++ b/discrete_optimization/pickup_vrp/solver/lp_solver_pymip.py
@@ -29,7 +29,11 @@ from discrete_optimization.generic_tools.do_problem import (
     ParamsObjectiveFunction,
     Solution,
 )
-from discrete_optimization.generic_tools.lp_tools import ParametersMilp, PymipMilpSolver
+from discrete_optimization.generic_tools.lp_tools import (
+    MilpSolverName,
+    ParametersMilp,
+    PymipMilpSolver,
+)
 from discrete_optimization.generic_tools.result_storage.result_storage import (
     ResultStorage,
     TupleFitness,
@@ -112,12 +116,15 @@ class LinearFlowSolver(PymipMilpSolver, SolverPickupVrp):
         self,
         problem: GPDP,
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
+        milp_solver_name: MilpSolverName = MilpSolverName.CBC,
         **kwargs: Any,
     ):
         super().__init__(
-            problem=problem, params_objective_function=params_objective_function
+            problem=problem,
+            params_objective_function=params_objective_function,
+            milp_solver_name=milp_solver_name,
+            **kwargs,
         )
-        self.model: Optional[mip.Model] = None
         self.constraint_on_edge: Dict[int, Any] = {}
         self.variable_order: Dict[Node, Any] = {}
 
@@ -334,7 +341,7 @@ class LinearFlowSolver(PymipMilpSolver, SolverPickupVrp):
         return {"time_coming": time_coming, "time_leaving": time_leaving}
 
     def init_model(self, **kwargs: Any) -> None:
-        solver_name = kwargs.get("solver_name", mip.CBC)
+        solver_name = kwargs.get("solver_name", self.solver_name)
         model: mip.Model = mip.Model(
             "GPDP-flow", sense=mip.MINIMIZE, solver_name=solver_name
         )

--- a/discrete_optimization/rcpsp/solver/rcpsp_lp_lns_solver.py
+++ b/discrete_optimization/rcpsp/solver/rcpsp_lp_lns_solver.py
@@ -5,7 +5,7 @@
 import logging
 import random
 from enum import Enum
-from typing import Any, Hashable, List, Mapping, Optional
+from typing import Any, Iterable, List, Optional
 
 import mip
 import numpy as np
@@ -19,8 +19,9 @@ from discrete_optimization.generic_tools.do_problem import (
 )
 from discrete_optimization.generic_tools.lns_mip import (
     LNS_MILP,
-    ConstraintHandler,
+    GurobiConstraintHandler,
     InitialSolution,
+    PymipConstraintHandler,
 )
 from discrete_optimization.generic_tools.lp_tools import ParametersMilp
 from discrete_optimization.generic_tools.ls.local_search import (
@@ -142,17 +143,17 @@ class InitialSolutionRCPSP(InitialSolution):
         return store_solution
 
 
-class ConstraintHandlerFixStartTime(ConstraintHandler):
+class ConstraintHandlerFixStartTime(PymipConstraintHandler):
     def __init__(self, problem: RCPSPModel, fraction_fix_start_time: float = 0.9):
         self.problem = problem
         self.fraction_fix_start_time = fraction_fix_start_time
 
     def adding_constraint_from_results_store(
         self, solver: LP_RCPSP, result_storage: ResultStorage, **kwargs: Any
-    ) -> Mapping[Hashable, Any]:
+    ) -> Iterable[Any]:
 
         nb_jobs = self.problem.n_jobs + 2
-        constraints_dict = {}
+        lns_constraints = []
         current_solution, fit = result_storage.get_best_solution_fit()
         current_solution: RCPSPSolution = current_solution
         # Starting point :
@@ -173,37 +174,26 @@ class ConstraintHandlerFixStartTime(ConstraintHandler):
                 int(self.fraction_fix_start_time * nb_jobs),
             )
         )
-        constraints_dict["fix_start_time"] = []
         for job_to_fix in jobs_to_fix:
             for t in solver.index_time:
                 if current_solution.rcpsp_schedule[job_to_fix]["start_time"] == t:
-                    constraints_dict["fix_start_time"].append(
+                    lns_constraints.append(
                         solver.model.add_constr(
                             solver.x[solver.index_in_var[job_to_fix]][t] == 1
                         )
                     )
                 else:
-                    constraints_dict["fix_start_time"].append(
+                    lns_constraints.append(
                         solver.model.add_constr(
                             solver.x[solver.index_in_var[job_to_fix]][t] == 0
                         )
                     )
             if solver.solver_name == mip.GRB:
                 solver.model.solver.update()
-        return constraints_dict
-
-    def remove_constraints_from_previous_iteration(
-        self,
-        solver: LP_RCPSP,
-        previous_constraints: Mapping[Hashable, Any],
-        **kwargs: Any
-    ):
-        solver.model.remove(previous_constraints["fix_start_time"])
-        if solver.solver_name == mip.GRB:
-            solver.model.solver.update()
+        return lns_constraints
 
 
-class ConstraintHandlerStartTimeInterval(ConstraintHandler):
+class ConstraintHandlerStartTimeInterval(PymipConstraintHandler):
     def __init__(
         self,
         problem: RCPSPModel,
@@ -218,8 +208,8 @@ class ConstraintHandlerStartTimeInterval(ConstraintHandler):
 
     def adding_constraint_from_results_store(
         self, solver: LP_RCPSP, result_storage: ResultStorage, **kwargs: Any
-    ) -> Mapping[Hashable, Any]:
-        constraints_dict = {}
+    ) -> Iterable[Any]:
+        lns_constraints = []
         current_solution, fit = result_storage.get_best_solution_fit()
         # Starting point :
         current_solution: RCPSPSolution = current_solution
@@ -233,7 +223,6 @@ class ConstraintHandlerStartTimeInterval(ConstraintHandler):
                 else:
                     start += [(solver.x[solver.index_in_var[j]][t], 0)]
         solver.model.start = start
-        constraints_dict["range_start_time"] = []
         max_time = max(
             [
                 current_solution.rcpsp_schedule[x]["end_time"]
@@ -261,27 +250,17 @@ class ConstraintHandlerStartTimeInterval(ConstraintHandler):
             max_st = min(start_time_j + self.plus_delta, max_time)
             for t in solver.index_time:
                 if t < min_st or t > max_st:
-                    constraints_dict["range_start_time"].append(
+                    lns_constraints.append(
                         solver.model.add_constr(
                             solver.x[solver.index_in_var[job]][t] == 0
                         )
                     )
         if solver.solver_name == mip.GRB:
             solver.model.solver.update()
-        return constraints_dict
-
-    def remove_constraints_from_previous_iteration(
-        self,
-        solver: LP_RCPSP,
-        previous_constraints: Mapping[Hashable, Any],
-        **kwargs: Any
-    ):
-        solver.model.remove(previous_constraints["range_start_time"])
-        if solver.solver_name == mip.GRB:
-            solver.model.solver.update()
+        return lns_constraints
 
 
-class ConstraintHandlerStartTimeIntervalMRCPSP(ConstraintHandler):
+class ConstraintHandlerStartTimeIntervalMRCPSP(PymipConstraintHandler):
     def __init__(
         self,
         problem: RCPSPModel,
@@ -296,7 +275,7 @@ class ConstraintHandlerStartTimeIntervalMRCPSP(ConstraintHandler):
 
     def adding_constraint_from_results_store(
         self, solver: LP_MRCPSP, result_storage: ResultStorage, **kwargs: Any
-    ) -> Mapping[Hashable, Any]:
+    ) -> Iterable[Any]:
         current_solution, fit = result_storage.get_best_solution_fit()
         current_solution: RCPSPSolution = current_solution
         st = solver.start_solution
@@ -323,7 +302,7 @@ class ConstraintHandlerStartTimeIntervalMRCPSP(ConstraintHandler):
                 else:
                     start += [(solver.x[k], 0)]
         solver.model.start = start
-        constraints_dict = {"range_start_time": []}
+        lns_constraints = []
         max_time = max(
             [
                 current_solution.rcpsp_schedule[x]["end_time"]
@@ -352,25 +331,13 @@ class ConstraintHandlerStartTimeIntervalMRCPSP(ConstraintHandler):
             for key in solver.variable_per_task[job]:
                 t = key[2]
                 if t < min_st or t > max_st:
-                    constraints_dict["range_start_time"].append(
-                        solver.model.add_constr(solver.x[key] == 0)
-                    )
+                    lns_constraints.append(solver.model.add_constr(solver.x[key] == 0))
         if solver.solver_name == mip.GRB:
             solver.model.solver.update()
-        return constraints_dict
-
-    def remove_constraints_from_previous_iteration(
-        self,
-        solver: LP_MRCPSP,
-        previous_constraints: Mapping[Hashable, Any],
-        **kwargs: Any
-    ):
-        solver.model.remove(previous_constraints["range_start_time"])
-        if solver.solver_name == mip.GRB:
-            solver.model.solver.update()
+        return lns_constraints
 
 
-class ConstraintHandlerStartTimeIntervalMRCPSP_GRB(ConstraintHandler):
+class ConstraintHandlerStartTimeIntervalMRCPSP_GRB(GurobiConstraintHandler):
     def __init__(
         self,
         problem: RCPSPModel,
@@ -385,7 +352,7 @@ class ConstraintHandlerStartTimeIntervalMRCPSP_GRB(ConstraintHandler):
 
     def adding_constraint_from_results_store(
         self, solver: LP_MRCPSP_GUROBI, result_storage: ResultStorage, **kwargs: Any
-    ) -> Mapping[Hashable, Any]:
+    ) -> Iterable[Any]:
         current_solution, fit = result_storage.get_best_solution_fit()
         st = solver.start_solution
         if (
@@ -411,7 +378,7 @@ class ConstraintHandlerStartTimeIntervalMRCPSP_GRB(ConstraintHandler):
                     solver.starts[j].start = start_time_j
                 else:
                     solver.x[k].start = 0
-        constraints_dict = {"range_start_time": []}
+        constraints = []
         max_time = max(
             [
                 current_solution.rcpsp_schedule[x]["end_time"]
@@ -440,20 +407,9 @@ class ConstraintHandlerStartTimeIntervalMRCPSP_GRB(ConstraintHandler):
             for key in solver.variable_per_task[job]:
                 t = key[2]
                 if t < min_st or t > max_st:
-                    constraints_dict["range_start_time"].append(
-                        solver.model.addLConstr(solver.x[key] == 0)
-                    )
+                    constraints.append(solver.model.addLConstr(solver.x[key] == 0))
         solver.model.update()
-        return constraints_dict
-
-    def remove_constraints_from_previous_iteration(
-        self,
-        solver: LP_MRCPSP_GUROBI,
-        previous_constraints: Mapping[Hashable, Any],
-        **kwargs: Any
-    ):
-        solver.model.remove(previous_constraints.get("range_start_time", []))
-        solver.model.update()
+        return constraints
 
 
 class LNS_LP_RCPSP_SOLVER(SolverRCPSP):

--- a/discrete_optimization/rcpsp/solver/rcpsp_lp_solver_gantt.py
+++ b/discrete_optimization/rcpsp/solver/rcpsp_lp_solver_gantt.py
@@ -153,20 +153,24 @@ class LP_MRCPSP_GANTT(PymipMilpSolver, _Base_LP_MRCPSP_GANTT):
         self,
         problem: RCPSPModel,
         rcpsp_solution: RCPSPSolution,
-        lp_solver=MilpSolverName.CBC,
+        milp_solver_name=MilpSolverName.CBC,
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
         **kwargs,
     ):
-        super().__init__(
+        _Base_LP_MRCPSP_GANTT.__init__(
+            self,
             problem=problem,
             rcpsp_solution=rcpsp_solution,
             params_objective_function=params_objective_function,
             **kwargs,
         )
-        self.lp_solver = lp_solver
+        # backward compatibility: lp_solver -> milp_solver_name
+        if "lp_solver" in kwargs:
+            milp_solver_name = kwargs["lp_solver"]
+        self.set_milp_solver_name(milp_solver_name=milp_solver_name)
 
     def init_model(self, **args):
-        self.model = Model(sense=MINIMIZE, solver_name=map_solver[self.lp_solver])
+        self.model = Model(sense=MINIMIZE, solver_name=self.solver_name)
         self.ressource_id_usage = {
             k: {i: {} for i in range(len(self.problem.calendar_details[k]))}
             for k in self.problem.calendar_details.keys()

--- a/discrete_optimization/rcpsp_multiskill/solvers/lp_model.py
+++ b/discrete_optimization/rcpsp_multiskill/solvers/lp_model.py
@@ -34,21 +34,25 @@ class LP_Solver_MRSCPSP(PymipMilpSolver):
     def __init__(
         self,
         problem: MS_RCPSPModel,
-        lp_solver: MilpSolverName = MilpSolverName.CBC,
+        milp_solver_name: MilpSolverName = MilpSolverName.CBC,
         params_objective_function: ParamsObjectiveFunction = None,
         **kwargs,
     ):
+        # backward compatibility: lp_solver -> milp_solver_name
+        if "lp_solver" in kwargs:
+            milp_solver_name = kwargs["lp_solver"]
+
         super().__init__(
-            problem=problem, params_objective_function=params_objective_function
+            problem=problem,
+            params_objective_function=params_objective_function,
+            milp_solver_name=milp_solver_name,
+            **kwargs,
         )
-        self.lp_solver = lp_solver
         self.variable_decision = {}
         self.constraints_dict = {"lns": []}
 
     def init_model(self, **args):
-        self.model = Model(
-            name="mrcpsp", sense=MINIMIZE, solver_name=map_solver[self.lp_solver]
-        )
+        self.model = Model(name="mrcpsp", sense=MINIMIZE, solver_name=self.solver_name)
         sorted_tasks = self.problem.tasks_list
         max_time = args.get("max_time", self.problem.horizon)
         max_duration = max_time


### PR DESCRIPTION
Do not forget to remove new constraints at the end of each lns iteration.
For minizinc lns, it is not doing anything are this is manage by the child instance creation but for mip lns, this is relevant.

We implement `remove_constraints_from_previous_iteration()` once for all in base classes for
- minizinc based constraint handlers (by doing nothing).
- gurobi based constraint handlers
- pymip based constraint handlers

We also unify their api so that the return value for `adding_constraint_from_results_store()`
(and type of previous_constraints in `remove_constraints_from_previous_iteration`)
is always an iterable of constraints. (no more dictionaries)

Add a common `__init__` for `PymipMilpSolver` to ensure that each pymip solvers have
a `milp_solver_name` attribute needed by the constraint handler `remove***()` method.