### PR TITLE
Stop limiting ortools for windows tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,11 +158,6 @@ jobs:
         with:
           name: dist
           path: dist
-      - name: Prevent installing newest release or ortools on windows (segmentation fault)
-        if: matrix.os == 'windows-latest'
-        run: |
-          python -m pip install -U pip
-          pip install "ortools<9.10"
       - name: Install only discrete-optimization
         run: |
           python -m pip install -U pip


### PR DESCRIPTION
With the release of ortools 9.11, the windows wf is working again.