### PR TITLE
Improve `SubBrickHyperparmeter.suggest_hyperparameter_with_optuna()`

### DIFF
--- a/discrete_optimization/generic_tools/hyperparameters/hyperparameter.py
+++ b/discrete_optimization/generic_tools/hyperparameters/hyperparameter.py
@@ -587,8 +587,15 @@ class SubBrickKwargsHyperparameter(Hyperparameter):
         trial: optuna.trial.Trial,
         subbrick: Optional[Type[Hyperparametrizable]] = None,
         names: Optional[List[str]] = None,
+        names_by_subbrick: Optional[Dict[Type[Hyperparametrizable], List[str]]] = None,
         kwargs_by_name: Optional[Dict[str, Dict[str, Any]]] = None,
+        kwargs_by_name_by_subbrick: Optional[
+            Dict[Type[Hyperparametrizable], Dict[str, Dict[str, Any]]]
+        ] = None,
         fixed_hyperparameters: Optional[Dict[str, Any]] = None,
+        fixed_hyperparameters_by_subbrick: Optional[
+            Dict[Type[Hyperparametrizable], Dict[str, Any]]
+        ] = None,
         prefix: str = "",
         **kwargs,
     ) -> Dict[str, Any]:
@@ -604,10 +611,19 @@ class SubBrickKwargsHyperparameter(Hyperparameter):
                 the other will be discarded (potentially, being meaningful for other subbricks).
                 By default, all available hyperparameters will be suggested.
                 Passed to `subbrick.suggest_hyperparameters_with_optuna()`.
+            names_by_subbrick: similar to `names` but depending on type of subbrick chosen.
+                `names` will be extended by `names_by_subbrick[subbrick]` (if the key exists)
+                where `subbrick` is either the argument of this function, or (if None) `self.subbrick_cls`.
             kwargs_by_name: options for optuna hyperparameter suggestions, by hyperparameter name.
                 Passed to `subbrick.suggest_hyperparameters_with_optuna()`.
+            kwargs_by_name_by_subbrick: same as `kwargs_by_name` but depending on type of subbrick chosen.
+                `kwargs_by_name` will be updated by `kwargs_by_name_by_subbrick[subbrick]` (if the key exists)
+                where `subbrick` is either the argument of this function, or (if None) `self.subbrick_cls`.
             fixed_hyperparameters: values of fixed hyperparameters, useful for suggesting subbrick hyperparameters,
                 if the subbrick class is not suggested by this method, but already fixed.
+            fixed_hyperparameters_by_subbrick: same as `fixed_hyperparameters` but depending on type of subbrick chosen.
+                `fixed_hyperparameters` will be updated by `fixed_hyperparameters_by_subbrick[subbrick]` (if the key exists)
+                where `subbrick` is either the argument of this function, or (if None) `self.subbrick_cls`.
             prefix: prefix to add to optuna corresponding parameter name
               (useful for disambiguating hyperparameters from subsolvers in case of meta-solvers)
             **kwargs: passed to `trial.suggest_categorical()`
@@ -622,18 +638,48 @@ class SubBrickKwargsHyperparameter(Hyperparameter):
                 )
             else:
                 subbrick = self.subbrick_cls
+
+        # kwargs_by_name updated according to subbrick
+        if kwargs_by_name is None:
+            kwargs_by_name_updated = {}
+        else:
+            kwargs_by_name_updated = dict(kwargs_by_name)
+        if kwargs_by_name_by_subbrick is not None:
+            kwargs_by_name_updated.update(kwargs_by_name_by_subbrick.get(subbrick, {}))
+
+        # fixed_hyperparameters updated according to subbrick
+        if fixed_hyperparameters is None:
+            fixed_hyperparameters_updated = {}
+        else:
+            fixed_hyperparameters_updated = dict(fixed_hyperparameters)
+        if fixed_hyperparameters_by_subbrick is not None:
+            fixed_hyperparameters_updated.update(
+                fixed_hyperparameters_by_subbrick.get(subbrick, {})
+            )
+
+        # names updated according to subbrick
         subbrick_hyperparameter_names = subbrick.get_hyperparameters_names()
