### PR TITLE
Fix bug in cpsat vrp model

### DIFF
--- a/discrete_optimization/vrp/solver/vrp_cpsat_solver.py
+++ b/discrete_optimization/vrp/solver/vrp_cpsat_solver.py
@@ -64,9 +64,11 @@ class CpSatVrpSolver(OrtoolsCPSatSolver, SolverVrp):
                 route_is_finished = False
                 path = []
                 route_distance = 0
-                # for arc in self.variables["arc_literals_per_vehicles"][vehicle]:
-                #    if cpsolvercb.boolean_value(self.variables["arc_literals_per_vehicles"][vehicle][arc]):
-                #        print("Vehicle ", vehicle, " from ", arc[0], " to ", arc[1])
+                for arc in self.variables["arc_literals_per_vehicles"][vehicle]:
+                    if cpsolvercb.boolean_value(
+                        self.variables["arc_literals_per_vehicles"][vehicle][arc]
+                    ):
+                        logger.debug(f"Vehicle {vehicle} from {arc[0]} to {arc[1]}")
                 while not route_is_finished:
                     for i in range(self.problem.customer_count):
                         if i == current_node:
@@ -141,8 +143,17 @@ class CpSatVrpSolver(OrtoolsCPSatSolver, SolverVrp):
                                 ingoing_arc_per_node[j] = []
                             ingoing_arc_per_node[j].append(lit)
                         if not (
-                            i == self.problem.end_indexes[vehicle]
-                            and j == self.problem.start_indexes[vehicle]
+                            (i, j)
+                            in {
+                                (
+                                    self.problem.end_indexes[vehicle],
+                                    self.problem.start_indexes[vehicle],
+                                ),
+                                (
+                                    self.problem.start_indexes[vehicle],
+                                    self.problem.end_indexes[vehicle],
+                                ),
+                            }
                         ):
                             arc_non_loop.append(lit)
                     obj_vars.append(lit)

--- a/examples/vrp/vrp_cpsat_example.py
+++ b/examples/vrp/vrp_cpsat_example.py
@@ -11,12 +11,12 @@ from discrete_optimization.vrp.solver.vrp_cpsat_solver import CpSatVrpSolver
 from discrete_optimization.vrp.vrp_model import VrpSolution
 from discrete_optimization.vrp.vrp_parser import get_data_available, parse_file
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.DEBUG)
 
 
 def run_cpsat_vrp():
     file = [f for f in get_data_available() if "vrp_26_8_1" in f][0]
-    problem = parse_file(file_path=file)
+    problem = parse_file(file_path=file, start_index=0, end_index=0)
     problem.vehicle_capacities = [
         problem.vehicle_capacities[i] for i in range(problem.vehicle_count)
     ]
@@ -27,6 +27,7 @@ def run_cpsat_vrp():
     p.nb_process = 10
     p.time_limit = 20
     res = solver.solve(parameters_cp=p)
+    print(solver.get_status_solver())
     sol, fit = res.get_best_solution_fit()
     sol: VrpSolution
     print(problem.evaluate(sol))
@@ -73,7 +74,6 @@ def run_cpsat_vrp_on_tsp():
     sol, fit = res.get_best_solution_fit()
     sol: VrpSolution
     print(problem.evaluate(sol))
-    assert problem.satisfy(sol)
     plot_vrp_solution(vrp_model=problem, solution=sol)
     sol_tsp = SolutionTSP(
         problem=problem_tsp,
@@ -86,4 +86,4 @@ def run_cpsat_vrp_on_tsp():
 
 
 if __name__ == "__main__":
-    run_cpsat_vrp_on_tsp()
+    run_cpsat_vrp()

--- a/examples/vrp/vrp_cpsat_example.py
+++ b/examples/vrp/vrp_cpsat_example.py
@@ -25,7 +25,7 @@ def run_cpsat_vrp():
     solver.init_model(optional_node=False, cut_transition=False)
     p = ParametersCP.default_cpsat()
     p.nb_process = 10
-    p.time_limit = 100
+    p.time_limit = 20
     res = solver.solve(parameters_cp=p)
     sol, fit = res.get_best_solution_fit()
     sol: VrpSolution
@@ -46,7 +46,7 @@ def run_cpsat_vrp_on_tsp():
     from discrete_optimization.vrp.vrp_model import Customer2D, VrpProblem2D
 
     file = [f for f in get_data_available() if "tsp_200_1" in f][0]
-    problem_tsp: TSPModel2D = parse_file(file_path=file, start_index=0, end_index=10)
+    problem_tsp: TSPModel2D = parse_file(file_path=file, start_index=0, end_index=0)
     problem = VrpProblem2D(
         vehicle_count=1,
         vehicle_capacities=[100000],

--- a/tests/vrp/test_vrp_cpsat.py
+++ b/tests/vrp/test_vrp_cpsat.py
@@ -42,7 +42,8 @@ def test_cpsat_vrp(optional_node, cut_transition):
     sol: VrpSolution
     print(problem.evaluate(sol))
     assert problem.satisfy(sol)
-    compute_nb_nodes_in_path(sol)
+    if not optional_node:
+        compute_nb_nodes_in_path(sol)
 
 
 def test_cpsat_lns_vrp():
@@ -90,7 +91,7 @@ def test_cpsat_vrp_on_tsp(optional_node, diff_start_end):
         parse_file,
     )
 
-    file = [f for f in get_data_available() if "tsp_200_1" in f][0]
+    file = [f for f in get_data_available() if "tsp_51_1" in f][0]
     if diff_start_end:
         problem_tsp: TSPModel2D = parse_file(
             file_path=file, start_index=0, end_index=10
@@ -122,7 +123,8 @@ def test_cpsat_vrp_on_tsp(optional_node, diff_start_end):
     sol, fit = res.get_best_solution_fit()
     sol: VrpSolution
     assert problem.satisfy(sol)
-    compute_nb_nodes_in_path(sol)
+    if not optional_node:
+        compute_nb_nodes_in_path(sol)
     sol_tsp = SolutionTSP(
         problem=problem_tsp,
         start_index=problem_tsp.start_index,


### PR DESCRIPTION
1 constraint was incorrect and was not insuring that when a given vehicle was used it was starting from the starting node.
It had the effect to give produce (sometimes) empty path in the retrieve solution. This should be fixed now.
- better unit test to check if the issue remains.