### PR TITLE
Implement lexicographic optimization

### DIFF
--- a/discrete_optimization/generic_tools/do_problem.py
+++ b/discrete_optimization/generic_tools/do_problem.py
@@ -213,6 +213,9 @@ class ObjectiveRegister:
         self.objective_handling = objective_handling
         self.dict_objective_to_doc = dict_objective_to_doc
 
+    def get_objective_names(self) -> List[str]:
+        return sorted(self.dict_objective_to_doc)
+
     def get_list_objective_and_default_weight(self) -> Tuple[List[str], List[float]]:
         """Flatten the list of kpi names and default weight.
 
@@ -220,7 +223,7 @@ class ObjectiveRegister:
         """
         d = [
             (k, self.dict_objective_to_doc[k].default_weight)
-            for k in self.dict_objective_to_doc
+            for k in self.get_objective_names()
         ]
         return [s[0] for s in d], [s[1] for s in d]
 
@@ -313,8 +316,7 @@ class Problem:
         Returns (TupleFitness): a flattened tuple fitness object representing the multi-objective criteria.
 
         """
-        obj_register = self.get_objective_register()
-        keys = sorted(obj_register.dict_objective_to_doc.keys())
+        keys = self.get_objective_names()
         dict_values = self.evaluate(variable)
         return TupleFitness(np.array([dict_values[k] for k in keys]), len(keys))
 
@@ -331,7 +333,7 @@ class Problem:
 
         """
         # output of evaluate(solution) typically
-        keys = sorted(self.get_objective_register().dict_objective_to_doc.keys())
+        keys = self.get_objective_names()
         return TupleFitness(np.array([dict_values[k] for k in keys]), len(keys))
 
     @abstractmethod
@@ -379,6 +381,9 @@ class Problem:
         else:
             direction = "maximize"
         return direction
+
+    def get_objective_names(self) -> List[str]:
+        return self.get_objective_register().get_objective_names()
 
 
 class BaseMethodAggregating(Enum):