-        if names is not None:
-            names = [name for name in names if name in subbrick_hyperparameter_names]
+        if names is None:
+            names_updated = list(subbrick_hyperparameter_names)
+        else:
+            names_updated = [
+                name for name in names if name in subbrick_hyperparameter_names
+            ]
+        if names_by_subbrick is not None:
+            names_updated.extend(names_by_subbrick.get(subbrick, []))
+
+        # update prefix with subbrick name and class (if not fixed class)
         if self.subbrick_hyperparameter is None:
             prefix = f"{prefix}{self.name}."
         else:
             prefix = f"{prefix}{self.subbrick_hyperparameter}.{subbrick.__name__}."
+
+        # use subbrick suggest method
         return subbrick.suggest_hyperparameters_with_optuna(
             trial=trial,
-            names=names,
-            kwargs_by_name=kwargs_by_name,
-            fixed_hyperparameters=fixed_hyperparameters,
+            names=names_updated,
+            kwargs_by_name=kwargs_by_name_updated,
+            fixed_hyperparameters=fixed_hyperparameters_updated,
             prefix=prefix,
             **kwargs,  # type: ignore
         )
@@ -705,8 +751,15 @@ class SubBrickHyperparameter(Hyperparameter):
             ]
         ] = None,
         names: Optional[List[str]] = None,
+        names_by_subbrick: Optional[Dict[Type[Hyperparametrizable], List[str]]] = None,
         kwargs_by_name: Optional[Dict[str, Dict[str, Any]]] = None,
+        kwargs_by_name_by_subbrick: Optional[
+            Dict[Type[Hyperparametrizable], Dict[str, Dict[str, Any]]]
+        ] = None,
         fixed_hyperparameters: Optional[Dict[str, Any]] = None,
+        fixed_hyperparameters_by_subbrick: Optional[
+            Dict[Type[Hyperparametrizable], Dict[str, Any]]
+        ] = None,
         prefix: str = "",
         **kwargs: Any,
     ) -> SubBrick:
@@ -716,8 +769,11 @@ class SubBrickHyperparameter(Hyperparameter):
             trial: see Hyperparameter doc
             choices: used by underlying SubBrickClsHyperparameter.suggest_with_optuna
             names: used by underlying SubBrickKwargsHyperparameter.suggest_with_optuna
+            names_by_subbrick: used by underlying SubBrickKwargsHyperparameter.suggest_with_optuna
             kwargs_by_name: used by underlying SubBrickKwargsHyperparameter.suggest_with_optuna
+            kwargs_by_name_by_subbrick: used by underlying SubBrickKwargsHyperparameter.suggest_with_optuna
             fixed_hyperparameters: used by underlying SubBrickKwargsHyperparameter.suggest_with_optuna
+            fixed_hyperparameters_by_subbrick: used by underlying SubBrickKwargsHyperparameter.suggest_with_optuna
             prefix: see Hyperparameter doc.
             **kwargs: passed to SubBrickClsHyperparameter.suggest_with_optuna
                 and SubBrickKwargsHyperparameter.suggest_with_optuna
@@ -732,8 +788,11 @@ class SubBrickHyperparameter(Hyperparameter):
             trial=trial,
             subbrick=subbrick_cls,
             names=names,
+            names_by_subbrick=names_by_subbrick,
             kwargs_by_name=kwargs_by_name,
+            kwargs_by_name_by_subbrick=kwargs_by_name_by_subbrick,
             fixed_hyperparameters=fixed_hyperparameters,
+            fixed_hyperparameters_by_subbrick=fixed_hyperparameters_by_subbrick,
             prefix=prefix,
             **kwargs,
         )

