### PR TITLE
Fix use of `time_limit_iter0` in LNS_CP

### DIFF
--- a/discrete_optimization/generic_tools/lns_cp.py
+++ b/discrete_optimization/generic_tools/lns_cp.py
@@ -106,12 +106,12 @@ class LNS_CP(BaseLNS):
 
     def solve_with_subsolver(
         self,
-        iteration: int,
+        no_previous_solution: bool,
         instance: Instance,
         parameters_cp: ParametersCP,
         **kwargs: Any,
     ) -> ResultStorage:
-        if iteration == 0:
+        if no_previous_solution:
             parameters_cp0 = parameters_cp.copy()
             parameters_cp0.time_limit = parameters_cp.time_limit_iter0
             result_store = self.subsolver.solve(
@@ -128,7 +128,7 @@ class LNS_CP(BaseLNS):
         nb_iteration_lns: int,
         parameters_cp: Optional[ParametersCP] = None,
         nb_iteration_no_improvement: Optional[int] = None,
-        skip_first_iteration: bool = False,
+        skip_initial_solution_provider: bool = False,
         stop_first_iteration_if_optimal: bool = True,
         callbacks: Optional[List[Callback]] = None,
         **kwargs: Any,
@@ -139,7 +139,7 @@ class LNS_CP(BaseLNS):
             parameters_cp=parameters_cp,
             nb_iteration_lns=nb_iteration_lns,
             nb_iteration_no_improvement=nb_iteration_no_improvement,
-            skip_first_iteration=skip_first_iteration,
+            skip_initial_solution_provider=skip_initial_solution_provider,
             stop_first_iteration_if_optimal=stop_first_iteration_if_optimal,
             callbacks=callbacks,
             **kwargs,

--- a/discrete_optimization/generic_tools/lns_mip.py
+++ b/discrete_optimization/generic_tools/lns_mip.py
@@ -92,7 +92,7 @@ class LNS_MILP(BaseLNS):
         nb_iteration_lns: int,
         parameters_milp: Optional[ParametersMilp] = None,
         nb_iteration_no_improvement: Optional[int] = None,
-        skip_first_iteration: Optional[bool] = False,
+        skip_initial_solution_provider: bool = False,
         stop_first_iteration_if_optimal: bool = True,
         callbacks: Optional[List[Callback]] = None,
         **kwargs: Any,
@@ -104,7 +104,7 @@ class LNS_MILP(BaseLNS):
             nb_iteration_lns=nb_iteration_lns,
             nb_iteration_no_improvement=nb_iteration_no_improvement,
             stop_first_iteration_if_optimal=stop_first_iteration_if_optimal,
-            skip_first_iteration=skip_first_iteration,
+            skip_initial_solution_provider=skip_initial_solution_provider,
             callbacks=callbacks,
             **kwargs,
         )

--- a/examples/rcpsp/rcpsp_lns_example.py
+++ b/examples/rcpsp/rcpsp_lns_example.py
@@ -28,7 +28,7 @@ def example_lns_solver():
     parameters_cp.time_limit = 2
     results = solver.solve(
         nb_iteration_lns=100,
-        skip_first_iteration=False,
+        skip_initial_solution_provider=False,
         stop_first_iteration_if_optimal=False,
         parameters_cp=parameters_cp,
         nb_iteration_no_improvement=200,
@@ -66,7 +66,7 @@ def example_lns_solver_rg300():
     parameters_cp.multiprocess = True
     results = solver.solve(
         nb_iteration_lns=10000,
-        skip_first_iteration=False,
+        skip_initial_solution_provider=False,
         stop_first_iteration_if_optimal=False,
         parameters_cp=parameters_cp,
         nb_iteration_no_improvement=10000,

--- a/tests/knapsack/test_knapsack_lns_cp_solver.py
+++ b/tests/knapsack/test_knapsack_lns_cp_solver.py
@@ -115,7 +115,7 @@ def test_knapsack_lns_timer():
     result_store = lns_solver.solve(
         parameters_cp=params_cp,
         nb_iteration_lns=200,
-        skip_first_iteration=False,
+        skip_initial_solution_provider=False,
         callbacks=callbacks,
     )
     assert nb_iteration_tracker.nb_iteration <= 6
@@ -136,8 +136,8 @@ class NbIterationTrackerWithAssert(Callback):
         self.nb_iteration += 1
 
 
-@pytest.mark.parametrize("skip_first_iteration", [False, True])
-def test_knapsack_lns_cb_nbiter(skip_first_iteration):
+@pytest.mark.parametrize("skip_initial_solution_provider", [False, True])
+def test_knapsack_lns_cb_nbiter(skip_initial_solution_provider):
     model_file = [f for f in get_data_available() if "ks_30_0" in f][
         0
     ]  # optim result "54939"
@@ -175,7 +175,7 @@ def test_knapsack_lns_cb_nbiter(skip_first_iteration):
     result_store = lns_solver.solve(
         parameters_cp=params_cp,
         nb_iteration_lns=2,
-        skip_first_iteration=skip_first_iteration,
+        skip_initial_solution_provider=skip_initial_solution_provider,
         callbacks=callbacks,
     )
 

--- a/tests/rcpsp/solver/test_large_neighborhood_search_solver.py
+++ b/tests/rcpsp/solver/test_large_neighborhood_search_solver.py
@@ -26,7 +26,7 @@ def test_lns_solver(file_name):
     parameters_cp.time_limit = 2
     results = solver.solve(
         nb_iteration_lns=100,
-        skip_first_iteration=False,
+        skip_initial_solution_provider=False,
         stop_first_iteration_if_optimal=False,
         parameters_cp=parameters_cp,
         nb_iteration_no_improvement=50,

--- a/tests/rcpsp/solver/test_rcpsp_lp_lns.py
+++ b/tests/rcpsp/solver/test_rcpsp_lp_lns.py
@@ -130,7 +130,7 @@ def test_lns_mm():
     result_store = lns_solver.solve(
         parameters_milp=parameters_milp,
         nb_iteration_lns=10,
-        skip_first_iteration=False,
+        skip_initial_solution_provider=False,
     )
     solution, fit = result_store.get_best_solution_fit()
     assert rcpsp_problem.satisfy(solution)

--- a/tests/rcpsp_multiskill/test_rcpsp_ms_lp_lns.py
+++ b/tests/rcpsp_multiskill/test_rcpsp_ms_lp_lns.py
@@ -89,7 +89,7 @@ def test_multiskill_imopse():
         nb_iteration_lns=10,
         nb_iteration_no_improvement=10,
         callbacks=[TimerStopper(total_seconds=200)],
-        skip_first_iteration=False,
+        skip_initial_solution_provider=False,
     )
     solution, fit = result_store.get_best_solution_fit()
     model.evaluate(solution)


### PR DESCRIPTION
Instead of passing iteration (which was wrongly always pass as 0) to `solve_with_subsolver()`, we pass a boolean `no_previous_solution` which will be true only if we skipped the initial_solution_provider and we are at the first lns iteration. In that case we will use `time_limit_iter0` instead of `time_limit` to start from a "good" solution.

We also
- rename `skip_first_iteration` into `skip_initial_solution_provider`
- skip the initial solution provider also if `self._initial_solution_provider` is `None`

NB: we keep the boolean for optuna hyperparameters suggestion