--- a/discrete_optimization/generic_tools/lexico_tools.py
+++ b/discrete_optimization/generic_tools/lexico_tools.py
@@ -1,0 +1,120 @@
+#  Copyright (c) 2024 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+"""Tools for lexicographic optimization."""
+import logging
+from typing import Any, Iterable, List, Optional, Protocol
+
+from discrete_optimization.generic_tools.callbacks.callback import (
+    Callback,
+    CallbackList,
+)
+from discrete_optimization.generic_tools.do_problem import (
+    ObjectiveHandling,
+    ParamsObjectiveFunction,
+    Problem,
+    get_default_objective_setup,
+)
+from discrete_optimization.generic_tools.do_solver import SolverDO
+from discrete_optimization.generic_tools.result_storage.result_storage import (
+    ResultStorage,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class LexicoSolver(SolverDO):
+
+    subsolver: SolverDO
+
+    def __init__(
+        self,
+        subsolver: Optional[SolverDO],
+        problem: Problem,
+        params_objective_function: Optional[ParamsObjectiveFunction] = None,
+        **kwargs: Any,
+    ):
+        # ensure no aggregation performed
+        if params_objective_function is None:
+            params_objective_function = get_default_objective_setup(problem)
+        params_objective_function.objective_handling = ObjectiveHandling.MULTI_OBJ
+
+        # SolverDO init after updating params_objective_function
+        super().__init__(
+            problem=problem,
+            params_objective_function=params_objective_function,
+            **kwargs,
+        )
+
+        # get subsolver (directly or from its hyperparameters to allow optuna tuning)
+        kwargs = self.complete_with_default_hyperparameters(kwargs)
+        if subsolver is None:
+            if kwargs["subsolver_kwargs"] is None:
+                subsolver_kwargs = kwargs
+            else:
+                subsolver_kwargs = kwargs["subsolver_kwargs"]
+            if kwargs["subsolver_cls"] is None:
+                if "build_default_subsolver" in kwargs:
+                    subsolver = kwargs["build_default_subsolver"](
+                        self.problem, **subsolver_kwargs
+                    )
+                else:
+                    raise ValueError(
+                        "`subsolver_cls` cannot be None if `subsolver` is not specified."
+                    )
+            else:
+                subsolver_cls = kwargs["subsolver_cls"]
+                subsolver = subsolver_cls(problem=self.problem, **subsolver_kwargs)
+                subsolver.init_model(**subsolver_kwargs)
+        self.subsolver = subsolver
+
+        # check compatibility with lexico optimization
+        if not subsolver.implements_lexico_api():
+            logger.warning(
+                "The chosen subsolver may not be implementing the api needed by LexicoSolver!"
+            )
+
+    def init_model(self, **kwargs: Any) -> None:
+        self.subsolver.init_model(**kwargs)
+
+    def solve(
+        self,
+        callbacks: Optional[List[Callback]] = None,
+        objectives: Optional[Iterable[str]] = None,
+        **kwargs: Any,
+    ) -> ResultStorage:
+        # wrap all callbacks in a single one
+        callbacks_list = CallbackList(callbacks=callbacks)
+        # start of solve callback
+        callbacks_list.on_solve_start(solver=self)
+
+        if objectives is None:
+            objectives = self.subsolver.get_model_objectives_available()
+
+        res = ResultStorage(
+            mode_optim=self.params_objective_function.sense_function,
+            list_solution_fits=[],
+        )
+
+        for i_obj, obj in enumerate(objectives):
+
+            # log
+            logger.debug(f"Optimizing on {obj}")
+
+            # optimize next objective
+            self.subsolver.set_model_objective(obj)
+            res.extend(self.subsolver.solve(**kwargs))
+
+            # end of step callback: stopping?
+            stopping = callbacks_list.on_step_end(step=i_obj, res=res, solver=self)
+            if stopping:
+                break
+
+            # add constraint on current objective for next one
+            fit = self.subsolver.get_model_objective_value(obj, res)
+            self.subsolver.add_model_constraint(obj, fit)
+
+        # end of solve callback
+        callbacks_list.on_solve_end(res=res, solver=self)
+
+        return res

--- a/discrete_optimization/generic_tools/ortools_cpsat_tools.py
+++ b/discrete_optimization/generic_tools/ortools_cpsat_tools.py
@@ -3,13 +3,14 @@
 #  LICENSE file in the root directory of this source tree.
 import logging
 from abc import abstractmethod
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 from ortools.sat.python.cp_model import (
     FEASIBLE,
     INFEASIBLE,
     OPTIMAL,
     UNKNOWN,
+    Constraint,
     CpModel,
     CpSolver,
     CpSolverSolutionCallback,
@@ -106,6 +107,20 @@ class OrtoolsCPSatSolver(CPSolver):
         res = ortools_callback.res
         callbacks_list.on_solve_end(res=res, solver=self)
         return res
+
+    def remove_model_constraint(self, constraints: Iterable[Any]) -> None:
+        """Remove the intern model constraints.
+
+        Args:
+            constraints: constraints created with `add_model_constraint()`
+
+        Returns:
+
+        """
+        for cstr in constraints:
+            if not isinstance(cstr, Constraint):
+                raise RuntimeError()
+            cstr.proto.Clear()
 
 
 class OrtoolsCallback(CpSolverSolutionCallback):

--- a/tests/knapsack/test_knapsack_lexico_ortools_solver.py
+++ b/tests/knapsack/test_knapsack_lexico_ortools_solver.py
@@ -1,0 +1,109 @@
+#  Copyright (c) 2022 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+import logging
+from typing import Dict, List, Optional
+
+import numpy as np
+import pytest
+
+from discrete_optimization.generic_tools.callbacks.callback import Callback
+from discrete_optimization.generic_tools.callbacks.early_stoppers import TimerStopper
+from discrete_optimization.generic_tools.cp_tools import ParametersCP
+from discrete_optimization.generic_tools.do_problem import get_default_objective_setup
+from discrete_optimization.generic_tools.do_solver import SolverDO
+from discrete_optimization.generic_tools.lexico_tools import LexicoSolver
+from discrete_optimization.generic_tools.ls.hill_climber import HillClimberPareto
+from discrete_optimization.generic_tools.ls.local_search import RestartHandlerLimit
+from discrete_optimization.generic_tools.ls.simulated_annealing import (
+    ModeMutation,
+    SimulatedAnnealing,
+    TemperatureSchedulingFactor,
+)
+from discrete_optimization.generic_tools.mutations.mixed_mutation import (
+    BasicPortfolioMutation,
+)
+from discrete_optimization.generic_tools.mutations.mutation_catalog import (
+    get_available_mutations,
+)
+from discrete_optimization.generic_tools.result_storage.multiobj_utils import (
+    TupleFitness,
+)
+from discrete_optimization.generic_tools.result_storage.result_storage import (
+    ResultStorage,
+)
+from discrete_optimization.knapsack.knapsack_model import (
+    KnapsackModel,
+    KnapsackModel_Mobj,
+)
+from discrete_optimization.knapsack.knapsack_parser import (
+    get_data_available,
+    parse_file,
+)
+from discrete_optimization.knapsack.mutation.mutation_knapsack import MutationKnapsack
+from discrete_optimization.knapsack.solvers.knapsack_cpsat_solver import (
+    CPSatKnapsackSolver,
+)
+
+
+def fit2dict(solver: SolverDO, fit: TupleFitness) -> Dict[str, float]:
+    return dict(zip(solver.problem.get_objective_names(), fit.vector_fitness))
+
+
+class MyCallback(Callback):
+    def __init__(self):
+        self.res_by_step: List[List[Dict[str, float]]] = []
+
+    def on_step_end(
+        self, step: int, res: ResultStorage, solver: SolverDO
+    ) -> Optional[bool]:
+        subres = [fit2dict(solver, fit) for sol, fit in res.list_solution_fits]
+        print(subres)
+        self.res_by_step.append(subres)
+
+        return False
+
+
+@pytest.mark.parametrize(
+    "objectives",
+    [
+        ("value", "weight", "heaviest_item"),
+        ("weight", "heaviest_item", "value"),
+        ("heaviest_item", "value", "weight"),
+    ],
+)
+def test_knapsack_ortools_lexico(objectives):
+    model_file = [f for f in get_data_available() if "ks_60_0" in f][0]
+    model: KnapsackModel = parse_file(model_file, force_recompute_values=True)
+    model: KnapsackModel_Mobj = KnapsackModel_Mobj.from_knapsack(model)
+    subsolver = CPSatKnapsackSolver(model)
+    solver = LexicoSolver(
+        problem=model,
+        subsolver=subsolver,
+    )
+    solver.init_model()
+    parameters_cp = ParametersCP.default()
+    parameters_cp.time_limit = 10
+    mycb = MyCallback()
+    result_storage = solver.solve(
+        parameters_cp=parameters_cp,
+        objectives=objectives,
+        callbacks=[mycb],
+    )
+
+    previous_obj_best_value = None
+    previous_obj = None
+    for obj, subres in zip(objectives, mycb.res_by_step):
+        if previous_obj_best_value is not None and previous_obj is not None:
+            assert all(d[previous_obj] >= previous_obj_best_value for d in subres)
+        previous_obj_best_value = max([d[obj] for d in subres])
+        previous_obj = obj
+
+    last_fit_dict = mycb.res_by_step[-1][-1]
+    first_obj = objectives[0]
+    if first_obj == "value":
+        assert last_fit_dict[first_obj] == 99837.0
+    elif first_obj == "weight":
+        assert last_fit_dict[first_obj] == 0.0
+    elif first_obj == "heaviest_item":
+        assert last_fit_dict[first_obj] == 90001.0

--- a/tests/rcpsp/solver/test_rcpsp_cp.py
+++ b/tests/rcpsp/solver/test_rcpsp_cp.py
@@ -46,6 +46,7 @@ from discrete_optimization.rcpsp.solver.cp_solvers_multiscenario import CP_MULTI
 from discrete_optimization.rcpsp.solver.cpsat_solver import (
     CPSatRCPSPSolver,
     CPSatRCPSPSolverCumulativeResource,
+    CPSatRCPSPSolverResource,
 )
 
 
@@ -147,11 +148,27 @@ def test_ortools(model):
     "model",
     ["j301_1.sm", "j1010_1.mm"],
 )
-def test_ortools_resource_optim(model):
+def test_ortools_cumulativeresource_optim(model):
     files_available = get_data_available()
     file = [f for f in files_available if model in f][0]
     rcpsp_problem = parse_file(file)
     solver = CPSatRCPSPSolverCumulativeResource(problem=rcpsp_problem)
+    parameters_cp = ParametersCP.default()
+    parameters_cp.time_limit = 50
+    result_storage = solver.solve(parameters_cp=parameters_cp)
+    solution, fit = result_storage.get_best_solution_fit()
+    assert rcpsp_problem.satisfy(solution)
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["j301_1.sm", "j1010_1.mm"],
+)
+def test_ortools_resource_optim(model):
+    files_available = get_data_available()
+    file = [f for f in files_available if model in f][0]
+    rcpsp_problem = parse_file(file)
+    solver = CPSatRCPSPSolverResource(problem=rcpsp_problem)
     parameters_cp = ParametersCP.default()
     parameters_cp.time_limit = 50
     result_storage = solver.solve(parameters_cp=parameters_cp)