--- a/discrete_optimization/generic_tools/hyperparameters/hyperparametrizable.py
+++ b/discrete_optimization/generic_tools/hyperparameters/hyperparametrizable.py
@@ -180,6 +180,7 @@ class Hyperparametrizable:
             kwargs_by_name: options for optuna hyperparameter suggestions, by hyperparameter name
             fixed_hyperparameters: values of fixed hyperparameters, useful for suggesting subbrick hyperparameters,
                 if the subbrick class is not suggested by this method, but already fixed.
+                Will be added to the suggested hyperparameters.
             prefix: prefix to add to optuna corresponding parameters
               (useful for disambiguating hyperparameters from subsolvers in case of meta-solvers)
 
@@ -188,6 +189,7 @@ class Hyperparametrizable:
             mapping between the hyperparameter name and its suggested value.
             If the hyperparameter has an attribute `name_in_kwargs`, this is used as the key in the mapping
             instead of the actual hyperparameter name.
+            the mapping is updated with `fixed_hyperparameters`.
 
         kwargs_by_name[some_name] will be passed as **kwargs to suggest_hyperparameter_with_optuna(name=some_name)
 
@@ -277,7 +279,7 @@ class Hyperparametrizable:
                     trial=trial, name=name, **kwargs_for_optuna_suggestion
                 )
 
-        return suggested_hyperparameters
+        return dict(suggested_and_fixed_hyperparameters)
 
     @classmethod
     def _get_hyperparameters_dependency_graph(cls) -> nx.DiGraph:

--- a/tests/generic_tools/hyperparameters/test_hyperparameter.py
+++ b/tests/generic_tools/hyperparameters/test_hyperparameter.py
@@ -582,6 +582,61 @@ def test_suggest_with_optuna_meta_solver():
     assert len(study.trials) == 2 * (4 * 5 + 3 * 5)
 
 
+def test_suggest_with_optuna_meta_solver_customized_by_subsolver():
+    def objective(trial: optuna.Trial) -> float:
+        # hyperparameters for the chosen solver
+        suggested_hyperparameters_kwargs = (
+            MetaSolver.suggest_hyperparameters_with_optuna(
+                trial=trial,
+                kwargs_by_name=dict(
+                    subsolver=dict(
+                        names=["nb"],
+                        names_by_subbrick={
+                            DummySolver: ["coeff"],
+                            DummySolver2: ["coeff2"],
+                        },
+                        kwargs_by_name=dict(
+                            coeff=dict(step=0.5), coeff2=dict(step=0.5)
+                        ),
+                        kwargs_by_name_by_subbrick={
+                            DummySolver: dict(nb=dict(high=1)),
+                            DummySolver2: dict(nb=dict(choices=[2, 3])),
+                        },
+                    )
+                ),
+            )
+        )
+        assert len(suggested_hyperparameters_kwargs) == 2
+        print(suggested_hyperparameters_kwargs)
+        assert "nb" in suggested_hyperparameters_kwargs
+        assert "nb" in suggested_hyperparameters_kwargs["subsolver"].kwargs
+        assert "nb" in trial.params
+        assert (
+            "subsolver.DummySolver.nb" in trial.params
+            or "subsolver.DummySolver2.nb" in trial.params
+        )
+        if "subsolver.DummySolver.nb" in trial.params:
+            param_name = "subsolver.DummySolver.nb"
+            suggested_hyperparameters_kwargs["subsolver"].kwargs["nb"] <= 1
+        else:
+            param_name = "subsolver.DummySolver2.nb"
+            suggested_hyperparameters_kwargs["subsolver"].kwargs["nb"] >= 2
+
+        assert (
+            trial.params[param_name]
+            == suggested_hyperparameters_kwargs["subsolver"].kwargs["nb"]
+        )
+
+        return 0.0
+
+    study = optuna.create_study(
+        sampler=optuna.samplers.BruteForceSampler(),
+    )
+    study.optimize(objective)
+
+    assert len(study.trials) == 2 * 2 * 2 * 5
+
+
 def test_suggest_with_optuna_meta_solver_level2():
     def objective(trial: optuna.Trial) -> float:
         # hyperparameters for the chosen solver

