### PR TITLE
Add a unit factor when reporting time with optuna callback 

### DIFF
--- a/tests/generic_tools/callbacks/test_timed_callbacks_n_pruner.py
+++ b/tests/generic_tools/callbacks/test_timed_callbacks_n_pruner.py
@@ -98,6 +98,7 @@ def test_optuna_timed_callback_timed_pruner(random_seed):
                     trial=trial,
                     optuna_report_nb_steps=10,
                     report_time=True,
+                    report_time_unit=0.001,
                 )
             ],
             **kwargs


### PR DESCRIPTION
Starting from optuna 4.0, report steps are automatically converted to integers (as they are meant to be) so that our "trick" of passing the time instead may result in intermediate value being overriden if steps are within the same second.
We thus introduce a unit factor (if 1., nothing change, if 0.001 it converts time to milliseconds) to be able to have a finer granularity.
This is useful to make the corresponding unit test still work without slowing it.