--- a/tests/rcpsp/solver/test_rcpsp_ortools_lexico.py
+++ b/tests/rcpsp/solver/test_rcpsp_ortools_lexico.py
@@ -1,0 +1,130 @@
+#  Copyright (c) 2022 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+
+import logging
+import random
+
+import numpy as np
+import pytest
+
+from discrete_optimization.datasets import get_data_home
+from discrete_optimization.generic_tools.callbacks.callback import Callback
+from discrete_optimization.generic_tools.callbacks.early_stoppers import (
+    NbIterationStopper,
+    TimerStopper,
+)
+from discrete_optimization.generic_tools.callbacks.loggers import NbIterationTracker
+from discrete_optimization.generic_tools.cp_tools import CPSolverName, ParametersCP
+from discrete_optimization.generic_tools.do_problem import (
+    BaseMethodAggregating,
+    MethodAggregating,
+)
+from discrete_optimization.generic_tools.lexico_tools import LexicoSolver
+from discrete_optimization.generic_tools.result_storage.result_storage import (
+    ResultStorage,
+    result_storage_to_pareto_front,
+)
+from discrete_optimization.rcpsp.rcpsp_model import RCPSPModel
+from discrete_optimization.rcpsp.rcpsp_parser import get_data_available, parse_file
+from discrete_optimization.rcpsp.rcpsp_solution import PartialSolution, RCPSPSolution
+from discrete_optimization.rcpsp.rcpsp_utils import (
+    kendall_tau_similarity,
+    plot_task_gantt,
+)
+from discrete_optimization.rcpsp.robust_rcpsp import (
+    AggregRCPSPModel,
+    MethodBaseRobustification,
+    MethodRobustification,
+    UncertainRCPSPModel,
+    create_poisson_laws_duration,
+)
+from discrete_optimization.rcpsp.solver.cp_solvers import (
+    CP_MRCPSP_MZN,
+    CP_MRCPSP_MZN_NOBOOL,
+    CP_RCPSP_MZN,
+)
+from discrete_optimization.rcpsp.solver.cp_solvers_multiscenario import CP_MULTISCENARIO
+from discrete_optimization.rcpsp.solver.cpsat_solver import (
+    CPSatRCPSPSolver,
+    CPSatRCPSPSolverCumulativeResource,
+    CPSatRCPSPSolverResource,
+)
+
+
+@pytest.mark.parametrize(
+    "objectives",
+    [
+        None,
+        ["makespan", "used_resource"],
+        ("used_resource", "makespan"),
+    ],
+)
+def test_ortools_cumulativeresource_optim(objectives):
+    files_available = get_data_available()
+    file = [f for f in files_available if "j301_1.sm" in f][0]
+    rcpsp_problem = parse_file(file)
+    subsolver = CPSatRCPSPSolverCumulativeResource(problem=rcpsp_problem)
+
+    solver = LexicoSolver(
+        problem=rcpsp_problem,
+        subsolver=subsolver,
+    )
+    solver.init_model()
+    parameters_cp = ParametersCP.default()
+    parameters_cp.time_limit = 10
+
+    result_storage = solver.solve(
+        parameters_cp=parameters_cp,
+        objectives=objectives,
+    )
+
+    print([sol._intern_objectives for sol, fit in result_storage.list_solution_fits])
+
+    for obj in subsolver.get_model_objectives_available():
+        obj_array = np.array(
+            [
+                sol._intern_objectives[obj]
+                for sol, fit in result_storage.list_solution_fits
+            ]
+        )
+        assert (obj_array[1:] <= obj_array[:-1]).all()
+
+
+@pytest.mark.parametrize(
+    "objectives",
+    [
+        None,
+        ["makespan", "used_resource"],
+        ("used_resource", "makespan"),
+    ],
+)
+def test_ortools_resource_optim(objectives):
+    files_available = get_data_available()
+    file = [f for f in files_available if "j301_1.sm" in f][0]
+    rcpsp_problem = parse_file(file)
+    subsolver = CPSatRCPSPSolverResource(problem=rcpsp_problem)
+
+    solver = LexicoSolver(
+        problem=rcpsp_problem,
+        subsolver=subsolver,
+    )
+    solver.init_model()
+    parameters_cp = ParametersCP.default()
+    parameters_cp.time_limit = 10
+
+    result_storage = solver.solve(
+        parameters_cp=parameters_cp,
+        objectives=objectives,
+    )
+
+    print([sol._intern_objectives for sol, fit in result_storage.list_solution_fits])
+
+    for obj in subsolver.get_model_objectives_available():
+        obj_array = np.array(
+            [
+                sol._intern_objectives[obj]
+                for sol, fit in result_storage.list_solution_fits
+            ]
+        )
+        assert (obj_array[1:] <= obj_array[:-1]).all()


### PR DESCRIPTION
- Add a `LexicoSolver` which makes a given subsolver solve sequentially
  several specified objectives, while adding a constraint at each step
  to avoid worsening results according to previous objectives

- Add a bunch of methods to implement (with partial default
  implementation) so that a solver can be used as a subsolver by
  `LexicoSolver`:
  - `implements_lexico_api()`: returns `True` if the solver is lexico ready
    (ie implement subsequent methods). `LexicoSolver` raise a warning if
    this is not the case
  - `get_model_objectives_available()`: list of labels available
    corresponding to the intern objectives the solver can optimize.
    Defaults to keys of the problem's `ObjectiveRegister` (via new method
    `problem.get_objective_names()`)
  - `set_model_objective()`: update the intern objective the subsolver
    will optimize
  - `get_model_objective_value()`: retrieve the value of the intern
    objective currently optimized
  - `add_model_constraint()`: add a constraint to the intern model
    on the given objective to avoid worsening it.

- Implement them for ortools-csat solvers on knapsack and rcpsp