--- a/tests/generic_tools/hyperparameters/test_hyperparameter.py
+++ b/tests/generic_tools/hyperparameters/test_hyperparameter.py
@@ -523,9 +523,9 @@ def test_suggest_with_optuna_with_dependencies_and_fixed_hyperparameters():
             )
         )
         if suggested_hyperparameters_kwargs["use_it"]:
-            assert len(suggested_hyperparameters_kwargs) == 3
+            assert len(suggested_hyperparameters_kwargs) == 3 + 1
         else:
-            assert len(suggested_hyperparameters_kwargs) == 2
+            assert len(suggested_hyperparameters_kwargs) == 2 + 1
 
         return 0.0
 
@@ -602,11 +602,16 @@ def test_suggest_with_optuna_meta_solver_customized_by_subsolver():
                             DummySolver: dict(nb=dict(high=1)),
                             DummySolver2: dict(nb=dict(choices=[2, 3])),
                         },
+                        fixed_hyperparameters_by_subbrick={
+                            DummySolver: dict(use_it=False)
+                        },
                     )
                 ),
             )
         )
+
         assert len(suggested_hyperparameters_kwargs) == 2
+
         print(suggested_hyperparameters_kwargs)
         assert "nb" in suggested_hyperparameters_kwargs
         assert "nb" in suggested_hyperparameters_kwargs["subsolver"].kwargs
@@ -617,10 +622,17 @@ def test_suggest_with_optuna_meta_solver_customized_by_subsolver():
         )
         if "subsolver.DummySolver.nb" in trial.params:
             param_name = "subsolver.DummySolver.nb"
-            suggested_hyperparameters_kwargs["subsolver"].kwargs["nb"] <= 1
+            assert suggested_hyperparameters_kwargs["subsolver"].kwargs["nb"] <= 1
+            assert (
+                suggested_hyperparameters_kwargs["subsolver"].kwargs["use_it"] is False
+            )
+            assert "coeff" in suggested_hyperparameters_kwargs["subsolver"].kwargs
+            assert len(suggested_hyperparameters_kwargs["subsolver"].kwargs) == 3
         else:
             param_name = "subsolver.DummySolver2.nb"
-            suggested_hyperparameters_kwargs["subsolver"].kwargs["nb"] >= 2
+            assert suggested_hyperparameters_kwargs["subsolver"].kwargs["nb"] >= 2
+            assert "coeff2" in suggested_hyperparameters_kwargs["subsolver"].kwargs
+            assert len(suggested_hyperparameters_kwargs["subsolver"].kwargs) == 2
 
         assert (
             trial.params[param_name]
@@ -731,7 +743,7 @@ def test_suggest_with_optuna_meta_solver_fixed_subsolver():
                 ),
             )
         )
-        assert len(suggested_hyperparameters_kwargs) == 2
+        assert len(suggested_hyperparameters_kwargs) == 2 + 1
         print(suggested_hyperparameters_kwargs)
         assert "nb" in suggested_hyperparameters_kwargs
         assert "nb" in suggested_hyperparameters_kwargs["kwargs_subsolver"]


### PR DESCRIPTION
- Include in returned kwargs the elements in `fixed_hyperparameters` argument (for `Hyperparametrizable`, and thus for `SubBrickKwargsHyperparmeter` and `SubBrickHyperparmeter`);
- Allow to specify by subbrick class the arguments `names`, `kwargs_by_name`, and `fixed_hyperparameters`, thanks to additional arguments `names_by_subbrick`, `kwargs_by_name_by_subbrick`, and `fixed_hyperparameters_by_subbrick`.

See examples of use in new implemented tests.