### PR TITLE
Drop support for python 3.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         run: echo "pre-commit" > requirements_precommit.txt
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.9"
           cache: "pip"
           cache-dependency-path: requirements_precommit.txt
       - name: install pre-commit
@@ -64,7 +64,7 @@ jobs:
           echo "build" > requirements_build.txt
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.9"
           cache: "pip"
           cache-dependency-path: requirements_build.txt
       - name: Install build dependencies
@@ -90,7 +90,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-12", "macos-latest", "windows-latest"]
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.9", "3.12"]
         wo_gurobi: ["", "without gurobi"]
         include:
           - os: "ubuntu-latest"
@@ -135,9 +135,9 @@ jobs:
             wo_gurobi: "without gurobi"
           - os: "ubuntu-latest"
             wo_gurobi: "without gurobi"
-            python-version: "3.8"
+            python-version: "3.9"
           - os: "macos-latest"
-            python-version: "3.8"
+            python-version: "3.9"
           - os: "macos-12"
             python-version: "3.12"
     runs-on: ${{ matrix.os }}

--- a/discrete_optimization/coloring/coloring_model.py
+++ b/discrete_optimization/coloring/coloring_model.py
@@ -8,7 +8,8 @@ The only constraint is that adjacent vertices should be colored by different col
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Dict, Hashable, List, Optional, Set, Type, Union
+from collections.abc import Hashable
+from typing import Optional, Union
 
 import numpy as np
 
@@ -36,7 +37,7 @@ class ColoringSolution(Solution):
 
     Attributes:
         problem (ColoringProblem): instance of the graph coloring problem
-        colors (Union[List[int], np.array]): list/array of the same size of problem.number_of_nodes number.
+        colors (Union[list[int], np.array]): list/array of the same size of problem.number_of_nodes number.
                                              It should contain integer values representing discrete colors.
         nb_color (Optional[int]): number of different colors present in colors attributes. can be used directly
                                   by the problem.evaluate function if this attribute is provided
@@ -47,7 +48,7 @@ class ColoringSolution(Solution):
     def __init__(
         self,
         problem: Problem,
-        colors: Optional[Union[List[int], np.ndarray]] = None,
+        colors: Optional[Union[list[int], np.ndarray]] = None,
         nb_color: Optional[int] = None,
         nb_violations: Optional[int] = None,
     ):
@@ -66,7 +67,7 @@ class ColoringSolution(Solution):
         Returns: A copy that can be considered as a deep copy of the current object.
 
         """
-        colors: Optional[Union[List[int], np.ndarray]]
+        colors: Optional[Union[list[int], np.ndarray]]
         if self.colors is None:
             colors = None
         elif isinstance(self.colors, np.ndarray):
@@ -109,7 +110,7 @@ class ColoringSolution(Solution):
         Returns: New ColoringSolution object with value precede chain property.
 
         """
-        colors: List[int]
+        colors: list[int]
         if self.colors is None:
             raise ValueError(
                 "self.colors should not be None when calling to_reformated_solution()"
@@ -154,7 +155,7 @@ class ColoringSolution(Solution):
             raise ValueError(
                 "new_problem must a ColoringProblem for a ColoringSolution."
             )
-        colors: Optional[Union[List[int], np.ndarray]]
+        colors: Optional[Union[list[int], np.ndarray]]
         if self.colors is None:
             self.colors = None
         elif isinstance(self.colors, np.ndarray):
@@ -164,11 +165,11 @@ class ColoringSolution(Solution):
         self.problem = new_problem
 
 
-def transform_color_values_to_value_precede(color_vector: List[int]) -> List[int]:
+def transform_color_values_to_value_precede(color_vector: list[int]) -> list[int]:
     """See method ColoringSolution.to_reformated_solution().
 
     Args:
-        color_vector (List[int]): vector representing colors of vertices
+        color_vector (list[int]): vector representing colors of vertices
 
     Returns: A vector with value precede chain property
 
@@ -187,13 +188,13 @@ def transform_color_values_to_value_precede(color_vector: List[int]) -> List[int
 class ConstraintsColoring:
     """Data structure to store additional constraints. Attributes will grow
     Attributes:
-        color_constraint (Dict[Hashable, int]): dictionary filled with color constraint.
+        color_constraint (dict[Hashable, int]): dictionary filled with color constraint.
     """
 
-    def __init__(self, color_constraint: Dict[Hashable, int]):
+    def __init__(self, color_constraint: dict[Hashable, int]):
         self.color_constraint = color_constraint
 
-    def nodes_fixed(self) -> Set[Hashable]:
+    def nodes_fixed(self) -> set[Hashable]:
         if self.color_constraint is not None:
             return set(self.color_constraint.keys())
         else:
@@ -206,17 +207,17 @@ class ColoringProblem(Problem):
     Attributes:
         graph (Graph): a graph object representing vertices and edges.
         number_of_nodes (int): number of nodes in the graph
-        subset_nodes (Set[Hashable]): subset of nodes id to take into account in the optimisation.
-        nodes_name (List[Hashable]): list of id of the graph vertices.
-        index_nodes_name (Dict[Hashable, int]): dictionary node_name->index
-        index_to_nodes_name (Dict[int, Hashable]): index->node_name
+        subset_nodes (set[Hashable]): subset of nodes id to take into account in the optimisation.
+        nodes_name (list[Hashable]): list of id of the graph vertices.
+        index_nodes_name (dict[Hashable, int]): dictionary node_name->index
+        index_to_nodes_name (dict[int, Hashable]): index->node_name
 
     """
 
     def __init__(
         self,
         graph: Graph,
-        subset_nodes: Set[Hashable] = None,
+        subset_nodes: set[Hashable] = None,
         constraints_coloring: Optional[ConstraintsColoring] = None,
     ):
         self.graph = graph
@@ -248,17 +249,17 @@ class ColoringProblem(Problem):
             return True
         return node in self.subset_nodes
 
-    def count_colors(self, colors_list: List[int]) -> int:
+    def count_colors(self, colors_list: list[int]) -> int:
         if self.use_subset:
             nb_color = len(set([colors_list[j] for j in self.index_subset_nodes]))
         else:
             nb_color = len(set(colors_list))
         return nb_color
 
-    def count_colors_all_index(self, colors_list: List[int]) -> int:
+    def count_colors_all_index(self, colors_list: list[int]) -> int:
         return len(set(colors_list))
 
-    def evaluate(self, variable: ColoringSolution) -> Dict[str, float]:  # type: ignore # avoid isinstance checks for efficiency
+    def evaluate(self, variable: ColoringSolution) -> dict[str, float]:  # type: ignore # avoid isinstance checks for efficiency
         """Evaluation implementation for ColoringProblem.
 
         Compute number of colors and violation of the current solution.
@@ -334,7 +335,7 @@ class ColoringProblem(Problem):
         }
         return EncodingRegister(dict_register)
 
-    def get_solution_type(self) -> Type[Solution]:
+    def get_solution_type(self) -> type[Solution]:
         """Returns the class of a solution instance for ColoringProblem."""
         return ColoringSolution
 
@@ -397,8 +398,8 @@ class ColoringProblem(Problem):
         return val
 
     def evaluate_from_encoding(
-        self, int_vector: List[int], encoding_name: str
-    ) -> Dict[str, float]:
+        self, int_vector: list[int], encoding_name: str
+    ) -> dict[str, float]:
         """Can be used in GA algorithm to build an object solution and evaluate from a int_vector representation.
 
         Args:
@@ -437,7 +438,7 @@ def compute_constraints_penalty(
 
 def transform_coloring_problem(
     coloring_problem: ColoringProblem,
-    subset_nodes: Optional[Set[Hashable]] = None,
+    subset_nodes: Optional[set[Hashable]] = None,
     constraints_coloring: Optional[ConstraintsColoring] = None,
 ) -> ColoringProblem:
     return ColoringProblem(

--- a/discrete_optimization/coloring/coloring_parser.py
+++ b/discrete_optimization/coloring/coloring_parser.py
@@ -3,7 +3,8 @@
 #  LICENSE file in the root directory of this source tree.
 
 import os
-from typing import Any, Dict, Hashable, List, Optional, Tuple
+from collections.abc import Hashable
+from typing import Any, Optional
 
 from discrete_optimization.coloring.coloring_model import ColoringProblem
 from discrete_optimization.datasets import get_data_home
@@ -12,7 +13,7 @@ from discrete_optimization.generic_tools.graph_api import Graph
 
 def get_data_available(
     data_folder: Optional[str] = None, data_home: Optional[str] = None
-) -> List[str]:
+) -> list[str]:
     """Get datasets available for coloring.
 
     Params:
@@ -49,8 +50,8 @@ def parse(input_data: str) -> ColoringProblem:
     first_line = lines[0].split()
     node_count = int(first_line[0])
     edge_count = int(first_line[1])
-    edges: List[Tuple[Hashable, Hashable, Dict[str, Any]]] = []
-    nodes: List[Tuple[Hashable, Dict[str, Any]]] = [(i, {}) for i in range(node_count)]
+    edges: list[tuple[Hashable, Hashable, dict[str, Any]]] = []
+    nodes: list[tuple[Hashable, dict[str, Any]]] = [(i, {}) for i in range(node_count)]
     for i in range(1, edge_count + 1):
         line = lines[i]
         parts = line.split()

--- a/discrete_optimization/coloring/coloring_solvers.py
+++ b/discrete_optimization/coloring/coloring_solvers.py
@@ -4,7 +4,7 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, List, Tuple, Type
+from typing import Any
 
 from discrete_optimization.coloring.solvers.coloring_asp_solver import ColoringASPSolver
 from discrete_optimization.coloring.solvers.coloring_cp_solvers import (
@@ -46,7 +46,7 @@ from discrete_optimization.generic_tools.result_storage.result_storage import (
     ResultStorage,
 )
 
-solvers: Dict[str, List[Tuple[Type[SolverColoring], Dict[str, Any]]]] = {
+solvers: dict[str, list[tuple[type[SolverColoring], dict[str, Any]]]] = {
     "lp": [
         (
             ColoringLP,
@@ -92,13 +92,13 @@ for key in solvers:
     for solver, param in solvers[key]:
         solvers_map[solver] = (key, param)
 
-solvers_compatibility: Dict[Type[SolverColoring], List[Type[Problem]]] = {}
+solvers_compatibility: dict[type[SolverColoring], list[type[Problem]]] = {}
 for x in solvers:
     for y in solvers[x]:
         solvers_compatibility[y[0]] = [ColoringProblem]
 
 
-def look_for_solver(domain: "ColoringProblem") -> List[Type[SolverColoring]]:
+def look_for_solver(domain: "ColoringProblem") -> list[type[SolverColoring]]:
     """Given an instance of ColoringProblem, return a list of class of solvers.
 
 
@@ -112,8 +112,8 @@ def look_for_solver(domain: "ColoringProblem") -> List[Type[SolverColoring]]:
 
 
 def look_for_solver_class(
-    class_domain: Type[ColoringProblem],
-) -> List[Type[SolverColoring]]:
+    class_domain: type[ColoringProblem],
+) -> list[type[SolverColoring]]:
     """Given a class domain, return a list of class of solvers.
 
 
@@ -130,7 +130,7 @@ def look_for_solver_class(
 
 
 def solve(
-    method: Type[SolverColoring], problem: ColoringProblem, **kwargs: Any
+    method: type[SolverColoring], problem: ColoringProblem, **kwargs: Any
 ) -> ResultStorage:
     """Solve a coloring instance with a given class of solver.
 
@@ -151,7 +151,7 @@ def solve(
 
 
 def return_solver(
-    method: Type[SolverColoring], problem: ColoringProblem, **kwargs: Any
+    method: type[SolverColoring], problem: ColoringProblem, **kwargs: Any
 ) -> SolverColoring:
     """Return the solver initialized with the coloring problem instance
 

--- a/discrete_optimization/coloring/coloring_toolbox.py
+++ b/discrete_optimization/coloring/coloring_toolbox.py
@@ -2,14 +2,15 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Hashable, List, Optional, Tuple
+from collections.abc import Hashable
+from typing import Optional
 
 import networkx as nx
 
 
 def compute_cliques(
     g: nx.Graph, nb_max: Optional[int] = None
-) -> Tuple[List[List[Hashable]], bool]:
+) -> tuple[list[list[Hashable]], bool]:
     """Compute nb_max cliques for a given graph (possibly a graph from a coloring model).
 
     A clique of a graph is a subset of nodes that are all adjacent to each other.

--- a/discrete_optimization/coloring/solvers/coloring_asp_solver.py
+++ b/discrete_optimization/coloring/solvers/coloring_asp_solver.py
@@ -3,7 +3,7 @@
 #  LICENSE file in the root directory of this source tree.
 import logging
 import os
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 import clingo
 
@@ -130,7 +130,7 @@ class ColoringASPSolver(ASPClingoSolver, SolverColoringWithStartingSolution):
                 s += f"fixed_color({index_node+1}, c_{value}). "
         return s
 
-    def compute_clever_colors_map(self, colors_name: List[str]):
+    def compute_clever_colors_map(self, colors_name: list[str]):
         colors_to_protect = set()
         colors_to_index = {}
         if self.problem.has_constraints_coloring:

--- a/discrete_optimization/coloring/solvers/coloring_cp_lns_solvers.py
+++ b/discrete_optimization/coloring/solvers/coloring_cp_lns_solvers.py
@@ -5,8 +5,9 @@
 #  LICENSE file in the root directory of this source tree.
 
 import random
+from collections.abc import Iterable
 from enum import Enum
-from typing import Any, Iterable, Optional
+from typing import Any, Optional
 
 from minizinc import Instance
 

--- a/discrete_optimization/coloring/solvers/coloring_cp_solvers.py
+++ b/discrete_optimization/coloring/solvers/coloring_cp_solvers.py
@@ -9,8 +9,9 @@ CP formulation rely on minizinc models stored in coloring/minizinc folder.
 
 import logging
 import os
+from collections.abc import Iterable
 from enum import Enum
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Optional
 
 import networkx as nx
 import pymzn
@@ -99,7 +100,7 @@ class ColoringCP(MinizincCPSolver, SolverColoring):
         self.graph = self.problem.graph
         self.g = None
         self.cp_solver_name = cp_solver_name
-        self.dict_datas: Optional[Dict[str, Any]] = None
+        self.dict_datas: Optional[dict[str, Any]] = None
 
     def init_model(self, **kwargs: Any) -> None:
         """Instantiate a minizinc model with the coloring problem data.
@@ -182,7 +183,7 @@ class ColoringCP(MinizincCPSolver, SolverColoring):
 
         Args:
             file_name (str): file path where to dump the data file
-            keys (List[str]): list of input data names to dump.
+            keys (list[str]): list of input data names to dump.
 
         Returns: None
 

--- a/discrete_optimization/coloring/solvers/coloring_cpsat_solver.py
+++ b/discrete_optimization/coloring/solvers/coloring_cpsat_solver.py
@@ -2,7 +2,7 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 from ortools.sat.python.cp_model import CpModel, CpSolverSolutionCallback, IntVar
 
@@ -66,7 +66,7 @@ class ColoringCPSatSolver(
     ):
         super().__init__(problem, params_objective_function, **kwargs)
         self.modeling: Optional[ModelingCPSat] = None
-        self.variables: Dict[str, Union[List[IntVar], List[Dict[int, IntVar]]]] = {}
+        self.variables: dict[str, Union[list[IntVar], list[dict[int, IntVar]]]] = {}
 
     def retrieve_solution(self, cpsolvercb: CpSolverSolutionCallback) -> Solution:
         if self.modeling == ModelingCPSat.INTEGER:

--- a/discrete_optimization/coloring/solvers/coloring_lp_lns_solvers.py
+++ b/discrete_optimization/coloring/solvers/coloring_lp_lns_solvers.py
@@ -5,8 +5,9 @@
 #  LICENSE file in the root directory of this source tree.
 
 import random
+from collections.abc import Iterable
 from enum import Enum
-from typing import Any, Iterable
+from typing import Any
 
 from discrete_optimization.coloring.coloring_model import (
     ColoringProblem,

--- a/discrete_optimization/coloring/solvers/coloring_lp_solvers.py
+++ b/discrete_optimization/coloring/solvers/coloring_lp_solvers.py
@@ -5,8 +5,8 @@
 #  LICENSE file in the root directory of this source tree.
 
 import logging
-import sys
-from typing import Any, Callable, Dict, Hashable, Optional, Tuple, Union
+from collections.abc import Callable, Hashable
+from typing import Any, Optional, TypedDict, Union
 
 import mip
 import networkx as nx
@@ -45,20 +45,15 @@ else:
     gurobi_available = True
     from gurobipy import GRB, Constr, GenConstr, MConstr, Model, QConstr, Var, quicksum
 
-if sys.version_info >= (3, 8):
-    from typing import TypedDict  # pylint: disable=no-name-in-module
-else:
-    from typing_extensions import TypedDict
-
 
 logger = logging.getLogger(__name__)
 
 
-OneColorConstraints = Dict[int, Union["Constr", "QConstr", "MConstr", "GenConstr"]]
-NeighborsConstraints = Dict[
-    Tuple[Hashable, Hashable, int], Union["Constr", "QConstr", "MConstr", "GenConstr"]
+OneColorConstraints = dict[int, Union["Constr", "QConstr", "MConstr", "GenConstr"]]
+NeighborsConstraints = dict[
+    tuple[Hashable, Hashable, int], Union["Constr", "QConstr", "MConstr", "GenConstr"]
 ]
-VariableDecision = Dict[str, Dict[Tuple[Hashable, int], Union["Var", mip.Var]]]
+VariableDecision = dict[str, dict[tuple[Hashable, int], Union["Var", mip.Var]]]
 
 
 class ConstraintsDict(TypedDict):
@@ -111,7 +106,7 @@ class _BaseColoringLP(MilpSolver, SolverColoring):
                 "descr": "for each node and each color," " a binary indicator",
             }
         }
-        self.description_constraint: Dict[str, Dict[str, str]] = {}
+        self.description_constraint: dict[str, dict[str, str]] = {}
         self.sense_optim = self.params_objective_function.sense_function
         self.start_solution: Optional[ColoringSolution] = None
 
@@ -205,7 +200,7 @@ class ColoringLP(GurobiMilpSolver, _BaseColoringLP, WarmstartMixin):
         if nb_colors is None:
             raise RuntimeError("self.start_solution.nb_color should not be None.")
         color_model = Model("color")
-        colors_var: Dict[Tuple[Hashable, int], "Var"] = {}
+        colors_var: dict[tuple[Hashable, int], "Var"] = {}
         range_node = self.nodes_name
         range_color = range(nb_colors)
         range_color_subset = range(nb_colors_subset)
@@ -235,7 +230,7 @@ class ColoringLP(GurobiMilpSolver, _BaseColoringLP, WarmstartMixin):
             cliques = sorted(cliques, key=lambda x: len(x), reverse=True)
         else:
             cliques = [[e[0], e[1]] for e in g.edges()]
-        cliques_constraint: Dict[Union[int, Tuple[int, int]], Any] = {}
+        cliques_constraint: dict[Union[int, tuple[int, int]], Any] = {}
         index_c = 0
         opt = color_model.addVar(vtype=GRB.INTEGER, lb=0, ub=nb_colors, obj=1)
         if use_cliques:
@@ -420,7 +415,7 @@ class ColoringLP_MIP(PymipMilpSolver, _BaseColoringLP):
             cliques = sorted(cliques, key=lambda x: len(x), reverse=True)
         else:
             cliques = [[e[0], e[1]] for e in g.edges()]
-        cliques_constraint: Dict[Union[int, Tuple[int, int]], Any] = {}
+        cliques_constraint: dict[Union[int, tuple[int, int]], Any] = {}
         index_c = 0
         opt = color_model.add_var(var_type=INTEGER, lb=0, ub=nb_colors, obj=1)
         if use_cliques:

--- a/discrete_optimization/coloring/solvers/coloring_toulbar_solver.py
+++ b/discrete_optimization/coloring/solvers/coloring_toulbar_solver.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from discrete_optimization.coloring.coloring_model import ColoringSolution
 from discrete_optimization.coloring.solvers.coloring_solver_with_starting_solution import (
@@ -213,8 +213,8 @@ class ToulbarColoringSolver(SolverColoringWithStartingSolution):
         self,
         index1: int,
         index2: int,
-        costs: Dict[str, List],
-        range_map: Dict[int, Any],
+        costs: dict[str, list],
+        range_map: dict[int, Any],
     ):
         in_subset_index1 = self.problem.is_in_subset_index(index1)
         in_subset_index2 = self.problem.is_in_subset_index(index2)

--- a/discrete_optimization/facility/facility_model.py
+++ b/discrete_optimization/facility/facility_model.py
@@ -14,7 +14,7 @@ import math
 from abc import abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Optional
 
 from discrete_optimization.generic_tools.do_problem import (
     EncodingRegister,
@@ -55,8 +55,8 @@ class FacilitySolution(Solution):
 
     Attributes:
         problem (FacilityProblem): facility problem instance
-        facility_for_customers (List[int]): for each customers, specify the index of the facility
-        dict_details (Dict): giving more metrics of the solution such as the capacities used, the setup cost etc.
+        facility_for_customers (list[int]): for each customers, specify the index of the facility
+        dict_details (dict): giving more metrics of the solution such as the capacities used, the setup cost etc.
         See problem.evaluate(sol) implementation for FacilityProblem
 
     """
@@ -64,8 +64,8 @@ class FacilitySolution(Solution):
     def __init__(
         self,
         problem: Problem,
-        facility_for_customers: List[int],
-        dict_details: Optional[Dict[str, Any]] = None,
+        facility_for_customers: list[int],
+        dict_details: Optional[dict[str, Any]] = None,
     ):
         self.problem = problem
         self.facility_for_customers = facility_for_customers
@@ -101,8 +101,8 @@ class FacilityProblem(Problem):
     Attributes:
         facility_count (int): number of facilities
         customer_count (int): number of customers
-        facilities (List[Facility]): list of facilities object, facility has a setup cost, capacity and location
-        customers (List[Customer]): list of customers object, which has demand and location.
+        facilities (list[Facility]): list of facilities object, facility has a setup cost, capacity and location
+        customers (list[Customer]): list of customers object, which has demand and location.
 
 
     """
@@ -111,8 +111,8 @@ class FacilityProblem(Problem):
         self,
         facility_count: int,
         customer_count: int,
-        facilities: List[Facility],
-        customers: List[Customer],
+        facilities: list[Facility],
+        customers: list[Customer],
     ):
         self.facility_count = facility_count
         self.customer_count = customer_count
@@ -134,7 +134,7 @@ class FacilityProblem(Problem):
         """
         ...
 
-    def evaluate(self, variable: FacilitySolution) -> Dict[str, float]:  # type: ignore # avoid isinstance checks for efficiency
+    def evaluate(self, variable: FacilitySolution) -> dict[str, float]:  # type: ignore # avoid isinstance checks for efficiency
         """Computes the KPI of a FacilitySolution.
 
         Args:
@@ -155,12 +155,12 @@ class FacilityProblem(Problem):
         return d
 
     def evaluate_from_encoding(
-        self, int_vector: List[int], encoding_name: str
-    ) -> Dict[str, float]:
+        self, int_vector: list[int], encoding_name: str
+    ) -> dict[str, float]:
         """Evaluate function based on direct integer vector (used in GA algorithms only)
 
         Args:
-            int_vector (List[int]): vector encoding the solution
+            int_vector (list[int]): vector encoding the solution
             encoding_name (str): name of encoding (see get_attribute_register) for available encoding
 
         Returns: kpi of the solution
@@ -170,7 +170,7 @@ class FacilityProblem(Problem):
         if encoding_name == "facility_for_customers":
             kp_sol = FacilitySolution(problem=self, facility_for_customers=int_vector)
         elif encoding_name == "custom":
-            kwargs: Dict[str, Any] = {encoding_name: int_vector}
+            kwargs: dict[str, Any] = {encoding_name: int_vector}
             kp_sol = FacilitySolution(problem=self, **kwargs)
         else:
             raise ValueError(
@@ -179,7 +179,7 @@ class FacilityProblem(Problem):
         objectives = self.evaluate(kp_sol)
         return objectives
 
-    def evaluate_cost(self, variable: FacilitySolution) -> Dict[str, Any]:
+    def evaluate_cost(self, variable: FacilitySolution) -> dict[str, Any]:
         """Compute the allocation cost of the solution along with setup cost too.
 
         Args:
@@ -245,7 +245,7 @@ class FacilityProblem(Problem):
         """
         return FacilitySolution(self, [0] * self.customer_count)
 
-    def get_solution_type(self) -> Type[Solution]:
+    def get_solution_type(self) -> type[Solution]:
         return FacilitySolution
 
     def get_objective_register(self) -> ObjectiveRegister:

--- a/discrete_optimization/facility/facility_parser.py
+++ b/discrete_optimization/facility/facility_parser.py
@@ -3,7 +3,7 @@
 #  LICENSE file in the root directory of this source tree.
 
 import os
-from typing import List, Optional
+from typing import Optional
 
 from discrete_optimization.datasets import get_data_home
 from discrete_optimization.facility.facility_model import (
@@ -16,7 +16,7 @@ from discrete_optimization.facility.facility_model import (
 
 def get_data_available(
     data_folder: Optional[str] = None, data_home: Optional[str] = None
-) -> List[str]:
+) -> list[str]:
     """Get datasets available for facility.
 
     Params:

--- a/discrete_optimization/facility/facility_solvers.py
+++ b/discrete_optimization/facility/facility_solvers.py
@@ -2,7 +2,7 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, List, Tuple, Type
+from typing import Any
 
 from discrete_optimization.facility.facility_model import (
     FacilityProblem,
@@ -30,7 +30,7 @@ from discrete_optimization.generic_tools.result_storage.result_storage import (
     ResultStorage,
 )
 
-solvers: Dict[str, List[Tuple[Type[SolverFacility], Dict[str, Any]]]] = {
+solvers: dict[str, list[tuple[type[SolverFacility], dict[str, Any]]]] = {
     "lp": [
         (
             LP_Facility_Solver,
@@ -80,20 +80,20 @@ for key in solvers:
     for solver, param in solvers[key]:
         solvers_map[solver] = (key, param)
 
-solvers_compatibility: Dict[Type[SolverFacility], List[Type[Problem]]] = {}
+solvers_compatibility: dict[type[SolverFacility], list[type[Problem]]] = {}
 for x in solvers:
     for y in solvers[x]:
         solvers_compatibility[y[0]] = [FacilityProblem2DPoints]
 
 
-def look_for_solver(domain: FacilityProblem) -> List[Type[SolverFacility]]:
+def look_for_solver(domain: FacilityProblem) -> list[type[SolverFacility]]:
     class_domain = domain.__class__
     return look_for_solver_class(class_domain)
 
 
 def look_for_solver_class(
-    class_domain: Type[FacilityProblem],
-) -> List[Type[SolverFacility]]:
+    class_domain: type[FacilityProblem],
+) -> list[type[SolverFacility]]:
     available = []
     for solver in solvers_compatibility:
         if class_domain in solvers_compatibility[solver]:
@@ -102,7 +102,7 @@ def look_for_solver_class(
 
 
 def solve(
-    method: Type[SolverFacility], problem: FacilityProblem, **kwargs: Any
+    method: type[SolverFacility], problem: FacilityProblem, **kwargs: Any
 ) -> ResultStorage:
     solver = method(problem, **kwargs)
     try:
@@ -113,7 +113,7 @@ def solve(
 
 
 def return_solver(
-    method: Type[SolverFacility], problem: FacilityProblem, **kwargs: Any
+    method: type[SolverFacility], problem: FacilityProblem, **kwargs: Any
 ) -> SolverFacility:
     solver = method(problem, **kwargs)
     try:

--- a/discrete_optimization/facility/solvers/facility_lp_lns_solver.py
+++ b/discrete_optimization/facility/solvers/facility_lp_lns_solver.py
@@ -4,8 +4,9 @@
 
 import logging
 import random
+from collections.abc import Iterable
 from enum import Enum
-from typing import Any, Iterable
+from typing import Any
 
 import mip
 

--- a/discrete_optimization/facility/solvers/facility_lp_solver.py
+++ b/discrete_optimization/facility/solvers/facility_lp_solver.py
@@ -5,7 +5,8 @@
 #  LICENSE file in the root directory of this source tree.
 
 import logging
-from typing import Any, Callable, Dict, Optional, Tuple, Union
+from collections.abc import Callable
+from typing import Any, Optional, Union
 
 import mip
 import numpy as np
@@ -60,7 +61,7 @@ else:
 
 def compute_length_matrix(
     facility_problem: FacilityProblem,
-) -> Tuple[npt.NDArray[np.float64], npt.NDArray[np.int_], npt.NDArray[np.float64]]:
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.int_], npt.NDArray[np.float64]]:
     """Precompute all the cost of allocation in a matrix form.
 
     A matrix "closest" is also computed, sorting for each customers the facility by distance.
@@ -88,7 +89,7 @@ def compute_length_matrix(
 
 def prune_search_space(
     facility_problem: FacilityProblem, n_cheapest: int = 10, n_shortest: int = 10
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     """Utility function that can prune the search space.
 
     Output of this function will be used to :
@@ -150,8 +151,8 @@ class _LPFacilitySolverBase(MilpSolver, SolverFacility):
             problem=problem, params_objective_function=params_objective_function
         )
         self.model = None
-        self.variable_decision: Dict[str, Dict[Tuple[int, int], Union[int, Any]]] = {}
-        self.constraints_dict: Dict[str, Dict[int, Any]] = {}
+        self.variable_decision: dict[str, dict[tuple[int, int], Union[int, Any]]] = {}
+        self.constraints_dict: dict[str, dict[int, Any]] = {}
         self.description_variable_description = {
             "x": {
                 "shape": (0, 0),
@@ -161,7 +162,7 @@ class _LPFacilitySolverBase(MilpSolver, SolverFacility):
                 "that the customer c is dealt with facility f",
             }
         }
-        self.description_constraint: Dict[str, Dict[str, str]] = {}
+        self.description_constraint: dict[str, dict[str, str]] = {}
 
     def retrieve_current_solution(
         self,
@@ -221,7 +222,7 @@ class LP_Facility_Solver(GurobiMilpSolver, _LPFacilitySolverBase, WarmstartMixin
                 n_shortest=nb_facilities,
             )
         s = Model("facilities")
-        x: Dict[Tuple[int, int], Union[int, Any]] = {}
+        x: dict[tuple[int, int], Union[int, Any]] = {}
         for f in range(nb_facilities):
             for c in range(nb_customers):
                 if matrix_fc_indicator[f, c] == 0:
@@ -233,7 +234,7 @@ class LP_Facility_Solver(GurobiMilpSolver, _LPFacilitySolverBase, WarmstartMixin
         facilities = self.problem.facilities
         customers = self.problem.customers
         used = s.addVars(nb_facilities, vtype=GRB.BINARY, name="y")
-        constraints_customer: Dict[
+        constraints_customer: dict[
             int, Union["Constr", "QConstr", "MConstr", "GenConstr"]
         ] = {}
         for c in range(nb_customers):
@@ -241,7 +242,7 @@ class LP_Facility_Solver(GurobiMilpSolver, _LPFacilitySolverBase, WarmstartMixin
                 quicksum([x[f, c] for f in range(nb_facilities)]) == 1
             )
             # one facility
-        constraint_capacity: Dict[
+        constraint_capacity: dict[
             int, Union["Constr", "QConstr", "MConstr", "GenConstr"]
         ] = {}
         for f in range(nb_facilities):
@@ -321,8 +322,8 @@ class LP_Facility_Solver_CBC(SolverFacility):
             problem=problem, params_objective_function=params_objective_function
         )
         self.model = None
-        self.variable_decision: Dict[str, Dict[Tuple[int, int], Union[int, Any]]] = {}
-        self.constraints_dict: Dict[str, Dict[int, Any]] = {}
+        self.variable_decision: dict[str, dict[tuple[int, int], Union[int, Any]]] = {}
+        self.constraints_dict: dict[str, dict[int, Any]] = {}
         self.description_variable_description = {
             "x": {
                 "shape": (0, 0),
@@ -332,7 +333,7 @@ class LP_Facility_Solver_CBC(SolverFacility):
                 "that the customer c is dealt with facility f",
             }
         }
-        self.description_constraint: Dict[str, Dict[str, str]] = {}
+        self.description_constraint: dict[str, dict[str, str]] = {}
 
     def init_model(self, **kwargs: Any) -> None:
         nb_facilities = self.problem.facility_count
@@ -352,7 +353,7 @@ class LP_Facility_Solver_CBC(SolverFacility):
                 n_shortest=nb_facilities,
             )
         s = pywraplp.Solver("facility", pywraplp.Solver.CBC_MIXED_INTEGER_PROGRAMMING)
-        x: Dict[Tuple[int, int], Union[int, Any]] = {}
+        x: dict[tuple[int, int], Union[int, Any]] = {}
         for f in range(nb_facilities):
             for c in range(nb_customers):
                 if matrix_fc_indicator[f, c] == 0:
@@ -366,13 +367,13 @@ class LP_Facility_Solver_CBC(SolverFacility):
         used = [
             s.BoolVar(name="y_" + str(j)) for j in range(self.problem.facility_count)
         ]
-        constraints_customer: Dict[int, Any] = {}
+        constraints_customer: dict[int, Any] = {}
         for c in range(nb_customers):
             constraints_customer[c] = s.Add(
                 s.Sum([x[f, c] for f in range(nb_facilities)]) == 1
             )
             # one facility
-        constraint_capacity: Dict[int, Any] = {}
+        constraint_capacity: dict[int, Any] = {}
         for f in range(nb_facilities):
             for c in range(nb_customers):
                 s.Add(used[f] >= x[f, c])
@@ -502,7 +503,7 @@ class LP_Facility_Solver_PyMip(PymipMilpSolver, _LPFacilitySolverBase):
         s = mip.Model(
             name="facilities", sense=mip.MINIMIZE, solver_name=self.solver_name
         )
-        x: Dict[Tuple[int, int], Union[int, Any]] = {}
+        x: dict[tuple[int, int], Union[int, Any]] = {}
         for f in range(nb_facilities):
             for c in range(nb_customers):
                 if matrix_fc_indicator[f, c] == 0:
@@ -516,13 +517,13 @@ class LP_Facility_Solver_PyMip(PymipMilpSolver, _LPFacilitySolverBase):
         facilities = self.problem.facilities
         customers = self.problem.customers
         used = s.add_var_tensor((nb_facilities, 1), var_type=GRB.BINARY, name="y")
-        constraints_customer: Dict[int, Any] = {}
+        constraints_customer: dict[int, Any] = {}
         for c in range(nb_customers):
             constraints_customer[c] = s.add_constr(
                 mip.xsum([x[f, c] for f in range(nb_facilities)]) == 1
             )
             # one facility
-        constraint_capacity: Dict[int, Any] = {}
+        constraint_capacity: dict[int, Any] = {}
         for f in range(nb_facilities):
             for c in range(nb_customers):
                 s.add_constr(used[f, 0] >= x[f, c])

--- a/discrete_optimization/facility/solvers/gphh_facility.py
+++ b/discrete_optimization/facility/solvers/gphh_facility.py
@@ -6,8 +6,9 @@
 #  LICENSE file in the root directory of this source tree.
 
 import operator
+from collections.abc import Callable, Iterable
 from enum import Enum
-from typing import Any, Callable, Dict, Iterable, List, Optional, Set
+from typing import Any, Optional
 
 import matplotlib.pyplot as plt
 import networkx as nx
@@ -38,7 +39,7 @@ from discrete_optimization.generic_tools.result_storage.result_storage import (
 
 def distance(
     problem: FacilityProblem, customer_index: int, **kwargs: Any
-) -> List[float]:
+) -> list[float]:
     """Compute distance to facilitied for a given customer index
 
     Args:
@@ -55,7 +56,7 @@ def distance(
 
 def demand_minus_capacity(
     problem: FacilityProblem, customer_index: int, **kwargs: Any
-) -> List[float]:
+) -> list[float]:
     """Compute demand-capacity feature for a given customer_index
 
     Args:
@@ -70,7 +71,7 @@ def demand_minus_capacity(
 
 def capacity(
     problem: FacilityProblem, customer_index: int, **kwargs: Any
-) -> List[float]:
+) -> list[float]:
     """Capacity feature.
     Args:
         problem (FacilityProblem): problem instance
@@ -105,7 +106,7 @@ class FeatureEnum(Enum):
     DEMAND_MINUS_CAPACITY = "demand_minus_capacity"
 
 
-feature_function_map: Dict[FeatureEnum, Callable[..., Iterable[float]]] = {
+feature_function_map: dict[FeatureEnum, Callable[..., Iterable[float]]] = {
     FeatureEnum.DISTANCE: distance,
     FeatureEnum.CAPACITIES: capacity,
     FeatureEnum.DEMAND_MINUS_CAPACITY: demand_minus_capacity,
@@ -122,7 +123,7 @@ class ParametersGPHH:
 
     def __init__(
         self,
-        set_feature: Set[FeatureEnum],
+        set_feature: set[FeatureEnum],
         set_primitives: PrimitiveSetTyped,
         tournament_ratio: float,
         pop_size: int,
@@ -201,7 +202,7 @@ class GPHH(SolverFacility):
     def __init__(
         self,
         problem: FacilityProblem,
-        training_domains: Optional[List[FacilityProblem]] = None,
+        training_domains: Optional[list[FacilityProblem]] = None,
         weight: int = 1,
         params_gphh: Optional[ParametersGPHH] = None,
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
@@ -317,10 +318,10 @@ class GPHH(SolverFacility):
     ) -> ResultStorage:
         if func_heuristic is None:
             func_heuristic = self.toolbox.compile(expr=individual)
-        raw_values: List[Iterable[int]] = []
+        raw_values: list[Iterable[int]] = []
 
         for j in range(domain.customer_count):
-            input_features: List[Iterable[float]] = [
+            input_features: list[Iterable[float]] = [
                 feature_function_map[lf](problem=domain, customer_index=j)
                 for lf in self.list_feature
             ]
@@ -332,9 +333,9 @@ class GPHH(SolverFacility):
         return result
 
     def evaluate_heuristic(
-        self, individual: Any, domains: List[FacilityProblem]
-    ) -> List[float]:
-        vals: List[float] = []
+        self, individual: Any, domains: list[FacilityProblem]
+    ) -> list[float]:
+        vals: list[float] = []
         func_heuristic = self.toolbox.compile(expr=individual)
         for domain in domains:
             result = self.build_solution(

--- a/discrete_optimization/generic_rcpsp_tools/gphh_solver.py
+++ b/discrete_optimization/generic_rcpsp_tools/gphh_solver.py
@@ -6,7 +6,7 @@ import logging
 import operator
 import random
 from enum import Enum
-from typing import Dict, List, Optional, Set
+from typing import Optional
 
 import numpy as np
 from deap import algorithms, creator, gp, tools
@@ -251,7 +251,7 @@ class PermutationDistance(Enum):
 
 
 class ParametersGPHH:
-    set_feature: Set[FeatureEnum] = None
+    set_feature: set[FeatureEnum] = None
     set_primitves: PrimitiveSet = None
     tournament_ratio: float = None
     pop_size: int = None
@@ -450,7 +450,7 @@ class ParametersGPHH:
         )
 
     @staticmethod
-    def default_for_set_features(set_feature: Set[FeatureEnum]):
+    def default_for_set_features(set_feature: set[FeatureEnum]):
         pset = PrimitiveSet("main", len(set_feature))
         pset.addPrimitive(operator.add, 2)
         pset.addPrimitive(operator.sub, 2)
@@ -476,19 +476,19 @@ class ParametersGPHH:
 
 
 class GPHH(SolverGenericRCPSP):
-    training_domains: List[Problem]
+    training_domains: list[Problem]
     weight: int
     pset: PrimitiveSet
     toolbox: Toolbox
     params_gphh: ParametersGPHH
     evaluation_method: EvaluationGPHH
-    reference_permutations: Dict
+    reference_permutations: dict
     permutation_distance: PermutationDistance
 
     def __init__(
         self,
         problem: Problem,
-        training_domains: Optional[List[Problem]] = None,
+        training_domains: Optional[list[Problem]] = None,
         weight: int = 1,
         params_gphh: ParametersGPHH = None,
         params_objective_function: ParamsObjectiveFunction = None,

--- a/discrete_optimization/generic_rcpsp_tools/ls_solver.py
+++ b/discrete_optimization/generic_rcpsp_tools/ls_solver.py
@@ -4,7 +4,7 @@
 
 import logging
 from enum import Enum
-from typing import List, Optional
+from typing import Optional
 
 import numpy as np
 
@@ -82,7 +82,7 @@ class LS_RCPSP_Solver(SolverGenericRCPSP):
         )
         self.ls_solver = ls_solver
 
-    def solve(self, callbacks: Optional[List[Callback]] = None, **kwargs):
+    def solve(self, callbacks: Optional[list[Callback]] = None, **kwargs):
         kwargs = self.complete_with_default_hyperparameters(kwargs)
         model = self.problem
         dummy = kwargs.get("starting_point", model.get_dummy_solution())

--- a/discrete_optimization/generic_rcpsp_tools/neighbor_tools_rcpsp.py
+++ b/discrete_optimization/generic_rcpsp_tools/neighbor_tools_rcpsp.py
@@ -6,8 +6,9 @@ import logging
 import math
 import random
 from abc import abstractmethod
+from collections.abc import Hashable, Iterable
 from enum import Enum
-from typing import Any, Hashable, Iterable, List, Optional, Set, Tuple, Union
+from typing import Any, Optional, Union
 
 import numpy as np
 from minizinc import Instance
@@ -162,8 +163,8 @@ class ParamsConstraintBuilder(Hyperparametrizable):
 def constraints_strings(
     current_solution: Union[RCPSPSolution, MS_RCPSPSolution],
     cp_solver: ANY_CP_SOLVER,
-    tasks_primary: Set[Hashable],
-    tasks_secondary: Set[Hashable],
+    tasks_primary: set[Hashable],
+    tasks_secondary: set[Hashable],
     params_constraints: ParamsConstraintBuilder,
 ):
     max_time = get_max_time_solution(solution=current_solution)
@@ -226,8 +227,8 @@ def constraints_strings(
 def constraints_strings_preemptive(
     current_solution: ANY_SOLUTION_PREEMPTIVE,
     cp_solver: ANY_CP_SOLVER,
-    tasks_primary: Set[Hashable],
-    tasks_secondary: Set[Hashable],
+    tasks_primary: set[Hashable],
+    tasks_secondary: set[Hashable],
     params_constraints: ParamsConstraintBuilder,
 ):
     max_time = get_max_time_solution(solution=current_solution)
@@ -414,8 +415,8 @@ def constraints_strings_preemptive(
 def constraints_strings_multiskill(
     current_solution: MS_RCPSPSolution,
     cp_solver: ANY_CP_SOLVER,
-    tasks_primary: Set[Hashable],
-    tasks_secondary: Set[Hashable],
+    tasks_primary: set[Hashable],
+    tasks_secondary: set[Hashable],
     params_constraints: ParamsConstraintBuilder,
 ):
     list_strings = constraints_strings(
@@ -774,8 +775,8 @@ def constraints_start_on_end_preemptive(
 def constraints_strings_multiskill_preemptive(
     current_solution: ANY_SOLUTION,
     cp_solver: ANY_CP_SOLVER,
-    tasks_primary: Set[Hashable],
-    tasks_secondary: Set[Hashable],
+    tasks_primary: set[Hashable],
+    tasks_secondary: set[Hashable],
     params_constraints: ParamsConstraintBuilder,
 ):
     list_strings = constraints_strings_preemptive(
@@ -843,7 +844,7 @@ def constraints_strings_multiskill_preemptive(
 
 
 def constraint_unit_used_to_tasks(
-    tasks_set: Set[Hashable],
+    tasks_set: set[Hashable],
     current_solution: MS_RCPSPSolution,
     cp_solver: Union[CP_MS_MRCPSP_MZN],
 ):
@@ -871,7 +872,7 @@ def constraint_unit_used_to_tasks(
 
 
 def constraint_unit_used_subset_employees(
-    employees_set: Set[Hashable],
+    employees_set: set[Hashable],
     current_solution: MS_RCPSPSolution,
     cp_solver: Union[CP_MS_MRCPSP_MZN],
     employees_usage_dict=None,
@@ -895,7 +896,7 @@ def constraint_unit_used_subset_employees(
 
 
 def constraint_unit_used_to_tasks_preemptive(
-    tasks_set: Set[Hashable],
+    tasks_set: set[Hashable],
     current_solution: MS_RCPSPSolution_Preemptive,
     cp_solver: Union[CP_MS_MRCPSP_MZN_PREEMPTIVE],
     exceptions=None,
@@ -936,7 +937,7 @@ def constraint_unit_used_to_tasks_preemptive(
 
 
 def constraint_unit_used_subset_employees_preemptive(
-    employees_set: Set[Hashable],
+    employees_set: set[Hashable],
     current_solution: MS_RCPSPSolution_Preemptive,
     cp_solver: Union[CP_MS_MRCPSP_MZN_PREEMPTIVE],
     employees_usage_dict=None,
@@ -970,8 +971,8 @@ def constraint_unit_used_subset_employees_preemptive(
 class NeighborBuilder:
     @abstractmethod
     def find_subtasks(
-        self, current_solution: ANY_SOLUTION, subtasks: Optional[Set[Hashable]] = None
-    ) -> Tuple[Set[Hashable], Set[Hashable]]:
+        self, current_solution: ANY_SOLUTION, subtasks: Optional[set[Hashable]] = None
+    ) -> tuple[set[Hashable], set[Hashable]]:
         """
         Split the scheduling task set in 2 part, it can then be used by constraint handler to introduce different
         constraints in those two subsets. Usually the first returned set will be considered
@@ -1010,8 +1011,8 @@ class NeighborBuilderSubPart(NeighborBuilder):
         self.set_tasks = set(self.problem.tasks_list)
 
     def find_subtasks(
-        self, current_solution: RCPSPSolution, subtasks: Optional[Set[Hashable]] = None
-    ) -> Tuple[Set[Hashable], Set[Hashable]]:
+        self, current_solution: RCPSPSolution, subtasks: Optional[set[Hashable]] = None
+    ) -> tuple[set[Hashable], set[Hashable]]:
         nb_job_sub = math.ceil(self.problem.n_jobs / self.nb_cut_part)
         task_of_interest = sorted(
             self.problem.tasks_list, key=lambda x: current_solution.get_end_time(x)
@@ -1054,8 +1055,8 @@ class NeighborRandom(NeighborBuilder):
         self.set_tasks = set(self.problem.tasks_list)
 
     def find_subtasks(
-        self, current_solution: ANY_SOLUTION, subtasks: Optional[Set[Hashable]] = None
-    ) -> Tuple[Set[Hashable], Set[Hashable]]:
+        self, current_solution: ANY_SOLUTION, subtasks: Optional[set[Hashable]] = None
+    ) -> tuple[set[Hashable], set[Hashable]]:
         if subtasks is None:
             subtasks = set()
         max_time = current_solution.get_end_time(self.problem.sink_task)
@@ -1100,8 +1101,8 @@ class NeighborRandomAndNeighborGraph(NeighborBuilder):
         self.set_tasks = set(self.problem.tasks_list)
 
     def find_subtasks(
-        self, current_solution: RCPSPSolution, subtasks: Optional[Set[Hashable]] = None
-    ) -> Tuple[Set[Hashable], Set[Hashable]]:
+        self, current_solution: RCPSPSolution, subtasks: Optional[set[Hashable]] = None
+    ) -> tuple[set[Hashable], set[Hashable]]:
         if subtasks is None:
             subtasks = set()
             len_subtask = 0
@@ -1172,8 +1173,8 @@ class NeighborConstraintBreaks(NeighborBuilder):
         self.set_tasks = set(self.problem.tasks_list)
 
     def find_subtasks(
-        self, current_solution: RCPSPSolution, subtasks: Optional[Set[Hashable]] = None
-    ) -> Tuple[Set[Hashable], Set[Hashable]]:
+        self, current_solution: RCPSPSolution, subtasks: Optional[set[Hashable]] = None
+    ) -> tuple[set[Hashable], set[Hashable]]:
         if "special_constraints" in self.problem.__dict__.keys():
             details_constraints = compute_constraints_details(
                 solution=current_solution, constraints=self.problem.special_constraints
@@ -1245,8 +1246,8 @@ class NeighborConstraintBreaks(NeighborBuilder):
 class NeighborBuilderMix(NeighborBuilder):
     def __init__(
         self,
-        list_neighbor: List[NeighborBuilder],
-        weight_neighbor: Union[List[float], np.array],
+        list_neighbor: list[NeighborBuilder],
+        weight_neighbor: Union[list[float], np.array],
         verbose: bool = False,
     ):
         self.list_neighbor = list_neighbor
@@ -1258,8 +1259,8 @@ class NeighborBuilderMix(NeighborBuilder):
         self.verbose = verbose
 
     def find_subtasks(
-        self, current_solution: RCPSPSolution, subtasks: Optional[Set[Hashable]] = None
-    ) -> Tuple[Set[Hashable], Set[Hashable]]:
+        self, current_solution: RCPSPSolution, subtasks: Optional[set[Hashable]] = None
+    ) -> tuple[set[Hashable], set[Hashable]]:
         choice = np.random.choice(self.index_np, size=1, p=self.weight_neighbor)[0]
         return self.list_neighbor[choice].find_subtasks(
             current_solution=current_solution, subtasks=subtasks
@@ -1268,8 +1269,8 @@ class NeighborBuilderMix(NeighborBuilder):
 
 class NeighborBuilderTimeWindow(NeighborBuilder):
     def find_subtasks(
-        self, current_solution: ANY_SOLUTION, subtasks: Optional[Set[Hashable]] = None
-    ) -> Tuple[Set[Hashable], Set[Hashable]]:
+        self, current_solution: ANY_SOLUTION, subtasks: Optional[set[Hashable]] = None
+    ) -> tuple[set[Hashable], set[Hashable]]:
         last_time = current_solution.get_end_time(self.problem.sink_task)
         if self.current_time_window[0] >= last_time:
             self.current_time_window = [0, self.time_window_length]
@@ -1361,7 +1362,7 @@ class ConstraintHandlerScheduling(MznConstraintHandler):
         self,
         problem: ANY_RCPSP,
         basic_constraint_builder: BasicConstraintBuilder,
-        params_list: List[ParamsConstraintBuilder] = None,
+        params_list: list[ParamsConstraintBuilder] = None,
         use_makespan_of_subtasks: bool = True,
         objective_subproblem: ObjectiveSubproblem = ObjectiveSubproblem.GLOBAL_MAKESPAN,
         verbose: bool = True,
@@ -1527,7 +1528,7 @@ class ConstraintHandlerMultiskillAllocation(MznConstraintHandler):
     def __init__(
         self,
         problem: ANY_MSRCPSP,
-        params_list: List[ParamsConstraintBuilder] = None,
+        params_list: list[ParamsConstraintBuilder] = None,
         verbose: bool = False,
     ):
         self.problem = problem
@@ -1599,7 +1600,7 @@ class EquilibrateMultiskillAllocationNonPreemptive(MznConstraintHandler):
     def __init__(
         self,
         problem: ANY_MSRCPSP,
-        params_list: List[ParamsConstraintBuilder] = None,
+        params_list: list[ParamsConstraintBuilder] = None,
         verbose: bool = False,
     ):
         self.problem = problem
@@ -1684,7 +1685,7 @@ class EquilibrateMultiskillAllocation(MznConstraintHandler):
     def __init__(
         self,
         problem: ANY_MSRCPSP,
-        params_list: List[ParamsConstraintBuilder] = None,
+        params_list: list[ParamsConstraintBuilder] = None,
         verbose: bool = False,
     ):
         self.problem = problem

--- a/discrete_optimization/generic_rcpsp_tools/solution_repair.py
+++ b/discrete_optimization/generic_rcpsp_tools/solution_repair.py
@@ -4,7 +4,8 @@
 
 import logging
 import random
-from typing import Any, Dict, Hashable, Iterable, List, Optional, Union
+from collections.abc import Hashable, Iterable
+from typing import Any, Optional, Union
 
 import numpy as np
 from minizinc import Instance
@@ -149,7 +150,7 @@ def find_possible_problems_preemptive(
 
 def problem_constraints(
     current_solution: Union[RCPSPSolutionPreemptive, MS_RCPSPSolution_Preemptive],
-    problems_output: Dict[Hashable, List],
+    problems_output: dict[Hashable, list],
     minus_delta: int,
     plus_delta: int,
     cp_solver: Union[
@@ -409,7 +410,7 @@ class NeighborRepairProblems(MznConstraintHandler):
             RCPSPModelSpecialConstraintsPreemptive,
             MS_RCPSPModel,
         ],
-        params_list: List[ParamsConstraintBuilder] = None,
+        params_list: list[ParamsConstraintBuilder] = None,
     ):
         self.problem = problem
         if isinstance(self.problem, RCPSPModelSpecialConstraintsPreemptive,) or (

--- a/discrete_optimization/generic_tools/asp_tools.py
+++ b/discrete_optimization/generic_tools/asp_tools.py
@@ -4,7 +4,7 @@
 import logging
 import os
 from abc import abstractmethod
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 import clingo
 
@@ -44,7 +44,7 @@ class ASPClingoSolver(SolverDO):
 
     def solve(
         self,
-        callbacks: Optional[List[Callback]] = None,
+        callbacks: Optional[list[Callback]] = None,
         time_limit: Optional[float] = 100.0,
         **kwargs: Any,
     ) -> ResultStorage:

--- a/discrete_optimization/generic_tools/cp_tools.py
+++ b/discrete_optimization/generic_tools/cp_tools.py
@@ -13,7 +13,7 @@ import logging
 from abc import abstractmethod
 from datetime import timedelta
 from enum import Enum
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Optional, Union
 
 import minizinc
 from minizinc import Instance, Status
@@ -167,7 +167,7 @@ class StatusSolver(Enum):
     UNKNOWN = "UNKNOWN"
 
 
-map_mzn_status_to_do_status: Dict[Status, StatusSolver] = {
+map_mzn_status_to_do_status: dict[Status, StatusSolver] = {
     Status.SATISFIED: StatusSolver.SATISFIED,
     Status.UNSATISFIABLE: StatusSolver.UNSATISFIABLE,
     Status.OPTIMAL_SOLUTION: StatusSolver.OPTIMAL,
@@ -209,7 +209,7 @@ class CPSolver(SolverDO):
     @abstractmethod
     def solve(
         self,
-        callbacks: Optional[List[Callback]] = None,
+        callbacks: Optional[list[Callback]] = None,
         parameters_cp: Optional[ParametersCP] = None,
         **args: Any,
     ) -> ResultStorage:
@@ -233,7 +233,7 @@ class MinizincCPSolver(CPSolver):
 
     def solve(
         self,
-        callbacks: Optional[List[Callback]] = None,
+        callbacks: Optional[list[Callback]] = None,
         parameters_cp: Optional[ParametersCP] = None,
         instance: Optional[Instance] = None,
         time_limit: Optional[float] = 100.0,
@@ -381,7 +381,7 @@ class MinizincCPSolution:
     @staticmethod
     def generate_subclass_for_solve(
         solver: MinizincCPSolver, callback: Callback
-    ) -> Type[MinizincCPSolution]:
+    ) -> type[MinizincCPSolution]:
         """Generate dynamically a subclass with initialized class attributes.
 
         Args:

--- a/discrete_optimization/generic_tools/do_mutation.py
+++ b/discrete_optimization/generic_tools/do_mutation.py
@@ -3,7 +3,7 @@
 #  LICENSE file in the root directory of this source tree.
 
 from abc import abstractmethod
-from typing import Any, Dict, Tuple
+from typing import Any
 
 from discrete_optimization.generic_tools.do_problem import Problem, Solution
 
@@ -43,11 +43,11 @@ class Mutation:
         raise NotImplementedError("Please implement it !")
 
     @abstractmethod
-    def mutate(self, solution: Solution) -> Tuple[Solution, LocalMove]:
+    def mutate(self, solution: Solution) -> tuple[Solution, LocalMove]:
         ...
 
     @abstractmethod
     def mutate_and_compute_obj(
         self, solution: Solution
-    ) -> Tuple[Solution, LocalMove, Dict[str, float]]:
+    ) -> tuple[Solution, LocalMove, dict[str, float]]:
         ...

--- a/discrete_optimization/generic_tools/do_problem.py
+++ b/discrete_optimization/generic_tools/do_problem.py
@@ -6,20 +6,10 @@
 
 import logging
 from abc import abstractmethod
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from enum import Enum
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Iterable,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import Any, Optional, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -62,7 +52,7 @@ class EncodingRegister:
     """Placeholder class where the Solution definition is defined.
 
     Attributes:
-        dict_attribute_to_type (Dict[str, Any]): specifies the encoding of a solution object.
+        dict_attribute_to_type (dict[str, Any]): specifies the encoding of a solution object.
         User may refer to example in the different implemented problem definition.
 
     Examples:
@@ -77,12 +67,12 @@ class EncodingRegister:
         }
     """
 
-    dict_attribute_to_type: Dict[str, Any]
+    dict_attribute_to_type: dict[str, Any]
 
-    def __init__(self, dict_attribute_to_type: Dict[str, Any]):
+    def __init__(self, dict_attribute_to_type: dict[str, Any]):
         self.dict_attribute_to_type = dict_attribute_to_type
 
-    def get_types(self) -> List[TypeAttribute]:
+    def get_types(self) -> list[TypeAttribute]:
         """Returns all the TypeAttribute that are present in our encoding."""
         return [
             t
@@ -93,14 +83,14 @@ class EncodingRegister:
     def __str__(self) -> str:
         return "Encoding : " + str(self.dict_attribute_to_type)
 
-    def lower_bound_vector_encoding(self, encoding_name: str) -> List[int]:
+    def lower_bound_vector_encoding(self, encoding_name: str) -> list[int]:
         """Return for an encoding that is of type LIST_INTEGER or associated, the lower bound vector.
         Examples: if the vector should contains value higher or equal to 1, the function will return a list full of 1.
         """
         dict_encoding = self.dict_attribute_to_type[encoding_name]
         return lower_bound_vector_encoding_from_dict(dict_encoding)
 
-    def upper_bound_vector_encoding(self, encoding_name: str) -> List[int]:
+    def upper_bound_vector_encoding(self, encoding_name: str) -> list[int]:
         """Return for an encoding that is of type LIST_INTEGER or associated, the upper bound vector.
         Examples: if the vector should contains value higher or equal to 1, the function will return a list full of 1.
         """
@@ -108,7 +98,7 @@ class EncodingRegister:
         return upper_bound_vector_encoding_from_dict(dict_encoding)
 
 
-def lower_bound_vector_encoding_from_dict(dict_encoding: Dict[str, Any]) -> List[int]:
+def lower_bound_vector_encoding_from_dict(dict_encoding: dict[str, Any]) -> list[int]:
     length_encoding = dict_encoding["n"]
     if "low" in dict_encoding:
         low_value: Union[int, Iterable[int]] = dict_encoding["low"]
@@ -120,7 +110,7 @@ def lower_bound_vector_encoding_from_dict(dict_encoding: Dict[str, Any]) -> List
         return [0 for i in range(length_encoding)]  # By default we start at zero.
 
 
-def upper_bound_vector_encoding_from_dict(dict_encoding: Dict[str, Any]) -> List[int]:
+def upper_bound_vector_encoding_from_dict(dict_encoding: dict[str, Any]) -> list[int]:
     """Return for an encoding that is of type LIST_INTEGER or associated, the upper bound vector.
 
     Examples: if the vector should contains value higher or equal to 1, the function will return a list full of 1.
@@ -201,22 +191,22 @@ class ObjectiveRegister:
 
     objective_sense: ModeOptim
     objective_handling: ObjectiveHandling
-    dict_objective_to_doc: Dict[str, ObjectiveDoc]
+    dict_objective_to_doc: dict[str, ObjectiveDoc]
 
     def __init__(
         self,
         objective_sense: ModeOptim,
         objective_handling: ObjectiveHandling,
-        dict_objective_to_doc: Dict[str, Any],
+        dict_objective_to_doc: dict[str, Any],
     ):
         self.objective_sense = objective_sense
         self.objective_handling = objective_handling
         self.dict_objective_to_doc = dict_objective_to_doc
 
-    def get_objective_names(self) -> List[str]:
+    def get_objective_names(self) -> list[str]:
         return sorted(self.dict_objective_to_doc)
 
-    def get_list_objective_and_default_weight(self) -> Tuple[List[str], List[float]]:
+    def get_list_objective_and_default_weight(self) -> tuple[list[str], list[float]]:
         """Flatten the list of kpi names and default weight.
 
         Returns: list of kpi names, list of default weight for the aggregated objective function.
@@ -291,7 +281,7 @@ class Problem:
     """Base class for a discrete optimization problem."""
 
     @abstractmethod
-    def evaluate(self, variable: Solution) -> Dict[str, float]:
+    def evaluate(self, variable: Solution) -> dict[str, float]:
         """Evaluate a given solution object for the given problem.
 
         This method should return a dictionnary of KPI, that can be then used for mono or multiobjective optimization.
@@ -299,7 +289,7 @@ class Problem:
         Args:
             variable (Solution): the Solution object to evaluate.
 
-        Returns: Dictionnary of float kpi for the solution.
+        Returns: dictionnary of float kpi for the solution.
 
         """
         ...
@@ -320,7 +310,7 @@ class Problem:
         dict_values = self.evaluate(variable)
         return TupleFitness(np.array([dict_values[k] for k in keys]), len(keys))
 
-    def evaluate_mobj_from_dict(self, dict_values: Dict[str, float]) -> TupleFitness:
+    def evaluate_mobj_from_dict(self, dict_values: dict[str, float]) -> TupleFitness:
         """Return an multiobjective fitness from a dictionnary of kpi (output of evaluate function).
 
         It consists in flattening the evaluate() function and put in an array.
@@ -357,7 +347,7 @@ class Problem:
         ...
 
     @abstractmethod
-    def get_solution_type(self) -> Type[Solution]:
+    def get_solution_type(self) -> type[Solution]:
         """Returns the class implementation of a Solution.
 
         Returns (class): class object of the given Problem.
@@ -382,7 +372,7 @@ class Problem:
             direction = "maximize"
         return direction
 
-    def get_objective_names(self) -> List[str]:
+    def get_objective_names(self) -> list[str]:
         return self.get_objective_register().get_objective_names()
 
 
@@ -491,13 +481,13 @@ class RobustProblem(Problem):
 
         return func
 
-    def evaluate(self, variable: Solution) -> Dict[str, float]:
+    def evaluate(self, variable: Solution) -> dict[str, float]:
         """Aggregated evaluate function.
 
         Args:
             variable (Solution): Solution to evaluate on the different scenarios.
 
-        Returns (Dict[str,float]): aggregated kpi on different scenarios.
+        Returns (dict[str,float]): aggregated kpi on different scenarios.
 
         """
         fits = [self.list_problem[i].evaluate(variable) for i in range(self.nb_problem)]
@@ -527,7 +517,7 @@ class RobustProblem(Problem):
         """See ```Problem.get_attribute_register``` doc."""
         return self.list_problem[0].get_attribute_register()
 
-    def get_solution_type(self) -> Type[Solution]:
+    def get_solution_type(self) -> type[Solution]:
         """See ```Problem.get_solution_type``` doc."""
         return self.list_problem[0].get_solution_type()
 
@@ -543,15 +533,15 @@ class ParamsObjectiveFunction:
     """
 
     objective_handling: ObjectiveHandling
-    objectives: List[str]
-    weights: List[float]
+    objectives: list[str]
+    weights: list[float]
     sense_function: ModeOptim
 
     def __init__(
         self,
         objective_handling: ObjectiveHandling,
-        objectives: List[str],
-        weights: List[float],
+        objectives: list[str],
+        weights: list[float],
         sense_function: ModeOptim,
     ):
         self.objective_handling = objective_handling
@@ -592,14 +582,14 @@ def get_default_objective_setup(problem: Problem) -> ParamsObjectiveFunction:
 def build_aggreg_function_and_params_objective(
     problem: Problem,
     params_objective_function: Optional[ParamsObjectiveFunction] = None,
-) -> Tuple[
+) -> tuple[
     Union[
         Callable[[Solution], float],
         Callable[[Solution], TupleFitness],
     ],
     Union[
-        Callable[[Dict[str, float]], float],
-        Callable[[Dict[str, float]], TupleFitness],
+        Callable[[dict[str, float]], float],
+        Callable[[dict[str, float]], TupleFitness],
     ],
     ParamsObjectiveFunction,
 ]:
@@ -613,7 +603,7 @@ def build_aggreg_function_and_params_objective(
 
     Returns: the function returns a 3-uple :
                     -first element is a function of Solution->Union[float,TupleFitness]
-                    -second element is a function of (Dict[str,float])->Union[float, TupleFitness]
+                    -second element is a function of (dict[str,float])->Union[float, TupleFitness]
                     -third element, return the params_objective_function (either the object passed in argument of the
                     function, or the one created inside the function.)
 
@@ -630,14 +620,14 @@ def build_evaluate_function_aggregated(
     problem: Problem,
     params_objective_function: Optional[ParamsObjectiveFunction] = None,
 ) -> Union[
-    Tuple[Callable[[Solution], float], Callable[[Dict[str, float]], float]],
-    Tuple[
-        Callable[[Solution], TupleFitness], Callable[[Dict[str, float]], TupleFitness]
+    tuple[Callable[[Solution], float], Callable[[dict[str, float]], float]],
+    tuple[
+        Callable[[Solution], TupleFitness], Callable[[dict[str, float]], TupleFitness]
     ],
 ]:
     """Build 2 eval functions based from the problem and params of objective function.
 
-    The 2 eval function are callable with a Solution for the first one, and a Dict[str, float]
+    The 2 eval function are callable with a Solution for the first one, and a dict[str, float]
     (output of Problem.evaluate function) for the second one. Those two eval function will return either a scalar for
     monoobjective problem or a TupleFitness for multiobjective.
     those aggregated function will be the one actually called by an optimisation algorithm at the end.
@@ -648,7 +638,7 @@ def build_evaluate_function_aggregated(
 
     Returns: the function returns a 2-uple :
                     -first element is a function of Solution->Union[float,TupleFitness]
-                    -second element is a function of (Dict[str,float])->Union[float, TupleFitness]
+                    -second element is a function of (dict[str,float])->Union[float, TupleFitness]
     """
     if params_objective_function is None:
         params_objective_function = get_default_objective_setup(problem)
@@ -664,7 +654,7 @@ def build_evaluate_function_aggregated(
             val = sum([dict_values[objectives[i]] * weights[i] for i in range(length)])
             return sign * val
 
-        def eval_from_dict_values(dict_values: Dict[str, float]) -> float:
+        def eval_from_dict_values(dict_values: dict[str, float]) -> float:
             val = sum([dict_values[objectives[i]] * weights[i] for i in range(length)])
             return sign * val
 
@@ -677,7 +667,7 @@ def build_evaluate_function_aggregated(
             dict_values = problem.evaluate(solution)
             return sign * dict_values[objectives[0]] * weights[0]
 
-        def eval_from_dict_values(dict_values: Dict[str, float]) -> float:
+        def eval_from_dict_values(dict_values: dict[str, float]) -> float:
             return sign * dict_values[objectives[0]] * weights[0]
 
         return eval_sol, eval_from_dict_values
@@ -695,7 +685,7 @@ def build_evaluate_function_aggregated(
                 * sign
             )
 
-        def eval_from_dict_values2(dict_values: Dict[str, float]) -> TupleFitness:
+        def eval_from_dict_values2(dict_values: dict[str, float]) -> TupleFitness:
             return (
                 TupleFitness(
                     np.array(

--- a/discrete_optimization/generic_tools/do_solver.py
+++ b/discrete_optimization/generic_tools/do_solver.py
@@ -6,7 +6,8 @@
 from __future__ import annotations  # see annotations as str
 
 from abc import ABC, abstractmethod
-from typing import Any, Iterable, List, Optional, Tuple
+from collections.abc import Iterable
+from typing import Any, Optional
 
 from discrete_optimization.generic_tools.callbacks.callback import Callback
 from discrete_optimization.generic_tools.do_problem import (
@@ -50,7 +51,7 @@ class SolverDO(Hyperparametrizable, ABC):
 
     @abstractmethod
     def solve(
-        self, callbacks: Optional[List[Callback]] = None, **kwargs: Any
+        self, callbacks: Optional[list[Callback]] = None, **kwargs: Any
     ) -> ResultStorage:
         """Generic solving function.
 
@@ -67,7 +68,7 @@ class SolverDO(Hyperparametrizable, ABC):
         ...
 
     def create_result_storage(
-        self, list_solution_fits: Optional[List[Tuple[Solution, fitness_class]]] = None
+        self, list_solution_fits: Optional[list[tuple[Solution, fitness_class]]] = None
     ) -> ResultStorage:
         """Create a result storage with the proper mode_optim.
 
@@ -103,7 +104,7 @@ class SolverDO(Hyperparametrizable, ABC):
         """
         return None
 
-    def get_model_objectives_available(self) -> List[str]:
+    def get_model_objectives_available(self) -> list[str]:
         """List objectives available for lexico optimization
 
         It corresponds to the labels accepted for obj argument for
@@ -229,7 +230,7 @@ class TrivialSolverFromResultStorage(SolverDO, WarmstartMixin):
         self.result_storage = result_storage
 
     def solve(
-        self, callbacks: Optional[List[Callback]] = None, **kwargs: Any
+        self, callbacks: Optional[list[Callback]] = None, **kwargs: Any
     ) -> ResultStorage:
         return self.result_storage
 
@@ -257,7 +258,7 @@ class TrivialSolverFromSolution(SolverDO):
         self.set_warm_start(solution)
 
     def solve(
-        self, callbacks: Optional[List[Callback]] = None, **kwargs: Any
+        self, callbacks: Optional[list[Callback]] = None, **kwargs: Any
     ) -> ResultStorage:
         return self.result_storage
 

--- a/discrete_optimization/generic_tools/ea/alternating_ga.py
+++ b/discrete_optimization/generic_tools/ea/alternating_ga.py
@@ -2,7 +2,7 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 from discrete_optimization.generic_tools.do_mutation import Mutation
 from discrete_optimization.generic_tools.do_problem import (
@@ -43,16 +43,16 @@ class AlternatingGa(SolverDO, WarmstartMixin):
     def __init__(
         self,
         problem: Problem,
-        objectives: Union[str, List[str]],
-        encodings: Optional[Union[List[str], List[Dict[str, Any]]]] = None,
-        mutations: Optional[Union[List[Mutation], List[DeapMutation]]] = None,
-        crossovers: Optional[List[DeapCrossover]] = None,
-        selections: Optional[List[DeapSelection]] = None,
+        objectives: Union[str, list[str]],
+        encodings: Optional[Union[list[str], list[dict[str, Any]]]] = None,
+        mutations: Optional[Union[list[Mutation], list[DeapMutation]]] = None,
+        crossovers: Optional[list[DeapCrossover]] = None,
+        selections: Optional[list[DeapSelection]] = None,
         objective_handling: Optional[ObjectiveHandling] = None,
-        objective_weights: Optional[List[float]] = None,
+        objective_weights: Optional[list[float]] = None,
         pop_size: Optional[int] = None,
         max_evals: int = 10000,
-        sub_evals: Optional[List[int]] = None,
+        sub_evals: Optional[list[int]] = None,
         mut_rate: Optional[float] = None,
         crossover_rate: Optional[float] = None,
         tournament_size: Optional[float] = None,
@@ -102,7 +102,7 @@ class AlternatingGa(SolverDO, WarmstartMixin):
                     self.encodings[i], start_solution  # type: ignore
                 )
         while count_evals < self.max_evals:
-            kwargs_ga: Dict[str, Any] = {}
+            kwargs_ga: dict[str, Any] = {}
             if self.mutations is not None:
                 kwargs_ga["mutation"] = self.mutations[current_encoding_index]
             if self.encodings is not None:

--- a/discrete_optimization/generic_tools/ea/deap_wrappers.py
+++ b/discrete_optimization/generic_tools/ea/deap_wrappers.py
@@ -2,7 +2,8 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, MutableSequence, Sequence, Tuple, Type, TypeVar
+from collections.abc import MutableSequence, Sequence
+from typing import Any, TypeVar
 
 from discrete_optimization.generic_tools.do_mutation import Mutation
 from discrete_optimization.generic_tools.do_problem import Problem, Solution
@@ -15,10 +16,10 @@ def generic_mutate_wrapper(
     problem: Problem,
     encoding_name: str,
     indpb: Any,
-    solution_fn: Type[Solution],
+    solution_fn: type[Solution],
     custom_mutation: Mutation,
-) -> Tuple[MutableSequence[T]]:
-    kwargs: Dict[str, Any] = {encoding_name: individual, "problem": problem}
+) -> tuple[MutableSequence[T]]:
+    kwargs: dict[str, Any] = {encoding_name: individual, "problem": problem}
     custom_sol: Solution = solution_fn(**kwargs)  # type: ignore
     new_custom_sol = custom_mutation.mutate(custom_sol)[0]
     new_individual = individual

--- a/discrete_optimization/generic_tools/ea/ga.py
+++ b/discrete_optimization/generic_tools/ea/ga.py
@@ -5,7 +5,7 @@
 import logging
 import random
 from enum import Enum
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 import numpy as np
 from deap import algorithms, base, creator, tools
@@ -105,20 +105,20 @@ class Ga(SolverDO, WarmstartMixin):
     def __init__(
         self,
         problem: Problem,
-        objectives: Union[str, List[str]],
+        objectives: Union[str, list[str]],
         mutation: Optional[Union[Mutation, DeapMutation]] = None,
         crossover: Optional[DeapCrossover] = None,
         selection: DeapSelection = DeapSelection.SEL_TOURNAMENT,
-        encoding: Optional[Union[str, Dict[str, Any]]] = None,
+        encoding: Optional[Union[str, dict[str, Any]]] = None,
         objective_handling: ObjectiveHandling = ObjectiveHandling.SINGLE,
-        objective_weights: Optional[List[float]] = None,
+        objective_weights: Optional[list[float]] = None,
         pop_size: int = 100,
         max_evals: Optional[int] = None,
         mut_rate: float = 0.1,
         crossover_rate: float = 0.9,
         tournament_size: float = 0.2,  # as a percentage of the population
         deap_verbose: bool = True,
-        initial_population: Optional[List[List[Any]]] = None,
+        initial_population: Optional[list[list[Any]]] = None,
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
         **kwargs,
     ):
@@ -127,7 +127,7 @@ class Ga(SolverDO, WarmstartMixin):
         )
         if not hasattr(self.problem, "evaluate_from_encoding"):
             raise ValueError("self.problem shoud define an evaluate_from_encoding()")
-            # self.problem.evaluate_from_encoding: Callable[[List[int], str], Dict[str, float]]
+            # self.problem.evaluate_from_encoding: Callable[[list[int], str], dict[str, float]]
 
         self._pop_size = pop_size
         if max_evals is not None:
@@ -169,7 +169,7 @@ class Ga(SolverDO, WarmstartMixin):
                         register_solution.dict_attribute_to_type[encoding_name]
                     )
 
-        elif encoding is not None and isinstance(encoding, Dict):
+        elif encoding is not None and isinstance(encoding, dict):
             # check there is a type key and a n key
             if (
                 "name" in encoding.keys()
@@ -248,7 +248,7 @@ class Ga(SolverDO, WarmstartMixin):
                 "Many objectives specified but single objective handling, using the first objective in the dictionary"
             )
 
-        self._objective_weights: List[float]
+        self._objective_weights: list[float]
         if (objective_weights is None) or (
             objective_weights is not None
             and (
@@ -418,8 +418,8 @@ class Ga(SolverDO, WarmstartMixin):
         elif self._selection_type == DeapSelection.SEL_STOCHASTIC_UNIVERSAL_SAMPLING:
             self._toolbox.register("select", tools.selStochasticUniversalSampling)
 
-    def evaluate_problem(self, int_vector: List[int]) -> Tuple[float]:
-        objective_values: Dict[str, float] = self.problem.evaluate_from_encoding(  # type: ignore
+    def evaluate_problem(self, int_vector: list[int]) -> tuple[float]:
+        objective_values: dict[str, float] = self.problem.evaluate_from_encoding(  # type: ignore
             int_vector, self._encoding_variable_name
         )
         if self._objective_handling == ObjectiveHandling.SINGLE:
@@ -437,7 +437,7 @@ class Ga(SolverDO, WarmstartMixin):
             )
         return (val,)
 
-    def generate_custom_population(self) -> List[Any]:
+    def generate_custom_population(self) -> list[Any]:
         if self.initial_population is None:
             raise RuntimeError(
                 "self.initial_population cannot be None when calling generate_custom_population()."

--- a/discrete_optimization/generic_tools/ea/ga_tools.py
+++ b/discrete_optimization/generic_tools/ea/ga_tools.py
@@ -2,7 +2,7 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import List, Union
+from typing import Union
 
 from discrete_optimization.generic_tools.do_mutation import Mutation
 from discrete_optimization.generic_tools.ea.ga import (
@@ -21,8 +21,8 @@ class ParametersGa:
         selection: DeapSelection,
         encoding: str,
         objective_handling: ObjectiveHandling,
-        objectives: Union[str, List[str]],
-        objective_weights: List[float],
+        objectives: Union[str, list[str]],
+        objective_weights: list[float],
         pop_size: int,
         max_evals: int,
         mut_rate: float,
@@ -66,20 +66,20 @@ class ParametersGa:
 class ParametersAltGa:
     def __init__(
         self,
-        mutations: List[Union[Mutation, DeapMutation]],
-        crossovers: List[DeapCrossover],
-        selections: List[DeapSelection],
-        encodings: List[str],
+        mutations: list[Union[Mutation, DeapMutation]],
+        crossovers: list[DeapCrossover],
+        selections: list[DeapSelection],
+        encodings: list[str],
         objective_handling: ObjectiveHandling,
-        objectives: Union[str, List[str]],
-        objective_weights: List[float],
+        objectives: Union[str, list[str]],
+        objective_weights: list[float],
         pop_size: int,
         max_evals: int,
         mut_rate: float,
         crossover_rate: float,
         tournament_size: float,
         deap_verbose: bool,
-        sub_evals: List[int],
+        sub_evals: list[int],
     ):
         self.mutations = mutations
         self.crossovers = crossovers

--- a/discrete_optimization/generic_tools/ea/nsga.py
+++ b/discrete_optimization/generic_tools/ea/nsga.py
@@ -4,7 +4,8 @@
 
 import logging
 import random
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from collections.abc import Callable
+from typing import Any, Optional, Union
 
 import numpy as np
 from deap import algorithms, base, creator, tools
@@ -65,11 +66,11 @@ class Nsga(SolverDO, WarmstartMixin):
     def __init__(
         self,
         problem: Problem,
-        objectives: Union[str, List[str]],
+        objectives: Union[str, list[str]],
         mutation: Optional[Union[Mutation, DeapMutation]] = None,
         crossover: Optional[DeapCrossover] = None,
-        encoding: Optional[Union[str, Dict[str, Any]]] = None,
-        objective_weights: Optional[List[float]] = None,
+        encoding: Optional[Union[str, dict[str, Any]]] = None,
+        objective_weights: Optional[list[float]] = None,
         pop_size: int = 100,
         max_evals: Optional[int] = None,
         mut_rate: float = 0.1,
@@ -79,7 +80,7 @@ class Nsga(SolverDO, WarmstartMixin):
         self.problem = problem
         if not hasattr(self.problem, "evaluate_from_encoding"):
             raise ValueError("self.problem shoud define an evaluate_from_encoding()")
-            # self.problem.evaluate_from_encoding: Callable[[List[int], str], Dict[str, float]]
+            # self.problem.evaluate_from_encoding: Callable[[list[int], str], dict[str, float]]
         self._pop_size = pop_size
         if max_evals is not None:
             self._max_evals = max_evals
@@ -119,7 +120,7 @@ class Nsga(SolverDO, WarmstartMixin):
                         encoding_name
                     ]["arities"]
 
-        if encoding is not None and isinstance(encoding, Dict):
+        if encoding is not None and isinstance(encoding, dict):
             # check there is a type key and a n key
             if (
                 "name" in encoding.keys()
@@ -184,7 +185,7 @@ class Nsga(SolverDO, WarmstartMixin):
             self._objectives = [objectives]
         else:
             self._objectives = objectives
-        self._objective_weights: List[float]
+        self._objective_weights: list[float]
         if (objective_weights is None) or (
             objective_weights is not None
             and (len(objective_weights) != len(self._objectives))
@@ -335,7 +336,7 @@ class Nsga(SolverDO, WarmstartMixin):
         # No choice of selection: In NSGA, only 1 selection: Non Dominated Sorted Selection
         self._toolbox.register("select", tools.selNSGA3, ref_points=ref_points)
 
-    def evaluate_problem(self, int_vector: List[int]) -> Tuple[float, ...]:
+    def evaluate_problem(self, int_vector: list[int]) -> tuple[float, ...]:
         objective_values = self.problem.evaluate_from_encoding(  # type: ignore
             int_vector, self._encoding_variable_name
         )

--- a/discrete_optimization/generic_tools/ghh_tools.py
+++ b/discrete_optimization/generic_tools/ghh_tools.py
@@ -2,16 +2,11 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-import sys
-from typing import Any, Iterable, TypeVar, Union
+from collections.abc import Iterable
+from typing import Any, Protocol, TypeVar, Union
 
 import numpy as np
 import numpy.typing as npt
-
-if sys.version_info >= (3, 8):
-    from typing import Protocol
-else:
-    from typing_extensions import Protocol
 
 
 def index_min(list_or_array: npt.ArrayLike) -> np.int_:

--- a/discrete_optimization/generic_tools/graph_api.py
+++ b/discrete_optimization/generic_tools/graph_api.py
@@ -2,7 +2,8 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 import string
-from typing import Any, Dict, Hashable, KeysView, List, Optional, Set, Tuple, Union
+from collections.abc import Hashable, KeysView
+from typing import Any, Optional, Union
 
 import networkx as nx
 
@@ -10,24 +11,24 @@ import networkx as nx
 class Graph:
     def __init__(
         self,
-        nodes: List[Tuple[Hashable, Dict[str, Any]]],
-        edges: List[Tuple[Hashable, Hashable, Dict[str, Any]]],
+        nodes: list[tuple[Hashable, dict[str, Any]]],
+        edges: list[tuple[Hashable, Hashable, dict[str, Any]]],
         undirected: bool = True,
         compute_predecessors: bool = True,
     ):
         self.nodes = nodes
         self.edges = edges
         self.undirected = undirected
-        self.neighbors_dict: Dict[Hashable, Set[Hashable]] = {}
-        self.predecessors_dict: Dict[Hashable, Set[Hashable]] = {}
-        self.edges_infos_dict: Dict[Tuple[Hashable, Hashable], Dict[str, Any]] = {}
-        self.nodes_infos_dict: Dict[Hashable, Dict[str, Any]] = {}
+        self.neighbors_dict: dict[Hashable, set[Hashable]] = {}
+        self.predecessors_dict: dict[Hashable, set[Hashable]] = {}
+        self.edges_infos_dict: dict[tuple[Hashable, Hashable], dict[str, Any]] = {}
+        self.nodes_infos_dict: dict[Hashable, dict[str, Any]] = {}
         self.build_nodes_infos_dict()
         self.build_edges()
         self.nodes_name = list(self.nodes_infos_dict)
         self.graph_nx = self.to_networkx()
-        self.full_predecessors: Optional[Dict[Hashable, Set[Hashable]]]
-        self.full_successors: Optional[Dict[Hashable, Set[Hashable]]]
+        self.full_predecessors: Optional[dict[Hashable, set[Hashable]]]
+        self.full_successors: Optional[dict[Hashable, set[Hashable]]]
         if compute_predecessors:
             self.full_predecessors = self.ancestors_map()
             self.full_successors = self.descendants_map()
@@ -35,10 +36,10 @@ class Graph:
             self.full_predecessors = None
             self.full_successors = None
 
-    def get_edges(self) -> KeysView[Tuple[Hashable, Hashable]]:
+    def get_edges(self) -> KeysView[tuple[Hashable, Hashable]]:
         return self.edges_infos_dict.keys()
 
-    def get_nodes(self) -> List[Hashable]:
+    def get_nodes(self) -> list[Hashable]:
         return self.nodes_name
 
     def build_nodes_infos_dict(self) -> None:
@@ -63,10 +64,10 @@ class Graph:
                 self.neighbors_dict[n2].add(n1)
                 self.edges_infos_dict[(n2, n1)] = d
 
-    def get_neighbors(self, node: Hashable) -> Set[Hashable]:
+    def get_neighbors(self, node: Hashable) -> set[Hashable]:
         return self.neighbors_dict.get(node, set())
 
-    def get_predecessors(self, node: Hashable) -> Set[Hashable]:
+    def get_predecessors(self, node: Hashable) -> set[Hashable]:
         return self.predecessors_dict.get(node, set())
 
     def get_attr_node(self, node: Hashable, attr: str) -> Any:
@@ -81,35 +82,35 @@ class Graph:
         graph_nx.add_edges_from(self.edges)
         return graph_nx
 
-    def check_loop(self) -> Optional[List[Tuple[Hashable, Hashable, str]]]:
+    def check_loop(self) -> Optional[list[tuple[Hashable, Hashable, str]]]:
         try:
             cycles = nx.find_cycle(self.graph_nx, orientation="original")
         except:
             cycles = None
         return cycles
 
-    def precedessors_nodes(self, n: Hashable) -> Set[Hashable]:
+    def precedessors_nodes(self, n: Hashable) -> set[Hashable]:
         return nx.algorithms.ancestors(self.graph_nx, n)
 
-    def ancestors_map(self) -> Dict[Hashable, Set[Hashable]]:
+    def ancestors_map(self) -> dict[Hashable, set[Hashable]]:
         return {
             n: nx.algorithms.ancestors(self.graph_nx, n) for n in self.graph_nx.nodes()
         }
 
-    def descendants_map(self) -> Dict[Hashable, Set[Hashable]]:
+    def descendants_map(self) -> dict[Hashable, set[Hashable]]:
         return {
             n: nx.algorithms.descendants(self.graph_nx, n)
             for n in self.graph_nx.nodes()
         }
 
-    def successors_map(self) -> Dict[Hashable, List[Hashable]]:
+    def successors_map(self) -> dict[Hashable, list[Hashable]]:
         return {n: list(nx.neighbors(self.graph_nx, n)) for n in self.graph_nx.nodes()}
 
-    def predecessors_map(self) -> Dict[Hashable, List[Hashable]]:
+    def predecessors_map(self) -> dict[Hashable, list[Hashable]]:
         return {n: list(self.graph_nx.predecessors(n)) for n in self.graph_nx.nodes()}
 
     def compute_length(
-        self, path: List[Hashable], attribute_name: Optional[str] = None
+        self, path: list[Hashable], attribute_name: Optional[str] = None
     ):
         if attribute_name is None:
             length = len(path) - 1
@@ -133,7 +134,7 @@ class Graph:
 
     def compute_all_shortest_path(
         self, attribute_name: Optional[str] = None
-    ) -> Dict[Hashable, Dict[Hashable, Tuple[List[Hashable], float]]]:
+    ) -> dict[Hashable, dict[Hashable, tuple[list[Hashable], float]]]:
         all_path = nx.all_pairs_dijkstra_path(G=self.graph_nx, weight=attribute_name)
         dict_path_and_distance = {}
         for source, dict_path in all_path:

--- a/discrete_optimization/generic_tools/hyperparameters/hyperparameter.py
+++ b/discrete_optimization/generic_tools/hyperparameters/hyperparameter.py
@@ -6,12 +6,10 @@ from __future__ import annotations  # see annotations as str
 
 import inspect
 from abc import ABC, abstractmethod
-from collections.abc import Mapping
+from collections.abc import Callable, Container, Iterable, Mapping
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Callable, Container, Dict, Iterable, List
-from typing import Mapping as MappingType
-from typing import Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 if TYPE_CHECKING:  # only for type checkers
     from discrete_optimization.generic_tools.hyperparameters.hyperparametrizable import (
@@ -43,7 +41,7 @@ class Hyperparameter:
 
     """
 
-    depends_on: Optional[Tuple[str, Container[Any]]] = None
+    depends_on: Optional[tuple[str, Container[Any]]] = None
     """Other hyperparameter on which this ones depends on.
 
     If None: this hyperparameter is always needed.
@@ -135,7 +133,7 @@ class IntegerHyperparameter(Hyperparameter):
 
     """
 
-    depends_on: Optional[Tuple[str, Container[Any]]] = None
+    depends_on: Optional[tuple[str, Container[Any]]] = None
     """Other hyperparameter on which this ones depends on.
 
     If None: this hyperparameter is always needed.
@@ -252,7 +250,7 @@ class FloatHyperparameter(Hyperparameter):
 
     """
 
-    depends_on: Optional[Tuple[str, Container[Any]]] = None
+    depends_on: Optional[tuple[str, Container[Any]]] = None
     """Other hyperparameter on which this ones depends on.
 
     If None: this hyperparameter is always needed.
@@ -349,15 +347,15 @@ LabelType = Optional[Union[bool, int, float, str]]
 class CategoricalHyperparameter(Hyperparameter):
     """Categorical hyperparameter."""
 
-    choices: MappingType[LabelType, Any]
+    choices: Mapping[LabelType, Any]
     """Mapping lables to corresponding possible choices."""
 
     def __init__(
         self,
         name: str,
-        choices: Union[Iterable[LabelType], MappingType[LabelType, Any]],
+        choices: Union[Iterable[LabelType], Mapping[LabelType, Any]],
         default: Optional[Any] = None,
-        depends_on: Optional[Tuple[str, Container[Any]]] = None,
+        depends_on: Optional[tuple[str, Container[Any]]] = None,
         name_in_kwargs: Optional[str] = None,
     ):
         super().__init__(
@@ -375,9 +373,7 @@ class CategoricalHyperparameter(Hyperparameter):
     def suggest_with_optuna(
         self,
         trial: optuna.trial.Trial,
-        choices: Optional[
-            Union[Iterable[LabelType], MappingType[LabelType, Any]]
-        ] = None,
+        choices: Optional[Union[Iterable[LabelType], Mapping[LabelType, Any]]] = None,
         prefix: str = "",
         **kwargs: Any,
     ) -> Any:
@@ -414,10 +410,10 @@ class EnumHyperparameter(CategoricalHyperparameter):
     def __init__(
         self,
         name: str,
-        enum: Type[Enum],
-        choices: Optional[Union[Iterable[Enum], Dict[str, Enum]]] = None,
+        enum: type[Enum],
+        choices: Optional[Union[Iterable[Enum], dict[str, Enum]]] = None,
         default: Optional[Any] = None,
-        depends_on: Optional[Tuple[str, Container[Any]]] = None,
+        depends_on: Optional[tuple[str, Container[Any]]] = None,
         name_in_kwargs: Optional[str] = None,
     ):
         if choices is None:
@@ -469,7 +465,7 @@ class SubBrickClsHyperparameter(CategoricalHyperparameter):
 
     """
 
-    choices: Dict[str, Type[Hyperparametrizable]]
+    choices: dict[str, type[Hyperparametrizable]]
     """Mapping of labelled Hyperparametrizable subclasses to choose from for the subbrick.
 
     NB: for now, it is not possible to pick the metasolver itself as a choice for its subbrick,
@@ -488,10 +484,10 @@ class SubBrickClsHyperparameter(CategoricalHyperparameter):
         self,
         name: str,
         choices: Union[
-            Dict[str, Type[Hyperparametrizable]], Iterable[Type[Hyperparametrizable]]
+            dict[str, type[Hyperparametrizable]], Iterable[type[Hyperparametrizable]]
         ],
-        default: Optional[Type[Hyperparametrizable]] = None,
-        depends_on: Optional[Tuple[str, Container[Any]]] = None,
+        default: Optional[type[Hyperparametrizable]] = None,
+        depends_on: Optional[tuple[str, Container[Any]]] = None,
         name_in_kwargs: Optional[str] = None,
         include_module_in_labels: bool = False,
     ):
@@ -516,13 +512,13 @@ class SubBrickClsHyperparameter(CategoricalHyperparameter):
         trial: optuna.trial.Trial,
         choices: Optional[
             Union[
-                Dict[str, Type[Hyperparametrizable]],
-                Iterable[Type[Hyperparametrizable]],
+                dict[str, type[Hyperparametrizable]],
+                Iterable[type[Hyperparametrizable]],
             ]
         ] = None,
         prefix: str = "",
         **kwargs: Any,
-    ) -> Type[Hyperparametrizable]:
+    ) -> type[Hyperparametrizable]:
         """Suggest hyperparameter value for an Optuna trial.
 
         Args:
@@ -565,9 +561,9 @@ class SubBrickKwargsHyperparameter(Hyperparameter):
         self,
         name: str,
         subbrick_hyperparameter: Optional[str] = None,
-        subbrick_cls: Optional[Type[Hyperparametrizable]] = None,
-        default: Optional[Dict[str, Any]] = None,
-        depends_on: Optional[Tuple[str, Container[Any]]] = None,
+        subbrick_cls: Optional[type[Hyperparametrizable]] = None,
+        default: Optional[dict[str, Any]] = None,
+        depends_on: Optional[tuple[str, Container[Any]]] = None,
         name_in_kwargs: Optional[str] = None,
     ):
         super().__init__(
@@ -586,20 +582,20 @@ class SubBrickKwargsHyperparameter(Hyperparameter):
     def suggest_with_optuna(
         self,
         trial: optuna.trial.Trial,
-        subbrick: Optional[Type[Hyperparametrizable]] = None,
-        names: Optional[List[str]] = None,
-        names_by_subbrick: Optional[Dict[Type[Hyperparametrizable], List[str]]] = None,
-        kwargs_by_name: Optional[Dict[str, Dict[str, Any]]] = None,
+        subbrick: Optional[type[Hyperparametrizable]] = None,
+        names: Optional[list[str]] = None,
+        names_by_subbrick: Optional[dict[type[Hyperparametrizable], list[str]]] = None,
+        kwargs_by_name: Optional[dict[str, dict[str, Any]]] = None,
         kwargs_by_name_by_subbrick: Optional[
-            Dict[Type[Hyperparametrizable], Dict[str, Dict[str, Any]]]
+            dict[type[Hyperparametrizable], dict[str, dict[str, Any]]]
         ] = None,
-        fixed_hyperparameters: Optional[Dict[str, Any]] = None,
+        fixed_hyperparameters: Optional[dict[str, Any]] = None,
         fixed_hyperparameters_by_subbrick: Optional[
-            Dict[Type[Hyperparametrizable], Dict[str, Any]]
+            dict[type[Hyperparametrizable], dict[str, Any]]
         ] = None,
         prefix: str = "",
         **kwargs,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Suggest hyperparameter value for an Optuna trial.
 
         Args:
@@ -705,10 +701,10 @@ class SubBrickHyperparameter(Hyperparameter):
         self,
         name: str,
         choices: Union[
-            Dict[str, Type[Hyperparametrizable]], Iterable[Type[Hyperparametrizable]]
+            dict[str, type[Hyperparametrizable]], Iterable[type[Hyperparametrizable]]
         ],
         default: Optional[SubBrick] = None,
-        depends_on: Optional[Tuple[str, Container[Any]]] = None,
+        depends_on: Optional[tuple[str, Container[Any]]] = None,
         name_in_kwargs: Optional[str] = None,
         include_module_in_labels: bool = False,
     ):
@@ -747,19 +743,19 @@ class SubBrickHyperparameter(Hyperparameter):
         trial: optuna.trial.Trial,
         choices: Optional[
             Union[
-                Dict[str, Type[Hyperparametrizable]],
-                Iterable[Type[Hyperparametrizable]],
+                dict[str, type[Hyperparametrizable]],
+                Iterable[type[Hyperparametrizable]],
             ]
         ] = None,
-        names: Optional[List[str]] = None,
-        names_by_subbrick: Optional[Dict[Type[Hyperparametrizable], List[str]]] = None,
-        kwargs_by_name: Optional[Dict[str, Dict[str, Any]]] = None,
+        names: Optional[list[str]] = None,
+        names_by_subbrick: Optional[dict[type[Hyperparametrizable], list[str]]] = None,
+        kwargs_by_name: Optional[dict[str, dict[str, Any]]] = None,
         kwargs_by_name_by_subbrick: Optional[
-            Dict[Type[Hyperparametrizable], Dict[str, Dict[str, Any]]]
+            dict[type[Hyperparametrizable], dict[str, dict[str, Any]]]
         ] = None,
-        fixed_hyperparameters: Optional[Dict[str, Any]] = None,
+        fixed_hyperparameters: Optional[dict[str, Any]] = None,
         fixed_hyperparameters_by_subbrick: Optional[
-            Dict[Type[Hyperparametrizable], Dict[str, Any]]
+            dict[type[Hyperparametrizable], dict[str, Any]]
         ] = None,
         prefix: str = "",
         **kwargs: Any,
@@ -808,9 +804,9 @@ class SubBrick:
 
     """
 
-    cls: Type[Hyperparametrizable]
-    kwargs: Dict[str, Any]
-    kwargs_from_solution: Optional[Dict[str, Callable[..., Any]]] = None
+    cls: type[Hyperparametrizable]
+    kwargs: dict[str, Any]
+    kwargs_from_solution: Optional[dict[str, Callable[..., Any]]] = None
 
 
 class ListHyperparameter(Hyperparameter):
@@ -839,7 +835,7 @@ class ListHyperparameter(Hyperparameter):
 
     """
 
-    depends_on: Optional[Tuple[str, Container[Any]]] = None
+    depends_on: Optional[tuple[str, Container[Any]]] = None
     """Other hyperparameter on which this ones depends on.
 
     If None: this hyperparameter is always needed.
@@ -877,8 +873,8 @@ class ListHyperparameter(Hyperparameter):
         length_high: int,
         length_low: int = 0,
         numbering_start: int = 0,
-        default: List[Any] = None,
-        depends_on: Optional[Tuple[str, Container[Any]]] = None,
+        default: list[Any] = None,
+        depends_on: Optional[tuple[str, Container[Any]]] = None,
         name_in_kwargs: Optional[str] = None,
     ):
         super().__init__(
@@ -900,7 +896,7 @@ class ListHyperparameter(Hyperparameter):
         numbering_start: Optional[int] = None,
         prefix: str = "",
         **kwargs: Any,
-    ) -> List[Any]:
+    ) -> list[Any]:
         """Suggest hyperparameter value for an Optuna trial.
 
         Args:
@@ -970,8 +966,8 @@ class BaseListWithoutReplacementHyperparameter(ListHyperparameter, ABC):
         length_high: Optional[int] = None,
         length_low: int = 0,
         numbering_start: int = 0,
-        default: List[Any] = None,
-        depends_on: Optional[Tuple[str, Container[Any]]] = None,
+        default: list[Any] = None,
+        depends_on: Optional[tuple[str, Container[Any]]] = None,
         name_in_kwargs: Optional[str] = None,
     ):
         if length_high is None:
@@ -995,7 +991,7 @@ class BaseListWithoutReplacementHyperparameter(ListHyperparameter, ABC):
         numbering_start: Optional[int] = None,
         prefix: str = "",
         **kwargs: Any,
-    ) -> List[Any]:
+    ) -> list[Any]:
         """Suggest hyperparameter value for an Optuna trial.
 
         Args:
@@ -1032,7 +1028,7 @@ class BaseListWithoutReplacementHyperparameter(ListHyperparameter, ABC):
         return list_values
 
     @abstractmethod
-    def has_duplicates(self, list_choices: List[Any]) -> True:
+    def has_duplicates(self, list_choices: list[Any]) -> True:
         """Check if the list contains duplicates
 
         Args:
@@ -1065,7 +1061,7 @@ class CategoricalListWithoutReplacementHyperparameter(
     hyperparameter_template: CategoricalHyperparameter
     """Hyperparameter template to fill the list."""
 
-    def has_duplicates(self, list_choices: List[Any]) -> True:
+    def has_duplicates(self, list_choices: list[Any]) -> True:
         """Check if the list contains duplicates
 
         Args:
@@ -1097,7 +1093,7 @@ class SubBrickListWithoutReplacementHyperparameter(
     hyperparameter_template: SubBrickHyperparameter
     """Hyperparameter template to fill the list."""
 
-    def has_duplicates(self, list_choices: List[Any]) -> True:
+    def has_duplicates(self, list_choices: list[Any]) -> True:
         """Check if the list contains duplicates
 
         Args:

--- a/discrete_optimization/generic_tools/hyperparameters/hyperparametrizable.py
+++ b/discrete_optimization/generic_tools/hyperparameters/hyperparametrizable.py
@@ -5,7 +5,8 @@
 from __future__ import annotations  # see annotations as str
 
 from collections import ChainMap, defaultdict
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Set
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any, Optional
 
 import networkx as nx
 
@@ -31,7 +32,7 @@ class Hyperparametrizable:
 
     """
 
-    hyperparameters: List[Hyperparameter] = []
+    hyperparameters: list[Hyperparameter] = []
     """Hyperparameters available for this solver.
 
     These hyperparameters are to be feed to **kwargs found in
@@ -42,12 +43,12 @@ class Hyperparametrizable:
     """
 
     @classmethod
-    def get_hyperparameters_names(cls) -> List[str]:
+    def get_hyperparameters_names(cls) -> list[str]:
         """List of hyperparameters names."""
         return [h.name for h in cls.hyperparameters]
 
     @classmethod
-    def get_hyperparameters_by_name(cls) -> Dict[str, Hyperparameter]:
+    def get_hyperparameters_by_name(cls) -> dict[str, Hyperparameter]:
         """Mapping from name to corresponding hyperparameter."""
         return {h.name: h for h in cls.hyperparameters}
 
@@ -58,8 +59,8 @@ class Hyperparametrizable:
 
     @classmethod
     def copy_and_update_hyperparameters(
-        cls, names: Optional[List[str]] = None, **kwargs_by_name: Dict[str, Any]
-    ) -> List[Hyperparameter]:
+        cls, names: Optional[list[str]] = None, **kwargs_by_name: dict[str, Any]
+    ) -> list[Hyperparameter]:
         """Copy hyperparameters definition of this class and update them with specified kwargs.
 
         This is useful to define hyperparameters for a child class
@@ -85,8 +86,8 @@ class Hyperparametrizable:
 
     @classmethod
     def get_default_hyperparameters(
-        cls, names: Optional[List[str]] = None
-    ) -> Dict[str, Any]:
+        cls, names: Optional[list[str]] = None
+    ) -> dict[str, Any]:
         """Get hyperparameters default values.
 
         Args:
@@ -109,7 +110,7 @@ class Hyperparametrizable:
 
     @classmethod
     def complete_with_default_hyperparameters(
-        cls, kwargs: Dict[str, Any], names: Optional[List[str]] = None
+        cls, kwargs: dict[str, Any], names: Optional[list[str]] = None
     ):
         """Add missing hyperparameters to kwargs by using default values
 
@@ -165,11 +166,11 @@ class Hyperparametrizable:
     def suggest_hyperparameters_with_optuna(
         cls,
         trial: optuna.trial.Trial,
-        names: Optional[List[str]] = None,
-        kwargs_by_name: Optional[Dict[str, Dict[str, Any]]] = None,
-        fixed_hyperparameters: Optional[Dict[str, Any]] = None,
+        names: Optional[list[str]] = None,
+        kwargs_by_name: Optional[dict[str, dict[str, Any]]] = None,
+        fixed_hyperparameters: Optional[dict[str, Any]] = None,
         prefix: str = "",
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Suggest hyperparameters values during an Optuna trial.
 
         Args:
@@ -212,7 +213,7 @@ class Hyperparametrizable:
         suggested_and_fixed_hyperparameters = ChainMap(
             suggested_hyperparameters, fixed_hyperparameters
         )
-        skipped_hyperparameters: Set[str] = set()
+        skipped_hyperparameters: set[str] = set()
 
         for name in cls._sort_hyperparameters_by_dependency():
             hyperparameter = name2hyperparameter[name]

--- a/discrete_optimization/generic_tools/lexico_tools.py
+++ b/discrete_optimization/generic_tools/lexico_tools.py
@@ -3,7 +3,8 @@
 #  LICENSE file in the root directory of this source tree.
 """Tools for lexicographic optimization."""
 import logging
-from typing import Any, Iterable, List, Optional, Protocol
+from collections.abc import Iterable
+from typing import Any, Optional
 
 from discrete_optimization.generic_tools.callbacks.callback import (
     Callback,
@@ -79,7 +80,7 @@ class LexicoSolver(SolverDO):
 
     def solve(
         self,
-        callbacks: Optional[List[Callback]] = None,
+        callbacks: Optional[list[Callback]] = None,
         objectives: Optional[Iterable[str]] = None,
         **kwargs: Any,
     ) -> ResultStorage:

--- a/discrete_optimization/generic_tools/lns_cp.py
+++ b/discrete_optimization/generic_tools/lns_cp.py
@@ -6,7 +6,8 @@ import logging
 import random
 import sys
 from abc import abstractmethod
-from typing import Any, Dict, Iterable, List, Optional
+from collections.abc import Iterable
+from typing import Any, Optional
 
 import numpy as np
 from minizinc import Instance
@@ -34,12 +35,6 @@ from discrete_optimization.generic_tools.result_storage.result_storage import (
     ResultStorage,
     fitness_class,
 )
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict  # pylint: disable=no-name-in-module
-else:
-    from typing_extensions import TypedDict
-
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +74,7 @@ class BaseLNS_CP(BaseLNS):
         nb_iteration_no_improvement: Optional[int] = None,
         skip_initial_solution_provider: bool = False,
         stop_first_iteration_if_optimal: bool = True,
-        callbacks: Optional[List[Callback]] = None,
+        callbacks: Optional[list[Callback]] = None,
         **kwargs: Any,
     ) -> ResultStorage:
         """Solve the problem with an LNS loop

--- a/discrete_optimization/generic_tools/lns_mip.py
+++ b/discrete_optimization/generic_tools/lns_mip.py
@@ -3,7 +3,8 @@
 #  LICENSE file in the root directory of this source tree.
 
 import logging
-from typing import Any, Iterable, List, Optional
+from collections.abc import Iterable
+from typing import Any, Optional
 
 from discrete_optimization.generic_tools.callbacks.callback import Callback
 from discrete_optimization.generic_tools.do_problem import (
@@ -96,7 +97,7 @@ class LNS_MILP(BaseLNS):
         nb_iteration_no_improvement: Optional[int] = None,
         skip_initial_solution_provider: bool = False,
         stop_first_iteration_if_optimal: bool = True,
-        callbacks: Optional[List[Callback]] = None,
+        callbacks: Optional[list[Callback]] = None,
         **kwargs: Any,
     ) -> ResultStorage:
         """Solve the problem with an LNS loop

--- a/discrete_optimization/generic_tools/lns_tools.py
+++ b/discrete_optimization/generic_tools/lns_tools.py
@@ -5,7 +5,8 @@ import contextlib
 import logging
 import random
 from abc import abstractmethod
-from typing import Any, Dict, Iterable, List, Optional, TypedDict
+from collections.abc import Iterable
+from typing import Any, Optional, TypedDict
 
 import numpy as np
 
@@ -284,7 +285,7 @@ class BaseLNS(SolverDO, WarmstartMixin):
         nb_iteration_no_improvement: Optional[int] = None,
         skip_initial_solution_provider: bool = False,
         stop_first_iteration_if_optimal: bool = True,
-        callbacks: Optional[List[Callback]] = None,
+        callbacks: Optional[list[Callback]] = None,
         **kwargs: Any,
     ) -> ResultStorage:
         """Solve the problem with an LNS loop
@@ -502,10 +503,10 @@ class ConstraintHandlerMix(ConstraintHandler):
     def __init__(
         self,
         problem: Problem,
-        list_constraints_handler: List[ConstraintHandler],
-        list_proba: List[float],
+        list_constraints_handler: list[ConstraintHandler],
+        list_proba: list[float],
         update_proba: bool = True,
-        tag_constraint_handler: Optional[List[str]] = None,
+        tag_constraint_handler: Optional[list[str]] = None,
         sequential: bool = False,
     ):
         self.problem = problem
@@ -521,7 +522,7 @@ class ConstraintHandlerMix(ConstraintHandler):
         self.list_proba = self.list_proba / np.sum(self.list_proba)
         self.index_np = np.array(range(len(self.list_proba)), dtype=np.int_)
         self.current_iteration = 0
-        self.status: Dict[int, ConstraintStatus] = {
+        self.status: dict[int, ConstraintStatus] = {
             i: {
                 "nb_usage": 0,
                 "nb_improvement": 0,

--- a/discrete_optimization/generic_tools/lp_tools.py
+++ b/discrete_optimization/generic_tools/lp_tools.py
@@ -4,8 +4,9 @@
 
 import logging
 from abc import abstractmethod
+from collections.abc import Callable
 from enum import Enum
-from typing import Any, Callable, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 import mip
 
@@ -101,7 +102,7 @@ class MilpSolver(SolverDO):
             n_solutions = self.nb_solutions
         else:
             n_solutions = 1
-        list_solution_fits: List[Tuple[Solution, Union[float, TupleFitness]]] = []
+        list_solution_fits: list[tuple[Solution, Union[float, TupleFitness]]] = []
         for i in range(n_solutions):
             solution = self.retrieve_ith_solution(i=i)
             fit = self.aggreg_from_sol(solution)
@@ -157,7 +158,7 @@ class MilpSolver(SolverDO):
     @abstractmethod
     def solve(
         self,
-        callbacks: Optional[List[Callback]] = None,
+        callbacks: Optional[list[Callback]] = None,
         parameters_milp: Optional[ParametersMilp] = None,
         **kwargs: Any,
     ) -> ResultStorage:
@@ -290,7 +291,7 @@ class GurobiMilpSolver(MilpSolver):
 
     def solve(
         self,
-        callbacks: Optional[List[Callback]] = None,
+        callbacks: Optional[list[Callback]] = None,
         parameters_milp: Optional[ParametersMilp] = None,
         time_limit: Optional[float] = 30.0,
         **kwargs: Any,
@@ -447,7 +448,7 @@ class GurobiCallback:
 
 class CplexMilpSolver(MilpSolver):
     model: Optional["docplex.mp.model.Model"]
-    results_solve: Optional[List["SolveSolution"]]
+    results_solve: Optional[list["SolveSolution"]]
 
     def solve(
         self,

--- a/discrete_optimization/generic_tools/ls/hill_climber.py
+++ b/discrete_optimization/generic_tools/ls/hill_climber.py
@@ -3,7 +3,7 @@
 #  LICENSE file in the root directory of this source tree.
 
 import logging
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 from discrete_optimization.generic_tools.callbacks.callback import (
     Callback,
@@ -65,7 +65,7 @@ class HillClimber(SolverDO, WarmstartMixin):
         self,
         nb_iteration_max: int,
         initial_variable: Optional[Solution] = None,
-        callbacks: Optional[List[Callback]] = None,
+        callbacks: Optional[list[Callback]] = None,
         **kwargs: Any,
     ) -> ResultStorage:
         callbacks_list = CallbackList(callbacks=callbacks)
@@ -174,7 +174,7 @@ class HillClimberPareto(HillClimber):
         nb_iteration_max: int,
         initial_variable: Optional[Solution] = None,
         update_iteration_pareto: int = 1000,
-        callbacks: Optional[List[Callback]] = None,
+        callbacks: Optional[list[Callback]] = None,
         **kwargs: Any,
     ) -> ParetoFront:
         callbacks_list = CallbackList(callbacks=callbacks)

--- a/discrete_optimization/generic_tools/ls/local_search.py
+++ b/discrete_optimization/generic_tools/ls/local_search.py
@@ -3,7 +3,6 @@
 #  LICENSE file in the root directory of this source tree.
 
 from enum import Enum
-from typing import Tuple
 
 from discrete_optimization.generic_tools.do_problem import Solution
 from discrete_optimization.generic_tools.result_storage.result_storage import (
@@ -48,7 +47,7 @@ class RestartHandler:
 
     def restart(
         self, cur_solution: Solution, cur_objective: fitness_class
-    ) -> Tuple[Solution, fitness_class]:
+    ) -> tuple[Solution, fitness_class]:
         return cur_solution, cur_objective
 
 
@@ -62,7 +61,7 @@ class RestartHandlerLimit(RestartHandler):
 
     def restart(
         self, cur_solution: Solution, cur_objective: fitness_class
-    ) -> Tuple[Solution, fitness_class]:
+    ) -> tuple[Solution, fitness_class]:
         if (
             self.nb_iteration_no_global_improve > self.nb_iteration_no_improvement
             or self.nb_iteration_no_local_improve > self.nb_iteration_no_improvement

--- a/discrete_optimization/generic_tools/ls/simulated_annealing.py
+++ b/discrete_optimization/generic_tools/ls/simulated_annealing.py
@@ -5,7 +5,8 @@
 import logging
 import random
 from abc import abstractmethod
-from typing import Any, Callable, Dict, List, Optional
+from collections.abc import Callable
+from typing import Any, Optional
 
 import numpy as np
 
@@ -45,7 +46,7 @@ class TemperatureScheduling:
 
 class SimulatedAnnealing(SolverDO, WarmstartMixin):
     aggreg_from_sol: Callable[[Solution], float]
-    aggreg_from_dict: Callable[[Dict[str, float]], float]
+    aggreg_from_dict: Callable[[dict[str, float]], float]
 
     initial_solution: Optional[Solution] = None
     """Initial solution used for warm start."""
@@ -90,7 +91,7 @@ class SimulatedAnnealing(SolverDO, WarmstartMixin):
         self,
         nb_iteration_max: int,
         initial_variable: Optional[Solution] = None,
-        callbacks: Optional[List[Callback]] = None,
+        callbacks: Optional[list[Callback]] = None,
         **kwargs: Any,
     ) -> ResultStorage:
         callbacks_list = CallbackList(callbacks=callbacks)

--- a/discrete_optimization/generic_tools/mip/pymip_tools.py
+++ b/discrete_optimization/generic_tools/mip/pymip_tools.py
@@ -3,7 +3,7 @@
 #  LICENSE file in the root directory of this source tree.
 
 import gc
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 import mip
 from mip import IncumbentUpdater, Model, Var
@@ -20,20 +20,20 @@ class IncumbentStoreSolution(IncumbentUpdater):
     # Store intermediate solutions for further use.
     def __init__(self, model: Model):
         super().__init__(model=model)
-        self._solution_store: List[Dict[str, Any]] = []
+        self._solution_store: list[dict[str, Any]] = []
 
     def nb_solutions(self) -> int:
         return len(self._solution_store)
 
-    def get_solutions(self) -> List[Dict[str, Any]]:
+    def get_solutions(self) -> list[dict[str, Any]]:
         return self._solution_store
 
     def update_incumbent(
         self,
         objective_value: float,
         best_bound: float,
-        solution: List[Tuple[Var, float]],
-    ) -> List[Tuple[Var, float]]:
+        solution: list[tuple[Var, float]],
+    ) -> list[tuple[Var, float]]:
         dict_solution = {
             "obj": objective_value,
             "best_bound": best_bound,
@@ -57,7 +57,7 @@ class MyModelMilp(Model):
 
     def remove(
         self: "MyModelMilp",
-        objects: Union[mip.Var, mip.Constr, List[Union["mip.Var", "mip.Constr"]]],
+        objects: Union[mip.Var, mip.Constr, list[Union["mip.Var", "mip.Constr"]]],
     ) -> None:
         super().remove(objects)
         self.update()

--- a/discrete_optimization/generic_tools/mutations/mixed_mutation.py
+++ b/discrete_optimization/generic_tools/mutations/mixed_mutation.py
@@ -2,7 +2,7 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Dict, List, Tuple, Union
+from typing import Union
 
 import numpy as np
 
@@ -13,8 +13,8 @@ from discrete_optimization.generic_tools.do_problem import Solution
 class BasicPortfolioMutation(Mutation):
     def __init__(
         self,
-        list_mutation: List[Mutation],
-        weight_mutation: Union[List[float], np.ndarray],
+        list_mutation: list[Mutation],
+        weight_mutation: Union[list[float], np.ndarray],
     ):
         self.list_mutation = list_mutation
         self.weight_mutation = weight_mutation
@@ -23,13 +23,13 @@ class BasicPortfolioMutation(Mutation):
         self.weight_mutation = self.weight_mutation / np.sum(self.weight_mutation)
         self.index_np = np.array(range(len(self.list_mutation)), dtype=np.int_)
 
-    def mutate(self, solution: Solution) -> Tuple[Solution, LocalMove]:
+    def mutate(self, solution: Solution) -> tuple[Solution, LocalMove]:
         choice = np.random.choice(self.index_np, size=1, p=self.weight_mutation)[0]
         return self.list_mutation[choice].mutate(solution)
 
     def mutate_and_compute_obj(
         self, solution: Solution
-    ) -> Tuple[Solution, LocalMove, Dict[str, float]]:
+    ) -> tuple[Solution, LocalMove, dict[str, float]]:
         choice = np.random.choice(self.index_np, size=1, p=self.weight_mutation)[0]
         return self.list_mutation[choice].mutate_and_compute_obj(solution)
 
@@ -37,8 +37,8 @@ class BasicPortfolioMutation(Mutation):
 class BasicPortfolioMutationTrack(Mutation):
     def __init__(
         self,
-        list_mutation: List[Mutation],
-        weight_mutation: Union[List[float], np.ndarray],
+        list_mutation: list[Mutation],
+        weight_mutation: Union[list[float], np.ndarray],
     ):
         self.list_mutation = list_mutation
         self.weight_mutation = weight_mutation
@@ -47,12 +47,12 @@ class BasicPortfolioMutationTrack(Mutation):
         self.weight_mutation = self.weight_mutation / np.sum(self.weight_mutation)
         self.index_np = np.array(range(len(self.list_mutation)), dtype=np.int_)
 
-    def mutate(self, solution: Solution) -> Tuple[Solution, LocalMove]:
+    def mutate(self, solution: Solution) -> tuple[Solution, LocalMove]:
         choice = np.random.choice(self.index_np, size=1, p=self.weight_mutation)[0]
         return self.list_mutation[choice].mutate(solution)
 
     def mutate_and_compute_obj(
         self, solution: Solution
-    ) -> Tuple[Solution, LocalMove, Dict[str, float]]:
+    ) -> tuple[Solution, LocalMove, dict[str, float]]:
         choice = np.random.choice(self.index_np, size=1, p=self.weight_mutation)[0]
         return self.list_mutation[choice].mutate_and_compute_obj(solution)

--- a/discrete_optimization/generic_tools/mutations/mutation_bool.py
+++ b/discrete_optimization/generic_tools/mutations/mutation_bool.py
@@ -2,7 +2,8 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, Iterable, Optional, Tuple
+from collections.abc import Iterable
+from typing import Any, Optional
 
 import numpy as np
 
@@ -54,14 +55,14 @@ class MutationBitFlip(Mutation):
             self.attribute = attribute
         self.length = register.dict_attribute_to_type[self.attribute]["n"]
 
-    def mutate(self, solution: Solution) -> Tuple[Solution, LocalMove]:
+    def mutate(self, solution: Solution) -> tuple[Solution, LocalMove]:
         indexes = np.where(np.random.random(self.length) <= self.probability_flip)
         move = BitFlipMove(self.attribute, indexes[0])
         return move.apply_local_move(solution), move
 
     def mutate_and_compute_obj(
         self, solution: Solution
-    ) -> Tuple[Solution, LocalMove, Dict[str, float]]:
+    ) -> tuple[Solution, LocalMove, dict[str, float]]:
         s, move = self.mutate(solution)
         f = self.problem.evaluate(s)
         return s, move, f

--- a/discrete_optimization/generic_tools/mutations/mutation_catalog.py
+++ b/discrete_optimization/generic_tools/mutations/mutation_catalog.py
@@ -3,7 +3,7 @@
 #  LICENSE file in the root directory of this source tree.
 
 import logging
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import Any, Optional
 
 from discrete_optimization.generic_tools.do_mutation import Mutation
 from discrete_optimization.generic_tools.do_problem import (
@@ -37,8 +37,8 @@ from discrete_optimization.tsp.mutation.mutation_tsp import (
 
 logger = logging.getLogger(__name__)
 
-dictionnary_mutation: Dict[
-    TypeAttribute, Dict[str, Tuple[Type[Mutation], Dict[str, Any]]]
+dictionnary_mutation: dict[
+    TypeAttribute, dict[str, tuple[type[Mutation], dict[str, Any]]]
 ] = {
     TypeAttribute.PERMUTATION: {
         "total_shuffle": (PermutationShuffleMutation, {}),
@@ -95,16 +95,16 @@ dictionnary_mutation: Dict[
 
 def get_available_mutations(
     problem: Problem, solution: Optional[Solution] = None
-) -> Tuple[
-    Dict[TypeAttribute, Dict[str, Tuple[Type[Mutation], Dict[str, Any]]]],
-    List[Tuple[Type[Mutation], Dict[str, Any]]],
+) -> tuple[
+    dict[TypeAttribute, dict[str, tuple[type[Mutation], dict[str, Any]]]],
+    list[tuple[type[Mutation], dict[str, Any]]],
 ]:
     register = problem.get_attribute_register()
     present_types = set(register.get_types())
-    mutations: Dict[
-        TypeAttribute, Dict[str, Tuple[Type[Mutation], Dict[str, Any]]]
+    mutations: dict[
+        TypeAttribute, dict[str, tuple[type[Mutation], dict[str, Any]]]
     ] = {}
-    mutations_list: List[Tuple[Type[Mutation], Dict[str, Any]]] = []
+    mutations_list: list[tuple[type[Mutation], dict[str, Any]]] = []
     nb_mutations = 0
     for pr_type in present_types:
         if pr_type in dictionnary_mutation:

--- a/discrete_optimization/generic_tools/mutations/mutation_integer.py
+++ b/discrete_optimization/generic_tools/mutations/mutation_integer.py
@@ -3,7 +3,7 @@
 #  LICENSE file in the root directory of this source tree.
 
 import random
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from discrete_optimization.generic_tools.do_mutation import (
     LocalMove,
@@ -39,7 +39,7 @@ class MutationIntegerSpecificArity(Mutation):
         self,
         problem: Problem,
         attribute: Optional[str] = None,
-        arities: Optional[List[int]] = None,
+        arities: Optional[list[int]] = None,
         probability_flip: float = 0.1,
         min_value: int = 1,
     ):
@@ -66,7 +66,7 @@ class MutationIntegerSpecificArity(Mutation):
         ]
         self.size = len(self.range_arities)
 
-    def mutate(self, solution: Solution) -> Tuple[Solution, LocalMove]:
+    def mutate(self, solution: Solution) -> tuple[Solution, LocalMove]:
         s2 = solution.copy()
         vector = getattr(s2, self.attribute)
         for k in range(self.size):
@@ -78,7 +78,7 @@ class MutationIntegerSpecificArity(Mutation):
 
     def mutate_and_compute_obj(
         self, solution: Solution
-    ) -> Tuple[Solution, LocalMove, Dict[str, float]]:
+    ) -> tuple[Solution, LocalMove, dict[str, float]]:
         s, m = self.mutate(solution)
         obj = self.problem.evaluate(s)
         return s, m, obj

--- a/discrete_optimization/generic_tools/mutations/permutation_mutations.py
+++ b/discrete_optimization/generic_tools/mutations/permutation_mutations.py
@@ -4,7 +4,7 @@
 
 import random
 from copy import deepcopy
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 import numpy as np
 
@@ -23,8 +23,8 @@ class ShuffleMove(LocalMove):
     def __init__(
         self,
         attribute: str,
-        new_permutation: Union[List[int], np.ndarray],
-        prev_permutation: Union[List[int], np.ndarray],
+        new_permutation: Union[list[int], np.ndarray],
+        prev_permutation: Union[list[int], np.ndarray],
     ):
         self.attribute = attribute
         self.permutation = new_permutation
@@ -58,7 +58,7 @@ class PermutationShuffleMutation(Mutation):
         self.range_shuffle = register.dict_attribute_to_type[self.attribute]["range"]
         self.range_int = list(range(len(self.range_shuffle)))
 
-    def mutate(self, solution: Solution) -> Tuple[Solution, LocalMove]:
+    def mutate(self, solution: Solution) -> tuple[Solution, LocalMove]:
         previous = list(getattr(solution, self.attribute))
         random.shuffle(self.range_int)
         new = [previous[i] for i in self.range_int]
@@ -71,7 +71,7 @@ class PermutationShuffleMutation(Mutation):
 
     def mutate_and_compute_obj(
         self, solution: Solution
-    ) -> Tuple[Solution, LocalMove, Dict[str, float]]:
+    ) -> tuple[Solution, LocalMove, dict[str, float]]:
         sol, move = self.mutate(solution)
         obj = self.problem.evaluate(sol)
         return sol, move, obj
@@ -107,7 +107,7 @@ class PermutationPartialShuffleMutation(Mutation):
         self.range_int = list(range(self.n_to_move))
         self.range_int_total = list(range(len(self.range_shuffle)))
 
-    def mutate(self, solution: Solution) -> Tuple[Solution, LocalMove]:
+    def mutate(self, solution: Solution) -> tuple[Solution, LocalMove]:
         previous = deepcopy(getattr(solution, self.attribute))
         random.shuffle(self.range_int_total)
         int_to_move = self.range_int_total[: self.n_to_move]
@@ -121,14 +121,14 @@ class PermutationPartialShuffleMutation(Mutation):
 
     def mutate_and_compute_obj(
         self, solution: Solution
-    ) -> Tuple[Solution, LocalMove, Dict[str, float]]:
+    ) -> tuple[Solution, LocalMove, dict[str, float]]:
         sol, move = self.mutate(solution)
         obj = self.problem.evaluate(sol)
         return sol, move, obj
 
 
 class SwapsLocalMove(LocalMove):
-    def __init__(self, attribute: str, list_index_swap: List[Tuple[int, int]]):
+    def __init__(self, attribute: str, list_index_swap: list[tuple[int, int]]):
         self.attribute = attribute
         self.list_index_swap = list_index_swap
 
@@ -173,7 +173,7 @@ class PermutationSwap(Mutation):
             self.attribute = attribute
         self.length = len(register.dict_attribute_to_type[self.attribute]["range"])
 
-    def mutate(self, solution: Solution) -> Tuple[Solution, LocalMove]:
+    def mutate(self, solution: Solution) -> tuple[Solution, LocalMove]:
         swaps = np.random.randint(low=0, high=self.length - 1, size=(self.nb_swap, 2))
         move = SwapsLocalMove(
             self.attribute, [(swaps[i, 0], swaps[i, 1]) for i in range(self.nb_swap)]
@@ -183,14 +183,14 @@ class PermutationSwap(Mutation):
 
     def mutate_and_compute_obj(
         self, solution: Solution
-    ) -> Tuple[Solution, LocalMove, Dict[str, float]]:
+    ) -> tuple[Solution, LocalMove, dict[str, float]]:
         sol, move = self.mutate(solution)
         obj = self.problem.evaluate(sol)
         return sol, move, obj
 
 
 class TwoOptMove(LocalMove):
-    def __init__(self, attribute: str, index_2opt: List[Tuple[int, int]]):
+    def __init__(self, attribute: str, index_2opt: list[tuple[int, int]]):
         self.attribute = attribute
         self.index_2opt = index_2opt
 
@@ -227,7 +227,7 @@ class TwoOptMutation(Mutation):
             self.attribute = attribute
         self.length = len(register.dict_attribute_to_type[self.attribute]["range"])
 
-    def mutate(self, solution: Solution) -> Tuple[Solution, LocalMove]:
+    def mutate(self, solution: Solution) -> tuple[Solution, LocalMove]:
         i = random.randint(0, self.length - 2)
         j = random.randint(i + 1, self.length - 1)
         two_opt_move = TwoOptMove(self.attribute, [(i, j)])
@@ -236,7 +236,7 @@ class TwoOptMutation(Mutation):
 
     def mutate_and_compute_obj(
         self, solution: Solution
-    ) -> Tuple[Solution, LocalMove, Dict[str, float]]:
+    ) -> tuple[Solution, LocalMove, dict[str, float]]:
         sol, move = self.mutate(solution)
         obj = self.problem.evaluate(sol)
         return sol, move, obj

--- a/discrete_optimization/generic_tools/optuna/timed_percentile_pruner.py
+++ b/discrete_optimization/generic_tools/optuna/timed_percentile_pruner.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import functools
 import logging
 import math
-from typing import KeysView, List
+from collections.abc import KeysView
 
 import numpy as np
 
@@ -49,7 +49,7 @@ else:
             return np.nan
 
     def _get_percentile_intermediate_result_over_trials(
-        completed_trials: List["optuna.trial.FrozenTrial"],
+        completed_trials: list["optuna.trial.FrozenTrial"],
         direction: StudyDirection,
         step: int,
         percentile: float,

--- a/discrete_optimization/generic_tools/optuna/utils.py
+++ b/discrete_optimization/generic_tools/optuna/utils.py
@@ -9,7 +9,7 @@ import logging
 import math
 import time
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Optional
 
 import numpy as np
 
@@ -61,13 +61,13 @@ def drop_already_tried_hyperparameters(trial: Trial) -> None:
 
 def generic_optuna_experiment_monoproblem(
     problem: Problem,
-    solvers_to_test: List[Type[SolverDO]],
-    kwargs_fixed_by_solver: Optional[Dict[Type[SolverDO], Dict[str, Any]]] = None,
+    solvers_to_test: list[type[SolverDO]],
+    kwargs_fixed_by_solver: Optional[dict[type[SolverDO], dict[str, Any]]] = None,
     suggest_optuna_kwargs_by_name_by_solver: Optional[
-        Dict[Type[SolverDO], Dict[str, Dict[str, Any]]]
+        dict[type[SolverDO], dict[str, dict[str, Any]]]
     ] = None,
     additional_hyperparameters_by_solver: Optional[
-        Dict[Type[SolverDO], List[Hyperparameter]]
+        dict[type[SolverDO], list[Hyperparameter]]
     ] = None,
     n_trials: int = 150,
     check_satisfy: bool = True,
@@ -80,7 +80,7 @@ def generic_optuna_experiment_monoproblem(
     pruner: Optional[BasePruner] = None,
     seed: Optional[int] = None,
     min_time_per_solver: int = 5,
-    callbacks: Optional[List[Callback]] = None,
+    callbacks: Optional[list[Callback]] = None,
 ) -> optuna.Study:
     """Create and run an optuna study to tune solvers hyperparameters on a given problem.
 
@@ -170,7 +170,7 @@ def generic_optuna_experiment_monoproblem(
 
     # we need to map the classes to a unique string, to be seen as a categorical hyperparameter by optuna
     # by default, we use the class name, but if there are identical names, f"{cls.__module__}.{cls.__name__}" could be used.
-    solvers_by_name: Dict[str, Type[SolverDO]] = {
+    solvers_by_name: dict[str, type[SolverDO]] = {
         cls.__name__: cls for cls in solvers_to_test
     }
 
@@ -300,14 +300,14 @@ def generic_optuna_experiment_monoproblem(
 
 
 def generic_optuna_experiment_multiproblem(
-    problems: List[Problem],
-    solvers_to_test: List[Type[SolverDO]],
-    kwargs_fixed_by_solver: Optional[Dict[Type[SolverDO], Dict[str, Any]]] = None,
+    problems: list[Problem],
+    solvers_to_test: list[type[SolverDO]],
+    kwargs_fixed_by_solver: Optional[dict[type[SolverDO], dict[str, Any]]] = None,
     suggest_optuna_kwargs_by_name_by_solver: Optional[
-        Dict[Type[SolverDO], Dict[str, Dict[str, Any]]]
+        dict[type[SolverDO], dict[str, dict[str, Any]]]
     ] = None,
     additional_hyperparameters_by_solver: Optional[
-        Dict[Type[SolverDO], List[Hyperparameter]]
+        dict[type[SolverDO], list[Hyperparameter]]
     ] = None,
     n_trials: int = 150,
     check_satisfy: bool = True,
@@ -321,7 +321,7 @@ def generic_optuna_experiment_multiproblem(
     prop_startup_instances: float = 0.2,
     randomize_instances: bool = True,
     report_cumulated_fitness: bool = False,
-    callbacks: Optional[List[Callback]] = None,
+    callbacks: Optional[list[Callback]] = None,
 ) -> optuna.Study:
     """Create and run an optuna study to tune solvers hyperparameters on several instances of a problem.
 
@@ -405,7 +405,7 @@ def generic_optuna_experiment_multiproblem(
 
     # we need to map the classes to a unique string, to be seen as a categorical hyperparameter by optuna
     # by default, we use the class name, but if there are identical names, f"{cls.__module__}.{cls.__name__}" could be used.
-    solvers_by_name: Dict[str, Type[SolverDO]] = {
+    solvers_by_name: dict[str, type[SolverDO]] = {
         cls.__name__: cls for cls in solvers_to_test
     }
 

--- a/discrete_optimization/generic_tools/ortools_cpsat_tools.py
+++ b/discrete_optimization/generic_tools/ortools_cpsat_tools.py
@@ -3,7 +3,8 @@
 #  LICENSE file in the root directory of this source tree.
 import logging
 from abc import abstractmethod
-from typing import Any, Dict, Iterable, List, Optional
+from collections.abc import Iterable
+from typing import Any, Optional
 
 from ortools.sat.python.cp_model import (
     FEASIBLE,
@@ -59,10 +60,10 @@ class OrtoolsCPSatSolver(CPSolver):
 
     def solve(
         self,
-        callbacks: Optional[List[Callback]] = None,
+        callbacks: Optional[list[Callback]] = None,
         parameters_cp: Optional[ParametersCP] = None,
         time_limit: Optional[float] = 100.0,
-        ortools_cpsat_solver_kwargs: Optional[Dict[str, Any]] = None,
+        ortools_cpsat_solver_kwargs: Optional[dict[str, Any]] = None,
         **kwargs: Any,
     ) -> ResultStorage:
         """Solve the problem with a CPSat solver drom ortools library.

--- a/discrete_optimization/generic_tools/qiskit_tools.py
+++ b/discrete_optimization/generic_tools/qiskit_tools.py
@@ -1,6 +1,7 @@
 import logging
 from abc import abstractmethod
-from typing import Any, Callable, Dict, List, Optional, Union
+from collections.abc import Callable
+from typing import Any, Optional, Union
 
 import numpy as np
 
@@ -84,7 +85,7 @@ else:
     qiskit_available = True
 
 
-def get_result_from_dict_result(dict_result: Dict[(str, int)]) -> np.ndarray:
+def get_result_from_dict_result(dict_result: dict[(str, int)]) -> np.ndarray:
     """
     @param dict_result: dictionnary where keys are qubit's value and values are the number of time where this qubit's value have been chosen
     @return: the qubit's value the must often chose
@@ -283,7 +284,7 @@ class QiskitQAOASolver(QiskitSolver, Hyperparametrizable):
 
     def solve(
         self,
-        callbacks: Optional[List[Callback]] = None,
+        callbacks: Optional[list[Callback]] = None,
         backend: Optional = None,
         use_session: Optional[bool] = False,
         **kwargs: Any,
@@ -404,7 +405,7 @@ class QiskitVQESolver(QiskitSolver):
 
     def solve(
         self,
-        callbacks: Optional[List[Callback]] = None,
+        callbacks: Optional[list[Callback]] = None,
         backend: Optional = None,
         use_session: Optional[bool] = False,
         **kwargs: Any,

--- a/discrete_optimization/generic_tools/quantum_solvers.py
+++ b/discrete_optimization/generic_tools/quantum_solvers.py
@@ -4,7 +4,7 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, List, Tuple, Type, Union
+from typing import Any, Union
 
 from discrete_optimization.coloring.solvers.coloring_quantum import (
     QAOAColoringSolver_FeasibleNbColor,
@@ -35,7 +35,7 @@ from discrete_optimization.maximum_independent_set.solvers.mis_quantum import (
 from discrete_optimization.tsp.solver.tsp_quantum import QAOATSPSolver, VQETSPSolver
 from discrete_optimization.tsp.tsp_model import TSPModel2D
 
-solvers_coloring: Dict[str, List[Tuple[Type[QiskitSolver], Dict[str, Any]]]] = {
+solvers_coloring: dict[str, list[tuple[type[QiskitSolver], dict[str, Any]]]] = {
     "qaoa": [
         (
             QAOAColoringSolver_MinimizeNbColor,
@@ -64,7 +64,7 @@ for key in solvers_coloring:
         solvers_map_coloring[solver] = (key, param)
 
 
-solvers_mis: Dict[str, List[Tuple[Type[QiskitSolver], Dict[str, Any]]]] = {
+solvers_mis: dict[str, list[tuple[type[QiskitSolver], dict[str, Any]]]] = {
     "qaoa": [
         (
             QAOAMisSolver,
@@ -84,7 +84,7 @@ for key in solvers_mis:
     for solver, param in solvers_mis[key]:
         solvers_map_mis[solver] = (key, param)
 
-solvers_facility: Dict[str, List[Tuple[Type[QiskitSolver], Dict[str, Any]]]] = {
+solvers_facility: dict[str, list[tuple[type[QiskitSolver], dict[str, Any]]]] = {
     "qaoa": [
         (
             QAOAFacilitySolver,
@@ -105,7 +105,7 @@ for key in solvers_facility:
         solvers_map_facility[solver] = (key, param)
 
 
-solvers_tsp: Dict[str, List[Tuple[Type[QiskitSolver], Dict[str, Any]]]] = {
+solvers_tsp: dict[str, list[tuple[type[QiskitSolver], dict[str, Any]]]] = {
     "qaoa": [
         (
             QAOATSPSolver,
@@ -125,7 +125,7 @@ for key in solvers_mis:
     for solver, param in solvers_tsp[key]:
         solvers_map_mis[solver] = (key, param)
 
-solvers_knapsack: Dict[str, List[Tuple[Type[QiskitSolver], Dict[str, Any]]]] = {
+solvers_knapsack: dict[str, list[tuple[type[QiskitSolver], dict[str, Any]]]] = {
     "qaoa": [
         (
             QAOAKnapsackSolver,
@@ -147,9 +147,9 @@ for key in solvers_mis:
 
 
 def solve(
-    method: Type[QiskitSolver],
+    method: type[QiskitSolver],
     problem: Union[MisProblem, TSPModel2D, KnapsackModel, FacilityProblem2DPoints],
-    **kwargs: Any
+    **kwargs: Any,
 ) -> ResultStorage:
     """Solve a problem instance with a given class of solver.
 
@@ -171,7 +171,7 @@ def solve(
 
 
 def solve_coloring(
-    method: Type[QiskitSolver], problem: ColoringProblem, nb_color, **kwargs: Any
+    method: type[QiskitSolver], problem: ColoringProblem, nb_color, **kwargs: Any
 ) -> ResultStorage:
     """Solve a problem instance with a given class of solver.
 

--- a/discrete_optimization/generic_tools/result_storage/result_storage.py
+++ b/discrete_optimization/generic_tools/result_storage/result_storage.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import random
 from collections.abc import MutableSequence
-from typing import Any, List, Optional, Tuple, Union, cast
+from typing import Any, Optional, Union, cast
 
 import matplotlib.pyplot as plt
 
@@ -33,12 +33,12 @@ class ResultStorage(MutableSequence):
 
     """
 
-    list_solution_fits: List[Tuple[Solution, fitness_class]]
+    list_solution_fits: list[tuple[Solution, fitness_class]]
 
     def __init__(
         self,
         mode_optim: ModeOptim,
-        list_solution_fits: Optional[List[Tuple[Solution, fitness_class]]] = None,
+        list_solution_fits: Optional[list[tuple[Solution, fitness_class]]] = None,
     ):
         if list_solution_fits is None:
             self.list_solution_fits = []
@@ -50,24 +50,24 @@ class ResultStorage(MutableSequence):
     def __add__(self, other: ResultStorage) -> ResultStorage:
         return merge_results_storage(self, other)
 
-    def __getitem__(self, index) -> Tuple[Solution, fitness_class]:
+    def __getitem__(self, index) -> tuple[Solution, fitness_class]:
         return self.list_solution_fits[index]
 
     def __len__(self) -> int:
         return len(self.list_solution_fits)
 
-    def __setitem__(self, index: int, value: Tuple[Solution, fitness_class]):
+    def __setitem__(self, index: int, value: tuple[Solution, fitness_class]):
         self.list_solution_fits[index] = value
 
     def __delitem__(self, index: int) -> None:
         del self.list_solution_fits[index]
 
-    def insert(self, index, value: Tuple[Solution, fitness_class]) -> None:
+    def insert(self, index, value: tuple[Solution, fitness_class]) -> None:
         self.list_solution_fits.insert(index, value)
 
     def get_best_solution_fit(
         self, satisfying: Optional[Problem] = None
-    ) -> Union[Tuple[Solution, fitness_class], Tuple[None, None]]:
+    ) -> Union[tuple[Solution, fitness_class], tuple[None, None]]:
         if len(self.list_solution_fits) == 0:
             return None, None
         if satisfying is None:
@@ -82,7 +82,7 @@ class ResultStorage(MutableSequence):
                     return sol, fit
             return None, None
 
-    def get_last_best_solution(self) -> Tuple[Solution, fitness_class]:
+    def get_last_best_solution(self) -> tuple[Solution, fitness_class]:
         f = max if self.maximize else min
         best = f(self.list_solution_fits, key=lambda x: x[1])[1]
         sol = max(
@@ -94,7 +94,7 @@ class ResultStorage(MutableSequence):
         )
         return self.list_solution_fits[sol]
 
-    def get_random_best_solution(self) -> Tuple[Solution, fitness_class]:
+    def get_random_best_solution(self) -> tuple[Solution, fitness_class]:
         f = max if self.maximize else min
         best = f(self.list_solution_fits, key=lambda x: x[1])[1]
         sol = random.choice(
@@ -106,7 +106,7 @@ class ResultStorage(MutableSequence):
         )
         return self.list_solution_fits[sol]
 
-    def get_random_solution(self) -> Tuple[Solution, fitness_class]:
+    def get_random_solution(self) -> tuple[Solution, fitness_class]:
         s = [
             l
             for l in self.list_solution_fits
@@ -125,7 +125,7 @@ class ResultStorage(MutableSequence):
 
     def get_n_best_solution(
         self, n_solutions: int
-    ) -> List[Tuple[Solution, fitness_class]]:
+    ) -> list[tuple[Solution, fitness_class]]:
         f = max if self.maximize else min
         n = min(n_solutions, len(self.list_solution_fits))
         l = sorted(self.list_solution_fits, key=lambda x: x[1])[:n]
@@ -165,7 +165,7 @@ def merge_results_storage(
 
 
 def from_solutions_to_result_storage(
-    list_solution: List[Solution],
+    list_solution: list[Solution],
     problem: Problem,
     params_objective_function: Optional[ParamsObjectiveFunction] = None,
 ) -> ResultStorage:
@@ -179,7 +179,7 @@ def from_solutions_to_result_storage(
     ) = build_aggreg_function_and_params_objective(
         problem=problem, params_objective_function=params_objective_function
     )
-    list_solution_fit: List[Tuple[Solution, fitness_class]] = []
+    list_solution_fit: list[tuple[Solution, fitness_class]] = []
     for s in list_solution:
         list_solution_fit += [(s, aggreg_from_sol(s))]
     return ResultStorage(mode_optim=mode_optim, list_solution_fits=list_solution_fit)
@@ -205,11 +205,11 @@ def result_storage_to_pareto_front(
 class ParetoFront(ResultStorage):
     def __init__(
         self,
-        list_solution_fits: List[Tuple[Solution, fitness_class]],
+        list_solution_fits: list[tuple[Solution, fitness_class]],
         mode_optim: ModeOptim = ModeOptim.MAXIMIZATION,
     ):
         super().__init__(mode_optim=mode_optim, list_solution_fits=list_solution_fits)
-        self.paretos: List[Tuple[Solution, TupleFitness]] = []
+        self.paretos: list[tuple[Solution, TupleFitness]] = []
 
     def add_point(self, solution: Solution, tuple_fitness: TupleFitness) -> None:
         if self.maximize:
@@ -246,19 +246,19 @@ class ParetoFront(ResultStorage):
                 )
             self.add_point(solution=s, tuple_fitness=t)
 
-    def compute_extreme_points(self) -> List[Tuple[Solution, TupleFitness]]:
+    def compute_extreme_points(self) -> list[tuple[Solution, TupleFitness]]:
         function_used = max if self.maximize else min
         number_fitness = self.list_solution_fits[0][1].size  # type: ignore
-        extreme_points: List[Tuple[Solution, TupleFitness]] = []
+        extreme_points: list[tuple[Solution, TupleFitness]] = []
         for i in range(number_fitness):
-            extr: Tuple[Solution, TupleFitness] = function_used(self.paretos, key=lambda x: x[1].vector_fitness[i])  # type: ignore
+            extr: tuple[Solution, TupleFitness] = function_used(self.paretos, key=lambda x: x[1].vector_fitness[i])  # type: ignore
             extreme_points += [extr]
         return extreme_points
 
 
 def plot_storage_2d(
     result_storage: ResultStorage,
-    name_axis: List[str],
+    name_axis: list[str],
     ax: Any = None,
     color: str = "r",
 ) -> None:
@@ -266,7 +266,7 @@ def plot_storage_2d(
         fig, ax = plt.subplots(1)
     # Specify for mypy that we should be in the multiobjective case
     list_solution_fits = cast(
-        List[Tuple[Solution, TupleFitness]], result_storage.list_solution_fits
+        list[tuple[Solution, TupleFitness]], result_storage.list_solution_fits
     )
     ax.scatter(
         x=[p[1].vector_fitness[0] for p in list_solution_fits],
@@ -278,7 +278,7 @@ def plot_storage_2d(
 
 
 def plot_pareto_2d(
-    pareto_front: ParetoFront, name_axis: List[str], ax: Any = None, color: str = "b"
+    pareto_front: ParetoFront, name_axis: list[str], ax: Any = None, color: str = "b"
 ) -> Any:
     if ax is None:
         fig, ax = plt.subplots(1)

--- a/discrete_optimization/generic_tools/result_storage/resultcomparator.py
+++ b/discrete_optimization/generic_tools/result_storage/resultcomparator.py
@@ -4,7 +4,7 @@
 
 import logging
 import math
-from typing import Dict, List, Optional, Tuple, cast
+from typing import Optional, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -34,18 +34,18 @@ class ResultComparator:
     # If test problem is None, then we use the fitnesses from the ResultStorage
     def __init__(
         self,
-        list_result_storage: List[ResultStorage],
-        result_storage_names: List[str],
-        objectives_str: List[str],
-        objective_weights: List[int],
-        test_problems: Optional[List[Problem]] = None,
+        list_result_storage: list[ResultStorage],
+        result_storage_names: list[str],
+        objectives_str: list[str],
+        objective_weights: list[int],
+        test_problems: Optional[list[Problem]] = None,
     ):
         self.list_result_storage = list_result_storage
         self.result_storage_names = result_storage_names
         self.objectives_str = objectives_str
         self.objective_weights = objective_weights
         self.test_problems = test_problems
-        self.reevaluated_results: Dict[int, Dict[str, List[float]]] = {}
+        self.reevaluated_results: dict[int, dict[str, list[float]]] = {}
 
         if self.test_problems is not None:
             self.reevaluate_result_storages()
@@ -96,9 +96,9 @@ class ResultComparator:
 
     def get_best_by_objective_by_result_storage(
         self, objectif_str: str
-    ) -> Dict[str, Tuple[Solution, fitness_class]]:
+    ) -> dict[str, tuple[Solution, fitness_class]]:
         obj_index = self.objectives_str.index(objectif_str)
-        val: Dict[str, Tuple[Solution, fitness_class]] = {}
+        val: dict[str, tuple[Solution, fitness_class]] = {}
         for i in range(len(self.list_result_storage)):
             fit_array = [
                 cast(
@@ -132,7 +132,7 @@ class ResultComparator:
         return pareto_store
 
     def plot_all_2d_paretos_single_plot(
-        self, objectives_str: Optional[List[str]] = None
+        self, objectives_str: Optional[list[str]] = None
     ) -> Axes:
 
         if objectives_str is None:
@@ -167,7 +167,7 @@ class ResultComparator:
         return ax
 
     def plot_all_2d_paretos_subplots(
-        self, objectives_str: Optional[List[str]] = None
+        self, objectives_str: Optional[list[str]] = None
     ) -> Figure:
 
         if objectives_str is None:

--- a/discrete_optimization/generic_tools/robustness/robustness_tool.py
+++ b/discrete_optimization/generic_tools/robustness/robustness_tool.py
@@ -4,8 +4,9 @@
 
 import logging
 import random
+from collections.abc import Callable
 from multiprocessing import Pool
-from typing import Callable, List, Optional
+from typing import Optional
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -55,9 +56,9 @@ class RobustnessTool:
     def __init__(
         self,
         base_instance: RCPSPModel,
-        all_instances: List[RCPSPModel],
-        train_instance: Optional[List[RCPSPModel]] = None,
-        test_instance: Optional[List[RCPSPModel]] = None,
+        all_instances: list[RCPSPModel],
+        train_instance: Optional[list[RCPSPModel]] = None,
+        test_instance: Optional[list[RCPSPModel]] = None,
         proportion_train: float = 0.8,
     ):
         self.base_instance = base_instance
@@ -89,9 +90,9 @@ class RobustnessTool:
 
     def get_models(
         self, apriori: bool = True, aposteriori: bool = True
-    ) -> List[RCPSPModel]:
-        models: List[RCPSPModel] = []
-        tags: List[str] = []
+    ) -> list[RCPSPModel]:
+        models: list[RCPSPModel] = []
+        tags: list[str] = []
         if aposteriori:
             models += [
                 self.model_aggreg_mean,
@@ -127,7 +128,7 @@ class RobustnessTool:
         models = self.get_models(apriori, aposteriori)
         p = Pool(min(8, len(models)))
         l = p.map(solve_models_function, models)
-        solutions: List[RCPSPSolution] = [li.get_best_solution_fit()[0] for li in l]  # type: ignore
+        solutions: list[RCPSPSolution] = [li.get_best_solution_fit()[0] for li in l]  # type: ignore
         results = np.zeros((len(solutions), len(self.test_instance), 3))
         for index_instance in range(len(self.test_instance)):
             logger.debug(f"Evaluating in instance #{index_instance}")

--- a/discrete_optimization/generic_tools/sequential_metasolver.py
+++ b/discrete_optimization/generic_tools/sequential_metasolver.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 from discrete_optimization.generic_tools.callbacks.callback import (
     Callback,
@@ -52,7 +52,7 @@ class SequentialMetasolver(SolverDO):
         self,
         problem: Problem,
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
-        list_subbricks: Optional[List[SubBrick]] = None,
+        list_subbricks: Optional[list[SubBrick]] = None,
         **kwargs,
     ):
         """
@@ -85,7 +85,7 @@ class SequentialMetasolver(SolverDO):
                 )
 
     def solve(
-        self, callbacks: Optional[List[Callback]] = None, **kwargs: Any
+        self, callbacks: Optional[list[Callback]] = None, **kwargs: Any
     ) -> ResultStorage:
         # wrap all callbacks in a single one
         callbacks_list = CallbackList(callbacks=callbacks)

--- a/discrete_optimization/knapsack/knapsack_model.py
+++ b/discrete_optimization/knapsack/knapsack_model.py
@@ -2,9 +2,10 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
+from collections.abc import Sequence
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Sequence, Set, Type, Union, cast
+from typing import Any, Optional, Union, cast
 
 import numpy as np
 
@@ -45,7 +46,7 @@ class KnapsackSolution(Solution):
     def __init__(
         self,
         problem: "KnapsackModel",
-        list_taken: List[int],
+        list_taken: list[int],
         value: Optional[float] = None,
         weight: Optional[float] = None,
     ):
@@ -94,7 +95,7 @@ class KnapsackSolution(Solution):
 class KnapsackModel(Problem):
     def __init__(
         self,
-        list_items: List[Item],
+        list_items: list[Item],
         max_capacity: float,
         force_recompute_values: bool = False,
     ):
@@ -133,8 +134,8 @@ class KnapsackModel(Problem):
         )
 
     def evaluate_from_encoding(
-        self, int_vector: List[int], encoding_name: str
-    ) -> Dict[str, float]:
+        self, int_vector: list[int], encoding_name: str
+    ) -> dict[str, float]:
         if encoding_name == "list_taken":
             kp_sol = KnapsackSolution(problem=self, list_taken=int_vector)
         else:
@@ -142,7 +143,7 @@ class KnapsackModel(Problem):
         objectives = self.evaluate(kp_sol)
         return objectives
 
-    def evaluate(self, knapsack_solution: KnapsackSolution) -> Dict[str, float]:  # type: ignore # avoid isinstance checks for efficiency
+    def evaluate(self, knapsack_solution: KnapsackSolution) -> dict[str, float]:  # type: ignore # avoid isinstance checks for efficiency
         if knapsack_solution.value is None or self.force_recompute_values:
             val = self.evaluate_value(knapsack_solution)
         else:
@@ -196,15 +197,15 @@ class KnapsackModel(Problem):
         self.evaluate(kp_sol)
         return kp_sol
 
-    def get_solution_type(self) -> Type[Solution]:
+    def get_solution_type(self) -> type[Solution]:
         return KnapsackSolution
 
 
 def create_subknapsack_model(
     knapsack_model: KnapsackModel,
     solution: KnapsackSolution,
-    indexes_to_remove: Set[int],
-    indexes_to_keep: Set[int] = None,
+    indexes_to_remove: set[int],
+    indexes_to_keep: set[int] = None,
 ):
     if indexes_to_keep is None:
         indexes_to_keep = set(range(knapsack_model.nb_items)).difference(
@@ -246,7 +247,7 @@ class KnapsackModel_Mobj(KnapsackModel):
             dict_objective_to_doc=dict_objective,
         )
 
-    def evaluate(self, knapsack_solution: KnapsackSolution) -> Dict[str, float]:  # type: ignore  # avoid isinstance checks for efficiency
+    def evaluate(self, knapsack_solution: KnapsackSolution) -> dict[str, float]:  # type: ignore  # avoid isinstance checks for efficiency
         res = super().evaluate(knapsack_solution)
         heaviest = 0.0
         weight = 0.0
@@ -258,7 +259,7 @@ class KnapsackModel_Mobj(KnapsackModel):
         res["weight"] = weight
         return res
 
-    def evaluate_mobj_from_dict(self, dict_values: Dict[str, float]) -> TupleFitness:
+    def evaluate_mobj_from_dict(self, dict_values: dict[str, float]) -> TupleFitness:
         return TupleFitness(
             np.array([dict_values["value"], -dict_values["heaviest_item"]]), 2
         )
@@ -273,9 +274,9 @@ class KnapsackSolutionMultidimensional(Solution):
         problem: Union[
             "MultidimensionalKnapsack", "MultiScenarioMultidimensionalKnapsack"
         ],
-        list_taken: List[int],
+        list_taken: list[int],
         value: Optional[float] = None,
-        weights: Optional[List[float]] = None,
+        weights: Optional[list[float]] = None,
     ):
         self.problem = problem
         self.value = value
@@ -326,7 +327,7 @@ class KnapsackSolutionMultidimensional(Solution):
 class ItemMultidimensional:
     index: int
     value: float
-    weights: List[float]
+    weights: list[float]
 
     def __str__(self) -> str:
         return (
@@ -342,8 +343,8 @@ class ItemMultidimensional:
 class MultidimensionalKnapsack(Problem):
     def __init__(
         self,
-        list_items: List[ItemMultidimensional],
-        max_capacities: List[float],
+        list_items: list[ItemMultidimensional],
+        max_capacities: list[float],
         force_recompute_values: bool = False,
     ):
         self.list_items = list_items
@@ -381,21 +382,21 @@ class MultidimensionalKnapsack(Problem):
         )
 
     def evaluate_from_encoding(
-        self, int_vector: List[int], encoding_name: str
-    ) -> Dict[str, float]:
+        self, int_vector: list[int], encoding_name: str
+    ) -> dict[str, float]:
         if encoding_name == "list_taken":
             kp_sol = KnapsackSolutionMultidimensional(
                 problem=self, list_taken=int_vector
             )
         elif encoding_name == "custom":
-            kwargs: Dict[str, Any] = {encoding_name: int_vector}
+            kwargs: dict[str, Any] = {encoding_name: int_vector}
             kp_sol = KnapsackSolutionMultidimensional(problem=self, **kwargs)
         else:
             raise NotImplementedError("encoding_name must be 'list_taken' or 'custom'")
         objectives = self.evaluate(kp_sol)
         return objectives
 
-    def evaluate(self, knapsack_solution: KnapsackSolutionMultidimensional) -> Dict[str, float]:  # type: ignore  # avoid isinstance checks for efficiency
+    def evaluate(self, knapsack_solution: KnapsackSolutionMultidimensional) -> dict[str, float]:  # type: ignore  # avoid isinstance checks for efficiency
         if knapsack_solution.value is None or self.force_recompute_values:
             val = self.evaluate_value(knapsack_solution)
         else:
@@ -469,7 +470,7 @@ class MultidimensionalKnapsack(Problem):
         self.evaluate(kp_sol)
         return kp_sol
 
-    def get_solution_type(self) -> Type[Solution]:
+    def get_solution_type(self) -> type[Solution]:
         return KnapsackSolutionMultidimensional
 
     def copy(self) -> "MultidimensionalKnapsack":
@@ -506,7 +507,7 @@ def from_kp_to_multi(knapsack_model: KnapsackModel) -> MultidimensionalKnapsack:
 
 def create_noised_scenario(
     problem: MultidimensionalKnapsack, nb_scenarios: int = 20
-) -> List[MultidimensionalKnapsack]:
+) -> list[MultidimensionalKnapsack]:
     scenarios = [problem.copy() for i in range(nb_scenarios)]
     for p in scenarios:
         litem = []

--- a/discrete_optimization/knapsack/knapsack_parser.py
+++ b/discrete_optimization/knapsack/knapsack_parser.py
@@ -3,7 +3,7 @@
 #  LICENSE file in the root directory of this source tree.
 
 import os
-from typing import List, Optional
+from typing import Optional
 
 from discrete_optimization.datasets import get_data_home
 from discrete_optimization.knapsack.knapsack_model import Item, KnapsackModel
@@ -11,7 +11,7 @@ from discrete_optimization.knapsack.knapsack_model import Item, KnapsackModel
 
 def get_data_available(
     data_folder: Optional[str] = None, data_home: Optional[str] = None
-) -> List[str]:
+) -> list[str]:
     """Get datasets available for knapsack.
 
     Params:

--- a/discrete_optimization/knapsack/knapsack_solvers.py
+++ b/discrete_optimization/knapsack/knapsack_solvers.py
@@ -2,7 +2,7 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, List, Tuple, Type
+from typing import Any
 
 from discrete_optimization.generic_tools.cp_tools import CPSolverName
 from discrete_optimization.generic_tools.do_problem import Problem
@@ -27,7 +27,7 @@ from discrete_optimization.knapsack.solvers.lp_solvers import (
     MilpSolverName,
 )
 
-solvers: Dict[str, List[Tuple[Type[SolverKnapsack], Dict[str, Any]]]] = {
+solvers: dict[str, list[tuple[type[SolverKnapsack], dict[str, Any]]]] = {
     "lp": [
         (KnapsackORTools, {}),
         (LPKnapsackCBC, {}),
@@ -64,20 +64,20 @@ for key in solvers:
     for solver, param in solvers[key]:
         solvers_map[solver] = (key, param)
 
-solvers_compatibility: Dict[Type[SolverKnapsack], List[Type[Problem]]] = {}
+solvers_compatibility: dict[type[SolverKnapsack], list[type[Problem]]] = {}
 for x in solvers:
     for y in solvers[x]:
         solvers_compatibility[y[0]] = [KnapsackModel]
 
 
-def look_for_solver(domain: KnapsackModel) -> List[Type[SolverKnapsack]]:
+def look_for_solver(domain: KnapsackModel) -> list[type[SolverKnapsack]]:
     class_domain = domain.__class__
     return look_for_solver_class(class_domain)
 
 
 def look_for_solver_class(
-    class_domain: Type[KnapsackModel],
-) -> List[Type[SolverKnapsack]]:
+    class_domain: type[KnapsackModel],
+) -> list[type[SolverKnapsack]]:
     available = []
     for solver in solvers_compatibility:
         if class_domain in solvers_compatibility[solver]:
@@ -86,7 +86,7 @@ def look_for_solver_class(
 
 
 def solve(
-    method: Type[SolverKnapsack], problem: KnapsackModel, **args: Any
+    method: type[SolverKnapsack], problem: KnapsackModel, **args: Any
 ) -> ResultStorage:
     solver = method(problem, **args)
     solver.init_model(**args)

--- a/discrete_optimization/knapsack/mutation/mutation_knapsack.py
+++ b/discrete_optimization/knapsack/mutation/mutation_knapsack.py
@@ -3,7 +3,7 @@
 #  LICENSE file in the root directory of this source tree.
 
 import random
-from typing import Dict, List, Optional, Tuple
+from typing import Optional
 
 import numpy as np
 
@@ -41,11 +41,11 @@ class KnapsackMutationSingleBitFlip(Mutation):
     def __init__(self, problem: KnapsackModel):
         self.problem = problem
 
-    def mutate(self, solution: KnapsackSolution) -> Tuple[KnapsackSolution, LocalMove]:  # type: ignore # avoid isinstance checks for efficiency
+    def mutate(self, solution: KnapsackSolution) -> tuple[KnapsackSolution, LocalMove]:  # type: ignore # avoid isinstance checks for efficiency
         s, m, f = self.mutate_and_compute_obj(solution)
         return s, m
 
-    def mutate_and_compute_obj(self, solution: KnapsackSolution) -> Tuple[KnapsackSolution, LocalMove, Dict[str, float]]:  # type: ignore # avoid isinstance checks for efficiency
+    def mutate_and_compute_obj(self, solution: KnapsackSolution) -> tuple[KnapsackSolution, LocalMove, dict[str, float]]:  # type: ignore # avoid isinstance checks for efficiency
         n = len(solution.list_taken)
         i = random.randint(0, n - 1)
         move = SingleBitFlipMove(i, self.problem)
@@ -73,7 +73,7 @@ class KnapsackMutationSingleBitFlip(Mutation):
 
 class BitFlipMoveKP(LocalMove):
     def __init__(
-        self, attribute: str, problem: KnapsackModel, list_index_flip: List[int]
+        self, attribute: str, problem: KnapsackModel, list_index_flip: list[int]
     ):
         self.attribute = attribute
         self.problem = problem
@@ -132,7 +132,7 @@ class MutationKnapsack(Mutation):
 
     def switch_on(
         self, variable: KnapsackSolution, come_from_outside: bool = False
-    ) -> Tuple[KnapsackSolution, LocalMove, Dict[str, float]]:
+    ) -> tuple[KnapsackSolution, LocalMove, dict[str, float]]:
         if variable.weight is None or variable.value is None:
             raise RuntimeError(
                 "variable.weight and variable.value should not be None at this point."
@@ -183,7 +183,7 @@ class MutationKnapsack(Mutation):
 
     def switch_off(
         self, variable: KnapsackSolution, come_from_outside: bool = False
-    ) -> Tuple[KnapsackSolution, LocalMove, Dict[str, float]]:
+    ) -> tuple[KnapsackSolution, LocalMove, dict[str, float]]:
         if variable.weight is None or variable.value is None:
             raise RuntimeError(
                 "variable.weight and variable.value should not be None at this point."
@@ -225,13 +225,13 @@ class MutationKnapsack(Mutation):
                 )
             return self.switch_on(variable, come_from_outside=True)
 
-    def mutate(self, variable: KnapsackSolution) -> Tuple[KnapsackSolution, LocalMove]:  # type: ignore # avoid isinstance checks for efficiency
+    def mutate(self, variable: KnapsackSolution) -> tuple[KnapsackSolution, LocalMove]:  # type: ignore # avoid isinstance checks for efficiency
         s, m, f = self.mutate_and_compute_obj(variable)
         return s, m
 
     def mutate_and_compute_obj(  # type: ignore # avoid isinstance checks for efficiency
         self, variable: KnapsackSolution
-    ) -> Tuple[KnapsackSolution, LocalMove, Dict[str, float]]:
+    ) -> tuple[KnapsackSolution, LocalMove, dict[str, float]]:
         if variable.weight is None:
             self.knapsack_model.evaluate(variable)
         r = random.random()

--- a/discrete_optimization/knapsack/solvers/cp_solvers.py
+++ b/discrete_optimization/knapsack/solvers/cp_solvers.py
@@ -5,7 +5,8 @@
 import logging
 import os
 import random
-from typing import Any, Iterable, Optional, Sequence
+from collections.abc import Iterable, Sequence
+from typing import Any, Optional
 
 from minizinc import Instance, Model, Solver
 

--- a/discrete_optimization/knapsack/solvers/gphh_knapsack.py
+++ b/discrete_optimization/knapsack/solvers/gphh_knapsack.py
@@ -3,8 +3,9 @@
 #  LICENSE file in the root directory of this source tree.
 
 import operator
+from collections.abc import Callable
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 import matplotlib.pyplot as plt
 import networkx as nx
@@ -57,13 +58,13 @@ def get_profit(
     return problem.list_items[item_index].value
 
 
-def get_capacities(problem: MultidimensionalKnapsack, **kwargs: Any) -> List[float]:
+def get_capacities(problem: MultidimensionalKnapsack, **kwargs: Any) -> list[float]:
     return problem.max_capacities
 
 
 def get_res_consumption(
     problem: MultidimensionalKnapsack, item_index: int, **kwargs: Any
-) -> List[float]:
+) -> list[float]:
     return problem.list_items[item_index].weights
 
 
@@ -79,7 +80,7 @@ def get_avg_res_consumption_delta_capacity(
     ) / len(problem.max_capacities)
 
 
-feature_function_map: Dict[FeatureEnum, Callable[..., Union[float, List[float]]]] = {
+feature_function_map: dict[FeatureEnum, Callable[..., Union[float, list[float]]]] = {
     FeatureEnum.PROFIT: get_profit,
     FeatureEnum.CAPACITIES: get_capacities,
     FeatureEnum.RES_CONSUMPTION_ARRAY: get_res_consumption,
@@ -90,7 +91,7 @@ feature_function_map: Dict[FeatureEnum, Callable[..., Union[float, List[float]]]
 class ParametersGPHH:
     def __init__(
         self,
-        list_feature: List[FeatureEnum],
+        list_feature: list[FeatureEnum],
         set_primitves: PrimitiveSetTyped,
         tournament_ratio: float,
         pop_size: int,
@@ -172,7 +173,7 @@ class GPHH(SolverDO):
     def __init__(
         self,
         problem: MultidimensionalKnapsack,
-        training_domains: Optional[List[MultidimensionalKnapsack]] = None,
+        training_domains: Optional[list[MultidimensionalKnapsack]] = None,
         weight: int = 1,
         params_gphh: Optional[ParametersGPHH] = None,
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
@@ -311,7 +312,7 @@ class GPHH(SolverDO):
         if func_heuristic is None:
             func_heuristic = self.toolbox.compile(expr=individual)
         d: MultidimensionalKnapsack = domain
-        raw_values: List[float] = []
+        raw_values: list[float] = []
         for j in range(len(d.list_items)):
             input_features = [
                 feature_function_map[lf](problem=domain, item_index=j)
@@ -351,8 +352,8 @@ class GPHH(SolverDO):
         return solution
 
     def evaluate_heuristic(
-        self, individual: Any, domains: List[MultidimensionalKnapsack]
-    ) -> List[float]:
+        self, individual: Any, domains: list[MultidimensionalKnapsack]
+    ) -> list[float]:
         vals = []
         func_heuristic = self.toolbox.compile(expr=individual)
         for domain in domains:

--- a/discrete_optimization/knapsack/solvers/greedy_solvers.py
+++ b/discrete_optimization/knapsack/solvers/greedy_solvers.py
@@ -2,7 +2,8 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Any, Callable, List, Optional
+from collections.abc import Callable
+from typing import Any, Optional
 
 from discrete_optimization.generic_tools.do_solver import ResultStorage
 from discrete_optimization.knapsack.knapsack_model import (
@@ -13,7 +14,7 @@ from discrete_optimization.knapsack.knapsack_model import (
 from discrete_optimization.knapsack.solvers.knapsack_solver import SolverKnapsack
 
 
-def compute_density(knapsack_model: KnapsackModel) -> List[Item]:
+def compute_density(knapsack_model: KnapsackModel) -> list[Item]:
     dd = sorted(
         [
             l
@@ -26,7 +27,7 @@ def compute_density(knapsack_model: KnapsackModel) -> List[Item]:
     return dd
 
 
-def compute_density_and_penalty(knapsack_model: KnapsackModel) -> List[Item]:
+def compute_density_and_penalty(knapsack_model: KnapsackModel) -> list[Item]:
     dd = sorted(
         [
             l
@@ -41,7 +42,7 @@ def compute_density_and_penalty(knapsack_model: KnapsackModel) -> List[Item]:
 
 def greedy_using_queue(
     knapsack_model: KnapsackModel,
-    method_queue: Optional[Callable[[KnapsackModel], List[Item]]] = None,
+    method_queue: Optional[Callable[[KnapsackModel], list[Item]]] = None,
 ) -> KnapsackSolution:
     if method_queue is None:
         method_queue = compute_density

--- a/discrete_optimization/knapsack/solvers/knapsack_cpmpy.py
+++ b/discrete_optimization/knapsack/solvers/knapsack_cpmpy.py
@@ -2,7 +2,7 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 # Thanks to Leuven university for the cpmyp library.
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from cpmpy import Model, boolvar
 
@@ -29,7 +29,7 @@ class CPMPYKnapsackSolver(SolverKnapsack):
             problem=problem, params_objective_function=params_objective_function
         )
         self.model: Optional[Model] = None
-        self.variables: Dict[str, Any] = {}
+        self.variables: dict[str, Any] = {}
 
     def init_model(self, **kwargs: Any) -> None:
         values = [

--- a/discrete_optimization/knapsack/solvers/knapsack_cpsat_solver.py
+++ b/discrete_optimization/knapsack/solvers/knapsack_cpsat_solver.py
@@ -2,7 +2,8 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 import logging
-from typing import Any, Dict, Iterable, List, Optional
+from collections.abc import Iterable
+from typing import Any, Optional
 
 from ortools.sat.python.cp_model import (
     Constraint,
@@ -38,7 +39,7 @@ class CPSatKnapsackSolver(OrtoolsCPSatSolver, SolverKnapsack, WarmstartMixin):
         super().__init__(
             problem=problem, params_objective_function=params_objective_function
         )
-        self.variables: Dict[str, List[IntVar]] = {}
+        self.variables: dict[str, list[IntVar]] = {}
 
     def init_model(self, **args: Any) -> None:
         """Init CP model."""
@@ -141,7 +142,7 @@ class CPSatKnapsackSolver(OrtoolsCPSatSolver, SolverKnapsack, WarmstartMixin):
     def implements_lexico_api() -> bool:
         return True
 
-    def get_model_objectives_available(self) -> List[str]:
+    def get_model_objectives_available(self) -> list[str]:
         return ["value", "weight", "heaviest_item"]
 
     def retrieve_solution(

--- a/discrete_optimization/knapsack/solvers/knapsack_decomposition.py
+++ b/discrete_optimization/knapsack/solvers/knapsack_decomposition.py
@@ -4,7 +4,7 @@
 import logging
 import os
 import random
-from typing import Any, Dict, List, Optional, Set, Type
+from typing import Any, Optional
 
 from discrete_optimization.generic_tools.callbacks.callback import (
     Callback,
@@ -97,7 +97,7 @@ class KnapsackDecomposedSolver(SolverKnapsack, WarmstartMixin):
         sol: KnapsackSolution,
         original_knapsack_model: KnapsackModel,
         original_solution: KnapsackSolution,
-        indexes_to_remove: Set[int],
+        indexes_to_remove: set[int],
     ):
         """
         Rebuild a knapsack solution object from a partial solution.
@@ -129,7 +129,7 @@ class KnapsackDecomposedSolver(SolverKnapsack, WarmstartMixin):
         self.initial_solution = solution
 
     def solve(
-        self, callbacks: Optional[List[Callback]] = None, **kwargs: Any
+        self, callbacks: Optional[list[Callback]] = None, **kwargs: Any
     ) -> ResultStorage:
         # wrap all callbacks in a single one
         callbacks_list = CallbackList(callbacks=callbacks)
@@ -146,11 +146,11 @@ class KnapsackDecomposedSolver(SolverKnapsack, WarmstartMixin):
         kwargs = self.complete_with_default_hyperparameters(kwargs)
 
         initial_solver: SubBrick = kwargs["initial_solver"]
-        initial_solver_cls: Type[SolverKnapsack] = initial_solver.cls
+        initial_solver_cls: type[SolverKnapsack] = initial_solver.cls
         initial_solver_kwargs = initial_solver.kwargs
 
         root_solver: SubBrick = kwargs["root_solver"]
-        root_solver_cls: Type[SolverKnapsack] = root_solver.cls
+        root_solver_cls: type[SolverKnapsack] = root_solver.cls
         root_solver_kwargs = root_solver.kwargs
 
         nb_iteration = kwargs["nb_iteration"]

--- a/discrete_optimization/knapsack/solvers/knapsack_lns_cp_solver.py
+++ b/discrete_optimization/knapsack/solvers/knapsack_lns_cp_solver.py
@@ -3,7 +3,8 @@
 #  LICENSE file in the root directory of this source tree.
 
 import random
-from typing import Any, Iterable, Optional
+from collections.abc import Iterable
+from typing import Any, Optional
 
 from minizinc import Instance
 from ortools.sat.python.cp_model import Constraint

--- a/discrete_optimization/knapsack/solvers/knapsack_lns_solver.py
+++ b/discrete_optimization/knapsack/solvers/knapsack_lns_solver.py
@@ -3,8 +3,9 @@
 #  LICENSE file in the root directory of this source tree.
 
 import random
+from collections.abc import Iterable
 from enum import Enum
-from typing import Any, Iterable
+from typing import Any
 
 from discrete_optimization.generic_tools.do_problem import (
     ParamsObjectiveFunction,

--- a/discrete_optimization/knapsack/solvers/lp_solvers.py
+++ b/discrete_optimization/knapsack/solvers/lp_solvers.py
@@ -3,7 +3,8 @@
 #  LICENSE file in the root directory of this source tree.
 
 import logging
-from typing import Any, Callable, Dict, Optional, Union
+from collections.abc import Callable
+from typing import Any, Optional, Union
 
 import mip
 from mip import BINARY, MAXIMIZE, xsum
@@ -49,12 +50,12 @@ class _BaseLPKnapsack(MilpSolver, SolverKnapsack):
         super().__init__(
             problem=problem, params_objective_function=params_objective_function
         )
-        self.variable_decision: Dict[str, Dict[int, Union["Var", mip.Var]]] = {}
-        self.constraints_dict: Dict[
+        self.variable_decision: dict[str, dict[int, Union["Var", mip.Var]]] = {}
+        self.constraints_dict: dict[
             str, Union["Constr", "QConstr", "MConstr", "GenConstr", "mip.Constr"]
         ] = {}
-        self.description_variable_description: Dict[str, Dict[str, Any]] = {}
-        self.description_constraint: Dict[str, Dict[str, str]] = {}
+        self.description_variable_description: dict[str, dict[str, Any]] = {}
+        self.description_constraint: dict[str, dict[str, str]] = {}
 
     def retrieve_current_solution(
         self,
@@ -145,13 +146,13 @@ class LPKnapsackCBC(SolverKnapsack):
             problem=problem, params_objective_function=params_objective_function
         )
         self.model: Optional[pywraplp.Solver] = None
-        self.variable_decision: Dict[str, Dict[int, Any]] = {}
-        self.constraints_dict: Dict[str, Any] = {}
-        self.description_variable_description: Dict[str, Dict[str, Any]] = {}
-        self.description_constraint: Dict[str, Dict[str, str]] = {}
+        self.variable_decision: dict[str, dict[int, Any]] = {}
+        self.constraints_dict: dict[str, Any] = {}
+        self.description_variable_description: dict[str, dict[str, Any]] = {}
+        self.description_constraint: dict[str, dict[str, str]] = {}
 
     def init_model(
-        self, warm_start: Optional[Dict[int, int]] = None, **kwargs: Any
+        self, warm_start: Optional[dict[int, int]] = None, **kwargs: Any
     ) -> None:
         if warm_start is None:
             warm_start = {}

--- a/discrete_optimization/maximum_independent_set/mis_model.py
+++ b/discrete_optimization/maximum_independent_set/mis_model.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Dict, List, Type, Union
+from typing import Union
 
 import networkx as nx
 import numpy as np
@@ -19,7 +19,7 @@ from discrete_optimization.generic_tools.graph_api import Graph
 
 
 class MisSolution(Solution):
-    def __init__(self, problem: "MisProblem", chosen: Union[List, np.ndarray]):
+    def __init__(self, problem: "MisProblem", chosen: Union[list, np.ndarray]):
         self.problem = problem
         self.chosen = chosen
 
@@ -83,7 +83,7 @@ class MisProblem(Problem):
                 self.attr_list = attr_list
             self.func = sum
 
-    def evaluate(self, variable: MisSolution) -> Dict[str, float]:
+    def evaluate(self, variable: MisSolution) -> dict[str, float]:
         return {
             "value": self.func(variable.chosen),
             "penalty": self.compute_violation(variable),
@@ -118,7 +118,7 @@ class MisProblem(Problem):
             }
         )
 
-    def get_solution_type(self) -> Type[Solution]:
+    def get_solution_type(self) -> type[Solution]:
         return MisSolution
 
     def get_objective_register(self) -> ObjectiveRegister:

--- a/discrete_optimization/maximum_independent_set/mis_parser.py
+++ b/discrete_optimization/maximum_independent_set/mis_parser.py
@@ -1,5 +1,6 @@
 import os
-from typing import Any, Dict, Hashable, List, Optional, Tuple
+from collections.abc import Hashable
+from typing import Any, Optional
 
 import networkx as nx
 
@@ -12,7 +13,7 @@ os.environ["DO_SKIP_MZN_CHECK"] = "1"
 
 def get_data_available(
     data_folder: Optional[str] = None, data_home: Optional[str] = None
-) -> List[str]:
+) -> list[str]:
     """Get datasets available for mis.
 
     Params:
@@ -50,8 +51,8 @@ def dimacs_parser(filename: str):
     first_line = lines[0].split()
     node_count = int(first_line[2])
     edge_count = int(first_line[3])
-    edges: List[Tuple[Hashable, Hashable, Dict[str, Any]]] = []
-    nodes: List[Tuple[Hashable, Dict[str, Any]]] = [(i, {}) for i in range(node_count)]
+    edges: list[tuple[Hashable, Hashable, dict[str, Any]]] = []
+    nodes: list[tuple[Hashable, dict[str, Any]]] = [(i, {}) for i in range(node_count)]
     for i in range(1, edge_count + 1):
         line = lines[i]
         parts = line.split()
@@ -73,8 +74,8 @@ def basic_parser(filename: str):
     first_line = lines[0].split()
     node_count = int(first_line[0])
     edge_count = int(first_line[1])
-    edges: List[Tuple[Hashable, Hashable, Dict[str, Any]]] = []
-    nodes: List[Tuple[Hashable, Dict[str, Any]]] = [(i, {}) for i in range(node_count)]
+    edges: list[tuple[Hashable, Hashable, dict[str, Any]]] = []
+    nodes: list[tuple[Hashable, dict[str, Any]]] = [(i, {}) for i in range(node_count)]
     for i in range(1, edge_count + 1):
         line = lines[i]
         parts = line.split()

--- a/discrete_optimization/maximum_independent_set/mis_solvers.py
+++ b/discrete_optimization/maximum_independent_set/mis_solvers.py
@@ -4,7 +4,7 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, List, Tuple, Type
+from typing import Any
 
 from discrete_optimization.coloring.solvers.coloring_cpsat_solver import ModelingCPSat
 from discrete_optimization.generic_tools.cp_tools import ParametersCP
@@ -33,7 +33,7 @@ from discrete_optimization.maximum_independent_set.solvers.mis_toulbar import (
     toulbar_available,
 )
 
-solvers: Dict[str, List[Tuple[Type[MisSolver], Dict[str, Any]]]] = {
+solvers: dict[str, list[tuple[type[MisSolver], dict[str, Any]]]] = {
     "lp": [
         (
             MisMilpSolver,
@@ -67,7 +67,7 @@ for key in solvers:
 
 
 def solve(
-    method_solver: Type[MisSolver], problem: MisProblem, **kwargs: Any
+    method_solver: type[MisSolver], problem: MisProblem, **kwargs: Any
 ) -> ResultStorage:
     """Solve a mis instance with a given class of solver.
 

--- a/discrete_optimization/maximum_independent_set/solvers/mis_decomposition.py
+++ b/discrete_optimization/maximum_independent_set/solvers/mis_decomposition.py
@@ -4,7 +4,7 @@
 import logging
 import os
 import random
-from typing import Any, Dict, List, Optional, Set, Type
+from typing import Any, Optional
 
 import numpy as np
 
@@ -77,7 +77,7 @@ class MisDecomposedSolver(MisSolver, WarmstartMixin):
         sol: MisSolution,
         original_mis_model: MisProblem,
         original_solution: MisSolution,
-        indexes_to_remove: Set[int] = None,
+        indexes_to_remove: set[int] = None,
     ):
         """
         Rebuild a full Mus solution object from a partial solution.
@@ -107,7 +107,7 @@ class MisDecomposedSolver(MisSolver, WarmstartMixin):
         self.initial_solution = solution
 
     def solve(
-        self, callbacks: Optional[List[Callback]] = None, **kwargs: Any
+        self, callbacks: Optional[list[Callback]] = None, **kwargs: Any
     ) -> ResultStorage:
         # wrap all callbacks in a single one
         callbacks_list = CallbackList(callbacks=callbacks)
@@ -123,11 +123,11 @@ class MisDecomposedSolver(MisSolver, WarmstartMixin):
         kwargs = self.complete_with_default_hyperparameters(kwargs)
 
         initial_solver: SubBrick = kwargs["initial_solver"]
-        initial_solver_cls: Type[MisSolver] = initial_solver.cls
+        initial_solver_cls: type[MisSolver] = initial_solver.cls
         initial_solver_kwargs = initial_solver.kwargs
 
         root_solver: SubBrick = kwargs["root_solver"]
-        root_solver_cls: Type[MisSolver] = root_solver.cls
+        root_solver_cls: type[MisSolver] = root_solver.cls
         root_solver_kwargs = root_solver.kwargs
 
         nb_iteration = kwargs["nb_iteration"]

--- a/discrete_optimization/maximum_independent_set/solvers/mis_gurobi.py
+++ b/discrete_optimization/maximum_independent_set/solvers/mis_gurobi.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Optional, Sequence
+from collections.abc import Callable, Sequence
+from typing import Any
 
 import networkx as nx
 import numpy as np

--- a/discrete_optimization/maximum_independent_set/solvers/mis_lns.py
+++ b/discrete_optimization/maximum_independent_set/solvers/mis_lns.py
@@ -1,5 +1,6 @@
 import random
-from typing import Any, Iterable, Optional
+from collections.abc import Iterable
+from typing import Any, Optional
 
 import numpy as np
 from ortools.sat.python.cp_model import Constraint

--- a/discrete_optimization/maximum_independent_set/solvers/mis_networkx.py
+++ b/discrete_optimization/maximum_independent_set/solvers/mis_networkx.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 import networkx as nx
 
@@ -12,7 +12,7 @@ from discrete_optimization.maximum_independent_set.solvers.mis_solver import Mis
 
 class MisNetworkXSolver(MisSolver):
     def solve(
-        self, callbacks: Optional[List[Callback]] = None, **kwargs: Any
+        self, callbacks: Optional[list[Callback]] = None, **kwargs: Any
     ) -> ResultStorage:
         sol = nx.approximation.maximum_independent_set(self.problem.graph_nx)
         chosen = [

--- a/discrete_optimization/pickup_vrp/builders/instance_builders.py
+++ b/discrete_optimization/pickup_vrp/builders/instance_builders.py
@@ -4,7 +4,8 @@
 
 import logging
 import random
-from typing import Any, Dict, Hashable, List, Optional, Set, Tuple, cast
+from collections.abc import Hashable
+from typing import Any, Optional, cast
 
 import numpy as np
 import scipy.spatial.distance as dist
@@ -38,31 +39,31 @@ def create_selective_tsp(
     number_vehicle = nb_vehicles
     nb_nodes_transportation = nb_nodes
     # non dummy nodes
-    nodes_transportation: Set[Node] = set(range(nb_nodes_transportation))
+    nodes_transportation: set[Node] = set(range(nb_nodes_transportation))
     # we stack the origin nodes after
-    nodes_origin: Set[Node] = {
+    nodes_origin: set[Node] = {
         nb_nodes_transportation + i for i in range(number_vehicle)
     }
     # and destination nodes too
-    nodes_target: Set[Node] = {
+    nodes_target: set[Node] = {
         nb_nodes_transportation + number_vehicle + i for i in range(number_vehicle)
     }
-    list_pickup_deliverable: List[Tuple[List[Node], List[Node]]] = []
-    origin_vehicle: Dict[int, Node] = {
+    list_pickup_deliverable: list[tuple[list[Node], list[Node]]] = []
+    origin_vehicle: dict[int, Node] = {
         i: nb_nodes_transportation + i for i in range(number_vehicle)
     }
-    target_vehicle: Dict[int, Node] = {
+    target_vehicle: dict[int, Node] = {
         i: nb_nodes_transportation + number_vehicle + i for i in range(number_vehicle)
     }
     # we don't include resources neither capacities
-    resources_set: Set[str] = set()
-    capacities: Dict[int, Dict[str, Tuple[float, float]]] = {
+    resources_set: set[str] = set()
+    capacities: dict[int, dict[str, tuple[float, float]]] = {
         i: {} for i in range(number_vehicle)
     }
-    resources_flow_node: Dict[Node, Dict[str, float]] = {
+    resources_flow_node: dict[Node, dict[str, float]] = {
         i: {} for i in range(nb_nodes_transportation)
     }
-    resources_flow_edges: Dict[Edge, Dict[str, float]] = {
+    resources_flow_edges: dict[Edge, dict[str, float]] = {
         (i, j): {}
         for i in range(nb_nodes_transportation)
         for j in range(nb_nodes_transportation)
@@ -76,11 +77,11 @@ def create_selective_tsp(
     coordinates[:, 0] += 40
     distance_delta = dist.cdist(coordinates, coordinates)
     distance_delta = np.array(distance_delta, dtype=np.int_)
-    distance_delta_dict: Dict[Node, Dict[Node, float]] = {
+    distance_delta_dict: dict[Node, dict[Node, float]] = {
         i: {j: int(distance_delta[i, j]) for j in range(nb_nodes_real) if j != i}
         for i in range(nb_nodes_real)
     }
-    time_delta_dict: Dict[Node, Dict[Node, float]] = {
+    time_delta_dict: dict[Node, dict[Node, float]] = {
         i: {j: int(distance_delta_dict[i][j] / 2) for j in distance_delta_dict[i]}
         for i in distance_delta_dict
     }
@@ -89,11 +90,11 @@ def create_selective_tsp(
     # compute clusters based on geographical positions.
     kmeans = KMeans(n_clusters=nb_clusters, random_state=0).fit(coordinates)
     labels = kmeans.labels_
-    coordinates_2d: Dict[Node, Tuple[float, float]] = {
-        i: cast(Tuple[float, float], tuple(coordinates[i, :]))
+    coordinates_2d: dict[Node, tuple[float, float]] = {
+        i: cast(tuple[float, float], tuple(coordinates[i, :]))
         for i in range(coordinates.shape[0])
     }
-    clusters_dict: Dict[Node, Hashable] = {i: i + 1 for i in range(nb_nodes_real)}
+    clusters_dict: dict[Node, Hashable] = {i: i + 1 for i in range(nb_nodes_real)}
     for i in clusters_dict:
         clusters_dict[i] = labels[i]
     for j in range(number_vehicle):
@@ -129,48 +130,48 @@ def create_pickup_and_delivery(
 ) -> GPDP:
     number_vehicle = number_of_vehicles
     nb_nodes_transportation = number_of_node
-    nodes_transportation: Set[Node] = set(range(nb_nodes_transportation))
-    nodes_origin: Set[Node] = {
+    nodes_transportation: set[Node] = set(range(nb_nodes_transportation))
+    nodes_origin: set[Node] = {
         nb_nodes_transportation + i for i in range(number_vehicle)
     }
     # and destination nodes too
-    nodes_target: Set[Node] = {
+    nodes_target: set[Node] = {
         nb_nodes_transportation + number_vehicle + i for i in range(number_vehicle)
     }
-    list_pickup_deliverable: List[Tuple[List[Node], List[Node]]] = []
-    origin_vehicle: Dict[int, Node] = {
+    list_pickup_deliverable: list[tuple[list[Node], list[Node]]] = []
+    origin_vehicle: dict[int, Node] = {
         i: nb_nodes_transportation + i for i in range(number_vehicle)
     }
-    target_vehicle: Dict[int, Node] = {
+    target_vehicle: dict[int, Node] = {
         i: nb_nodes_transportation + number_vehicle + i for i in range(number_vehicle)
     }
 
     all_nodes = set(range(nb_nodes_transportation + 2 * number_vehicle))
-    resources_set: Set[str] = set()
-    capacities: Dict[int, Dict[str, Tuple[float, float]]] = {0: {}}
-    resources_flow_node: Dict[Node, Dict[str, float]] = {i: {} for i in all_nodes}
-    resources_flow_edges: Dict[Edge, Dict[str, float]] = {
+    resources_set: set[str] = set()
+    capacities: dict[int, dict[str, tuple[float, float]]] = {0: {}}
+    resources_flow_node: dict[Node, dict[str, float]] = {i: {} for i in all_nodes}
+    resources_flow_edges: dict[Edge, dict[str, float]] = {
         (i, j): {} for i in all_nodes for j in all_nodes if j != i
     }
 
     coordinates = np.random.randint(-20, 20, size=(len(all_nodes), 2))
-    coordinates_2d: Optional[Dict[Node, Tuple[float, float]]] = {
-        i: cast(Tuple[float, float], tuple(coordinates[i, :]))
+    coordinates_2d: Optional[dict[Node, tuple[float, float]]] = {
+        i: cast(tuple[float, float], tuple(coordinates[i, :]))
         for i in range(coordinates.shape[0])
     }
 
     distance_delta = dist.cdist(coordinates, coordinates)
     distance_delta = np.array(distance_delta, dtype=np.int_)
-    distance_delta_dict: Dict[Node, Dict[Node, float]] = {
+    distance_delta_dict: dict[Node, dict[Node, float]] = {
         i: {j: int(distance_delta[i, j]) for j in all_nodes if j != i}
         for i in all_nodes
     }
-    time_delta_dict: Dict[Node, Dict[Node, float]] = {
+    time_delta_dict: dict[Node, dict[Node, float]] = {
         i: {j: int(distance_delta_dict[i][j] / 2) for j in distance_delta_dict[i]}
         for i in distance_delta_dict
     }
 
-    clusters_dict: Dict[Node, Hashable] = {i: i + 1 for i in all_nodes}
+    clusters_dict: dict[Node, Hashable] = {i: i + 1 for i in all_nodes}
     if include_cluster:
         nb_clusters = nb_clusters
         kmeans = KMeans(n_clusters=nb_clusters, random_state=0).fit(coordinates)
@@ -180,7 +181,7 @@ def create_pickup_and_delivery(
         for j in range(number_vehicle):
             clusters_dict[target_vehicle[j]] = max(labels)
             clusters_dict[origin_vehicle[j]] = min(labels)
-    list_pickup_deliverable_per_cluster: List[Tuple[List[Node], List[Node]]] = []
+    list_pickup_deliverable_per_cluster: list[tuple[list[Node], list[Node]]] = []
     if include_pickup:
         if not pickup_per_cluster:
             nodes_possible = set(clusters_dict.keys())
@@ -247,7 +248,7 @@ def load_tsp_and_transform(index_in_files_available: int = 1) -> GPDP:
 
 def create_ortools_example() -> GPDP:
     """Build instances from ortools reference guide."""
-    data: Dict[str, Any] = {}
+    data: dict[str, Any] = {}
     coordinates = [
         (456, 320),  # location 0 - the depot
         (228, 0),  # location 1
@@ -674,23 +675,23 @@ def create_ortools_example() -> GPDP:
     for j in range(len(original_index)):
         original_index_to_new[original_index[j]] = j
     number_nodes_non_depot = len(coordinates) - 1
-    nodes_origin: List[Node] = list(
+    nodes_origin: list[Node] = list(
         range(number_nodes_non_depot, number_nodes_non_depot + data["num_vehicles"])
     )
-    nodes_target: List[Node] = list(
+    nodes_target: list[Node] = list(
         range(
             number_nodes_non_depot + data["num_vehicles"],
             number_nodes_non_depot + 2 * data["num_vehicles"],
         )
     )
-    nodes_origin_dict: Dict[int, Node] = {
+    nodes_origin_dict: dict[int, Node] = {
         i: nodes_origin[i] for i in range(data["num_vehicles"])
     }
-    nodes_target_dict: Dict[int, Node] = {
+    nodes_target_dict: dict[int, Node] = {
         i: nodes_target[i] for i in range(data["num_vehicles"])
     }
-    distance_delta_dict: Dict[Node, Dict[Node, float]] = {}
-    time_delta_dict: Dict[Node, Dict[Node, float]] = {}
+    distance_delta_dict: dict[Node, dict[Node, float]] = {}
+    time_delta_dict: dict[Node, dict[Node, float]] = {}
     for index in range(len(original_index)):
         distance_delta_dict[index] = {}
         time_delta_dict[index] = {}
@@ -701,21 +702,21 @@ def create_ortools_example() -> GPDP:
             time_delta_dict[index][index_2] = data["time_matrix"][
                 original_index[index]
             ][original_index[index_2]]
-    pickup_and_deliveries: List[Tuple[List[Node], List[Node]]] = []
+    pickup_and_deliveries: list[tuple[list[Node], list[Node]]] = []
     for p_d in data["pickups_deliveries"]:
         pickup_and_deliveries += [
             ([original_index_to_new[p_d[0]]], [original_index_to_new[p_d[1]]])
         ]
-    capacities: Dict[int, Dict[str, Tuple[float, float]]] = {}
-    resources_set: Set[str] = {"demand"}
+    capacities: dict[int, dict[str, tuple[float, float]]] = {}
+    resources_set: set[str] = {"demand"}
     for i in range(data["num_vehicles"]):
         capacities[i] = {"demand": (0, data["vehicle_capacities"][i])}
-    resources_flow_edges: Dict[Edge, Dict[str, float]] = {
+    resources_flow_edges: dict[Edge, dict[str, float]] = {
         (x, y): {"demand": 0}
         for x in distance_delta_dict
         for y in distance_delta_dict[x]
     }
-    resources_flow_nodes: Dict[Node, Dict[str, float]] = {}
+    resources_flow_nodes: dict[Node, dict[str, float]] = {}
     for index in range(len(original_index)):
         resources_flow_nodes[index] = {
             "demand": -data["demands"][original_index[index]]
@@ -726,10 +727,10 @@ def create_ortools_example() -> GPDP:
         }
     for k in nodes_target_dict:
         resources_flow_nodes[nodes_target_dict[k]] = {"demand": 0}
-    coordinates_dict: Dict[Node, Tuple[float, float]] = {}
+    coordinates_dict: dict[Node, tuple[float, float]] = {}
     for i in range(len(coordinates_reindex)):
         coordinates_dict[i] = coordinates_reindex[i]
-    time_windows_nodes: Dict[Node, Tuple[Optional[int], Optional[int]]] = {}
+    time_windows_nodes: dict[Node, tuple[Optional[int], Optional[int]]] = {}
     for i in range(len(original_index)):
         if i in nodes_target:
             continue

--- a/discrete_optimization/pickup_vrp/plots/gpdp_plot_utils.py
+++ b/discrete_optimization/pickup_vrp/plots/gpdp_plot_utils.py
@@ -3,8 +3,6 @@
 #  LICENSE file in the root directory of this source tree.
 from __future__ import print_function
 
-from typing import Tuple
-
 import matplotlib.pyplot as plt
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
@@ -16,7 +14,7 @@ from discrete_optimization.pickup_vrp.gpdp import GPDP, GPDPSolution
 def plot_gpdp_solution(
     sol: GPDPSolution,
     problem: GPDP,
-) -> Tuple[Figure, Axes]:
+) -> tuple[Figure, Axes]:
     if problem.coordinates_2d is None:
         raise ValueError(
             "problem.coordinates_2d cannot be None when calling plot_ortools_solution."

--- a/discrete_optimization/pickup_vrp/solver/ortools_solver.py
+++ b/discrete_optimization/pickup_vrp/solver/ortools_solver.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 import logging
 from enum import Enum
 from functools import partial
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 import numpy as np
 from ortools.constraint_solver import (
@@ -65,7 +65,7 @@ class ParametersCost:
         dimension_name: str,
         global_span: bool = True,
         sum_over_vehicles: bool = False,
-        coefficient_vehicles: Union[float, List[float]] = 100,
+        coefficient_vehicles: Union[float, list[float]] = 100,
     ):
         self.dimension_name = dimension_name
         self.global_span = global_span
@@ -87,7 +87,7 @@ class ParametersCost:
 
 
 def apply_cost(
-    list_parameters_cost: List[ParametersCost], routing: pywrapcp.RoutingModel
+    list_parameters_cost: list[ParametersCost], routing: pywrapcp.RoutingModel
 ) -> None:
     dimension_names = set([p.dimension_name for p in list_parameters_cost])
     dimension_dict = {d: routing.GetDimensionOrDie(d) for d in dimension_names}
@@ -189,7 +189,7 @@ class ORToolsGPDP(SolverPickupVrp, WarmstartMixin):
         super().__init__(
             problem=problem, params_objective_function=params_objective_function
         )
-        self.dimension_names: List[str] = []
+        self.dimension_names: list[str] = []
         self.factor_multiplier_distance = factor_multiplier_distance  # 10**3
         self.factor_multiplier_time = factor_multiplier_time  # 10**3
 
@@ -245,7 +245,7 @@ class ORToolsGPDP(SolverPickupVrp, WarmstartMixin):
         }
         # Neg Capacity version :
         neg_capacity_version = kwargs.get("neg_capacity_version", True)
-        demands: Dict[str, List[float]]
+        demands: dict[str, list[float]]
         if neg_capacity_version:
             demands = {
                 r: [
@@ -829,7 +829,7 @@ class ORToolsGPDP(SolverPickupVrp, WarmstartMixin):
         search_parameters: Optional[
             routing_parameters_pb2.RoutingSearchParameters
         ] = None,
-        callbacks: Optional[List[Callback]] = None,
+        callbacks: Optional[list[Callback]] = None,
         **kwargs: Any,
     ) -> ResultStorage:
         callbacks_list = CallbackList(callbacks=callbacks)
@@ -869,7 +869,7 @@ class ORToolsGPDP(SolverPickupVrp, WarmstartMixin):
         """
         self.initial_solution = solution
 
-    def _solution2routes(self, solution: GPDPSolution) -> List[List[int]]:
+    def _solution2routes(self, solution: GPDPSolution) -> list[list[int]]:
         return [
             [
                 self.manager.NodeToIndex(self.problem.index_nodes[node])
@@ -931,19 +931,19 @@ class RoutingMonitor(pywrapcp.SearchMonitor):
 
     def retrieve_current_solution(self) -> None:
         vehicle_count = self.problem.number_vehicle
-        vehicle_tours: Dict[int, List[int]] = {i: [] for i in range(vehicle_count)}
-        dimension_output: Dict[
-            Tuple[int, int, NodePosition], Dict[str, Tuple[float, float, float]]
+        vehicle_tours: dict[int, list[int]] = {i: [] for i in range(vehicle_count)}
+        dimension_output: dict[
+            tuple[int, int, NodePosition], dict[str, tuple[float, float, float]]
         ] = {}
         dimensions_names = self.do_solver.dimension_names
-        dimensions: Dict[str, pywrapcp.RoutingDimension] = {
+        dimensions: dict[str, pywrapcp.RoutingDimension] = {
             r: self.model.GetDimensionOrDie(r) for r in dimensions_names
         }
         objective = 0.0
         route_distance = 0.0
         for vehicle_id in range(vehicle_count):
             index = self.model.Start(vehicle_id)
-            route_load: Dict[str, float] = {r: 0.0 for r in self.problem.resources_set}
+            route_load: dict[str, float] = {r: 0.0 for r in self.problem.resources_set}
             cnt = 0
             while not self.model.IsEnd(index) or cnt > 10000:
                 node_index = self.do_solver.manager.IndexToNode(index)
@@ -998,11 +998,11 @@ class RoutingMonitor(pywrapcp.SearchMonitor):
                     except Exception as e:
                         logger.warning(("2,", e))
                         break
-        sol: Tuple[
-            Dict[int, List[int]],
-            Dict[
-                Tuple[int, int, NodePosition],
-                Dict[str, Tuple[float, float, float]],
+        sol: tuple[
+            dict[int, list[int]],
+            dict[
+                tuple[int, int, NodePosition],
+                dict[str, tuple[float, float, float]],
             ],
             float,
             float,
@@ -1021,9 +1021,9 @@ class RoutingMonitor(pywrapcp.SearchMonitor):
 
 def convert_to_gpdpsolution(
     problem: GPDP,
-    sol: Tuple[
-        Dict[int, List[int]],
-        Dict[Tuple[int, int, NodePosition], Dict[str, Tuple[float, float, float]]],
+    sol: tuple[
+        dict[int, list[int]],
+        dict[tuple[int, int, NodePosition], dict[str, tuple[float, float, float]]],
         float,
         float,
         float,
@@ -1036,7 +1036,7 @@ def convert_to_gpdpsolution(
         objective,
         cost,
     ) = sol
-    times: Dict[Node, float] = {}
+    times: dict[Node, float] = {}
     trajectories = {
         v: [problem.list_nodes[nodeindex] for nodeindex in traj]
         for v, traj in vehicle_tours.items()
@@ -1046,7 +1046,7 @@ def convert_to_gpdpsolution(
         if (node not in times) or (node_position != NodePosition.START):
             if "Time" in output:
                 times[node] = output["Time"][1]
-    resource_evolution: Dict[Node, Dict[Node, List[int]]] = {}
+    resource_evolution: dict[Node, dict[Node, list[int]]] = {}
     return GPDPSolution(
         problem=problem,
         trajectories=trajectories,

--- a/discrete_optimization/rcpsp/fast_function_rcpsp.py
+++ b/discrete_optimization/rcpsp/fast_function_rcpsp.py
@@ -3,7 +3,6 @@
 #  LICENSE file in the root directory of this source tree.
 
 import logging
-from typing import Dict, Tuple
 
 import numba.typed
 import numba.types
@@ -30,7 +29,7 @@ def sgs_fast(
     ressource_available: npt.NDArray[np.int_],
     ressource_renewable: npt.NDArray[np.bool_],
     minimum_starting_time_array: npt.NDArray[np.int_],
-) -> Tuple[Dict[int, Tuple[int, int]], bool]:
+) -> tuple[dict[int, tuple[int, int]], bool]:
     activity_end_times = {}
     unfeasible_non_renewable_resources = False
     new_horizon = horizon
@@ -106,7 +105,7 @@ def sgs_fast(
                         int(activity_end_times[act_id]),
                     )
                     pred_links[j] -= 1
-    rcpsp_schedule: Dict[int, Tuple[int, int]] = {}
+    rcpsp_schedule: dict[int, tuple[int, int]] = {}
     for act_id in activity_end_times:
         rcpsp_schedule[act_id] = (
             activity_end_times[act_id] - duration_array[act_id, modes_array[act_id]],
@@ -130,7 +129,7 @@ def sgs_fast_preemptive(
     ressource_available: npt.NDArray[np.int_],
     ressource_renewable: npt.NDArray[np.bool_],
     minimum_starting_time_array: npt.NDArray[np.int_],
-) -> Tuple[Dict[int, npt.NDArray[np.int_]], Dict[int, npt.NDArray[np.int_]], bool]:
+) -> tuple[dict[int, npt.NDArray[np.int_]], dict[int, npt.NDArray[np.int_]], bool]:
     activity_end_times = {}
     unfeasible_non_renewable_resources = False
     new_horizon = horizon
@@ -276,7 +275,7 @@ def sgs_fast_preemptive_some_special_constraints(
     horizon: int,
     ressource_available: npt.NDArray[np.int_],
     ressource_renewable: npt.NDArray[np.bool_],
-) -> Tuple[Dict[int, npt.NDArray[np.int_]], Dict[int, npt.NDArray[np.int_]], bool]:
+) -> tuple[dict[int, npt.NDArray[np.int_]], dict[int, npt.NDArray[np.int_]], bool]:
     activity_end_times = {}
     unfeasible_non_renewable_resources = False
     new_horizon = horizon
@@ -461,7 +460,7 @@ def sgs_fast_preemptive_minduration(
     ressource_renewable: npt.NDArray[np.bool_],
     min_duration_preemptive_bool: npt.NDArray[np.bool_],
     min_duration_preemptive: npt.NDArray[np.int_],
-) -> Tuple[Dict[int, npt.NDArray[np.int_]], Dict[int, npt.NDArray[np.int_]], bool]:
+) -> tuple[dict[int, npt.NDArray[np.int_]], dict[int, npt.NDArray[np.int_]], bool]:
     activity_end_times = {}
     unfeasible_non_renewable_resources = False
     new_horizon = horizon
@@ -617,8 +616,8 @@ def sgs_fast_partial_schedule(
     ressource_available: npt.NDArray[np.int_],
     ressource_renewable: npt.NDArray[np.bool_],
     minimum_starting_time_array: npt.NDArray[np.int_],
-) -> Tuple[Dict[int, Tuple[int, int]], bool]:
-    activity_end_times: Dict[int, int] = {}
+) -> tuple[dict[int, tuple[int, int]], bool]:
+    activity_end_times: dict[int, int] = {}
     unfeasible_non_renewable_resources = False
     new_horizon = horizon
     resource_avail_in_time = {}
@@ -725,7 +724,7 @@ def sgs_fast_partial_schedule(
                         int(minimum_starting_time[s]), int(activity_end_times[act_id])
                     )
                     pred_links[s] -= 1
-    rcpsp_schedule: Dict[int, Tuple[int, int]] = {}
+    rcpsp_schedule: dict[int, tuple[int, int]] = {}
     for act_id in activity_end_times:
         rcpsp_schedule[act_id] = (
             activity_end_times[act_id] - duration_array[act_id, modes_array[act_id]],
@@ -753,7 +752,7 @@ def sgs_fast_partial_schedule_incomplete_permutation_tasks(
     ressource_available: npt.NDArray[np.int_],
     ressource_renewable: npt.NDArray[np.bool_],
     minimum_starting_time_array: npt.NDArray[np.int_],
-) -> Tuple[Dict[int, Tuple[int, int]], bool]:
+) -> tuple[dict[int, tuple[int, int]], bool]:
     activity_end_times = {}
     unfeasible_non_renewable_resources = False
     new_horizon = horizon
@@ -899,7 +898,7 @@ def sgs_fast_partial_schedule_preemptive(
     ressource_available: npt.NDArray[np.int_],
     ressource_renewable: npt.NDArray[np.bool_],
     minimum_starting_time_array: npt.NDArray[np.int_],
-) -> Tuple[Dict[int, npt.NDArray[np.int_]], Dict[int, npt.NDArray[np.int_]], bool]:
+) -> tuple[dict[int, npt.NDArray[np.int_]], dict[int, npt.NDArray[np.int_]], bool]:
     activity_end_times = {}
     unfeasible_non_renewable_resources = False
     new_horizon = horizon
@@ -1092,7 +1091,7 @@ def sgs_fast_partial_schedule_preemptive_minduration(
     ressource_renewable: npt.NDArray[np.bool_],
     min_duration_preemptive_bool: npt.NDArray[np.bool_],
     min_duration_preemptive: npt.NDArray[np.int_],
-) -> Tuple[Dict[int, npt.NDArray[np.int_]], Dict[int, npt.NDArray[np.int_]], bool]:
+) -> tuple[dict[int, npt.NDArray[np.int_]], dict[int, npt.NDArray[np.int_]], bool]:
     activity_end_times = {}
     unfeasible_non_renewable_resources = False
     new_horizon = horizon
@@ -1338,9 +1337,9 @@ def compute_ressource_consumption(
     horizon: int,
     ressource_available: npt.NDArray[np.int_],
     ressource_renewable: npt.NDArray[np.bool_],
-) -> Dict[int, npt.NDArray[np.int_]]:
+) -> dict[int, npt.NDArray[np.int_]]:
     new_horizon = horizon
-    resource_avail_in_time: Dict[int, npt.NDArray[np.int_]] = {}
+    resource_avail_in_time: dict[int, npt.NDArray[np.int_]] = {}
     for index in range(ressource_available.shape[0]):
         resource_avail_in_time[index] = np.zeros(new_horizon + 1, dtype=np.int_)
     nb_task = start_array.shape[0]

--- a/discrete_optimization/rcpsp/mutations/mutation_rcpsp.py
+++ b/discrete_optimization/rcpsp/mutations/mutation_rcpsp.py
@@ -3,7 +3,7 @@
 #  LICENSE file in the root directory of this source tree.
 
 import random
-from typing import Any, Dict, Optional, Tuple, Type
+from typing import Any, Optional
 
 import numpy as np
 
@@ -34,7 +34,7 @@ class PermutationMutationRCPSP(Mutation):
     def build(
         problem: Problem,
         solution: Solution,
-        other_mutation: Type[Mutation] = PermutationShuffleMutation,
+        other_mutation: type[Mutation] = PermutationShuffleMutation,
         **kwargs: Any
     ) -> "PermutationMutationRCPSP":
         built_other_mutation = other_mutation.build(problem, solution, **kwargs)
@@ -47,7 +47,7 @@ class PermutationMutationRCPSP(Mutation):
         self.solution = solution
         self.other_mutation = other_mutation
 
-    def mutate(self, solution: RCPSPSolution) -> Tuple[Solution, LocalMove]:  # type: ignore
+    def mutate(self, solution: RCPSPSolution) -> tuple[Solution, LocalMove]:  # type: ignore
         s: RCPSPSolution
         s, lm = self.other_mutation.mutate(solution)  # type: ignore
         try:
@@ -59,7 +59,7 @@ class PermutationMutationRCPSP(Mutation):
 
     def mutate_and_compute_obj(  # type: ignore
         self, solution: RCPSPSolution
-    ) -> Tuple[Solution, LocalMove, Dict[str, float]]:
+    ) -> tuple[Solution, LocalMove, dict[str, float]]:
         s: RCPSPSolution
         s, lm, fit = self.other_mutation.mutate_and_compute_obj(solution)  # type: ignore
         try:
@@ -91,7 +91,7 @@ class DeadlineMutationRCPSP(Mutation):
         except:
             pass
 
-    def mutate(self, solution: ANY_SOLUTION) -> Tuple[ANY_SOLUTION, LocalMove]:  # type: ignore
+    def mutate(self, solution: ANY_SOLUTION) -> tuple[ANY_SOLUTION, LocalMove]:  # type: ignore
         if not is_instance_any_rcpsp_solution(solution):
             raise ValueError("solution must be an rcsp solution (of any kind)")
         if "special_constraints" in self.problem.__dict__.keys():
@@ -138,7 +138,7 @@ class DeadlineMutationRCPSP(Mutation):
 
     def mutate_and_compute_obj(
         self, solution: Solution
-    ) -> Tuple[Solution, LocalMove, Dict[str, float]]:
+    ) -> tuple[Solution, LocalMove, dict[str, float]]:
         if not is_instance_any_rcpsp_solution(solution):
             raise ValueError("solution must be an rcsp solution (of any kind)")
         sol: ANY_SOLUTION

--- a/discrete_optimization/rcpsp/plots/rcpsp_utils_preemptive.py
+++ b/discrete_optimization/rcpsp/plots/rcpsp_utils_preemptive.py
@@ -3,7 +3,7 @@
 #  LICENSE file in the root directory of this source tree.
 
 import logging
-from typing import List, Union
+from typing import Union
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 def compute_resource_consumption(
     rcpsp_model: RCPSPModelPreemptive,
     rcpsp_sol: RCPSPSolutionPreemptive,
-    list_resources: List[Union[int, str]] = None,
+    list_resources: list[Union[int, str]] = None,
     future_view=True,
 ):
     modes_dict = rcpsp_model.get_modes_dict(rcpsp_sol)
@@ -58,7 +58,7 @@ def compute_resource_consumption(
 def compute_nice_resource_consumption(
     rcpsp_model: RCPSPModelPreemptive,
     rcpsp_sol: RCPSPSolutionPreemptive,
-    list_resources: List[Union[int, str]] = None,
+    list_resources: list[Union[int, str]] = None,
 ):
     if list_resources is None:
         list_resources = rcpsp_model.resources_list
@@ -83,7 +83,7 @@ def compute_nice_resource_consumption(
 def plot_ressource_view(
     rcpsp_model: RCPSPModelPreemptive,
     rcpsp_sol: RCPSPSolutionPreemptive,
-    list_resource: List[Union[int, str]] = None,
+    list_resource: list[Union[int, str]] = None,
     title_figure="",
     x_lim=None,
     fig=None,
@@ -282,7 +282,7 @@ def plot_task_gantt(
 def compute_schedule_per_resource_individual(
     rcpsp_model: RCPSPModelPreemptive,
     rcpsp_sol: RCPSPSolutionPreemptive,
-    resource_types_to_consider: List[str] = None,
+    resource_types_to_consider: list[str] = None,
 ):
     modes_dict = rcpsp_model.build_mode_dict(
         rcpsp_modes_from_solution=rcpsp_sol.rcpsp_modes
@@ -452,7 +452,7 @@ def compute_schedule_per_resource_individual(
 def plot_resource_individual_gantt(
     rcpsp_model: RCPSPModelPreemptive,
     rcpsp_sol: RCPSPSolutionPreemptive,
-    resource_types_to_consider: List[str] = None,
+    resource_types_to_consider: list[str] = None,
     title_figure="",
     x_lim=None,
     fig=None,

--- a/discrete_optimization/rcpsp/rcpsp_model_preemptive.py
+++ b/discrete_optimization/rcpsp/rcpsp_model_preemptive.py
@@ -5,10 +5,11 @@
 import logging
 import math
 from collections import defaultdict
+from collections.abc import Hashable, Iterable
 from copy import deepcopy
 from enum import Enum
 from functools import partial
-from typing import Dict, Hashable, Iterable, List, Optional, Set, Tuple, Type, Union
+from typing import Optional, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -48,12 +49,12 @@ class ScheduleGenerationScheme(Enum):
 
 
 class RCPSPSolutionPreemptive(Solution):
-    rcpsp_permutation: Union[List[int], np.array]
-    rcpsp_schedule: Dict[Hashable, Dict[str, List[int]]]
+    rcpsp_permutation: Union[list[int], np.array]
+    rcpsp_schedule: dict[Hashable, dict[str, list[int]]]
     #  {task_id: {'starts': [start_times], 'ends':  [end_times], 'resources': list_of_resource_ids}
     #   for task_id in self.problem.tasks_list}
-    rcpsp_modes: List[int]  # [mode_id[i] for i in range(self.problem.n_jobs_non_dummy)]
-    standardised_permutation: Union[List[int], np.array]
+    rcpsp_modes: list[int]  # [mode_id[i] for i in range(self.problem.n_jobs_non_dummy)]
+    standardised_permutation: Union[list[int], np.array]
 
     def __init__(
         self,
@@ -274,8 +275,8 @@ class RCPSPSolutionPreemptive(Solution):
     def generate_schedule_from_permutation_serial_sgs_2(
         self,
         current_t=0,
-        completed_tasks: Optional[Set[Hashable]] = None,
-        partial_schedule: Optional[Dict[Hashable, Dict[str, List[int]]]] = None,
+        completed_tasks: Optional[set[Hashable]] = None,
+        partial_schedule: Optional[dict[Hashable, dict[str, list[int]]]] = None,
         do_fast=True,
     ):
         if completed_tasks is None:
@@ -376,18 +377,18 @@ class RCPSPSolutionPreemptive(Solution):
 class PartialSolutionPreemptive:
     def __init__(
         self,
-        task_mode: Dict[int, int] = None,
-        start_times: Dict[int, int] = None,
-        end_times: Dict[int, int] = None,
-        partial_permutation: List[int] = None,
-        list_partial_order: List[List[int]] = None,
-        start_together: List[Tuple[int, int]] = None,
-        start_at_end: List[Tuple[int, int]] = None,
-        start_at_end_plus_offset: List[Tuple[int, int, int]] = None,
-        start_after_nunit: List[Tuple[int, int, int]] = None,
-        disjunctive_tasks: List[Tuple[int, int]] = None,
-        start_times_window: Dict[Hashable, Tuple[int, int]] = None,
-        end_times_window: Dict[Hashable, Tuple[int, int]] = None,
+        task_mode: dict[int, int] = None,
+        start_times: dict[int, int] = None,
+        end_times: dict[int, int] = None,
+        partial_permutation: list[int] = None,
+        list_partial_order: list[list[int]] = None,
+        start_together: list[tuple[int, int]] = None,
+        start_at_end: list[tuple[int, int]] = None,
+        start_at_end_plus_offset: list[tuple[int, int, int]] = None,
+        start_after_nunit: list[tuple[int, int, int]] = None,
+        disjunctive_tasks: list[tuple[int, int]] = None,
+        start_times_window: dict[Hashable, tuple[int, int]] = None,
+        end_times_window: dict[Hashable, tuple[int, int]] = None,
     ):
         self.task_mode = task_mode
         self.start_times = start_times
@@ -408,29 +409,29 @@ class PartialSolutionPreemptive:
 class RCPSPModelPreemptive(Problem):
     sgs: ScheduleGenerationScheme
     resources: Union[
-        Dict[str, int], Dict[str, List[int]]
+        dict[str, int], dict[str, list[int]]
     ]  # {resource_name: number_of_resource}
-    non_renewable_resources: List[str]  # e.g. [resource_name3, resource_name4]
+    non_renewable_resources: list[str]  # e.g. [resource_name3, resource_name4]
     n_jobs: int  # excluding dummy activities Start (0) and End (n)
-    mode_details: Dict[Hashable, Dict[int, Dict[str, int]]]
+    mode_details: dict[Hashable, dict[int, dict[str, int]]]
     # e.g. {job_id: {mode_id: {resource_name1: number_of_resources_needed, resource_name2: ...}}
     # one key being "duration"
-    successors: Dict[int, List[int]]  # {task_id: list of successor task ids}
+    successors: dict[int, list[int]]  # {task_id: list of successor task ids}
 
     def __init__(
         self,
-        resources: Union[Dict[str, int], Dict[str, List[int]]],
-        non_renewable_resources: List[str],
-        mode_details: Dict[Hashable, Dict[Union[str, int], Dict[str, int]]],
-        successors: Dict[Union[int, str], List[Union[str, int]]],
+        resources: Union[dict[str, int], dict[str, list[int]]],
+        non_renewable_resources: list[str],
+        mode_details: dict[Hashable, dict[Union[str, int], dict[str, int]]],
+        successors: dict[Union[int, str], list[Union[str, int]]],
         horizon,
         horizon_multiplier=1,
-        tasks_list: List[Union[int, str]] = None,
+        tasks_list: list[Union[int, str]] = None,
         source_task=None,
         sink_task=None,
-        preemptive_indicator: Dict[Hashable, bool] = None,
-        duration_subtask: Dict[Hashable, Tuple[bool, int]] = None,
-        name_task: Dict[int, str] = None,
+        preemptive_indicator: dict[Hashable, bool] = None,
+        duration_subtask: dict[Hashable, tuple[bool, int]] = None,
+        name_task: dict[int, str] = None,
     ):
         self.resources = resources
         self.resources_list = list(self.resources.keys())
@@ -574,7 +575,7 @@ class RCPSPModelPreemptive(Problem):
             return objectives
         return None
 
-    def evaluate(self, rcpsp_sol: RCPSPSolutionPreemptive) -> Dict[str, float]:
+    def evaluate(self, rcpsp_sol: RCPSPSolutionPreemptive) -> dict[str, float]:
         obj_makespan, obj_mean_resource_reserve = self.evaluate_function(rcpsp_sol)
         return {
             "makespan": obj_makespan,
@@ -584,7 +585,7 @@ class RCPSPModelPreemptive(Problem):
     def evaluate_mobj(self, rcpsp_sol: RCPSPSolutionPreemptive):
         return self.evaluate_mobj_from_dict(self.evaluate(rcpsp_sol))
 
-    def evaluate_mobj_from_dict(self, dict_values: Dict[str, float]) -> TupleFitness:
+    def evaluate_mobj_from_dict(self, dict_values: dict[str, float]) -> TupleFitness:
         return TupleFitness(
             np.array([-dict_values["makespan"], dict_values["mean_resource_reserve"]]),
             2,
@@ -654,7 +655,7 @@ class RCPSPModelPreemptive(Problem):
 
             return True
 
-    def get_solution_type(self) -> Type[Solution]:
+    def get_solution_type(self) -> type[Solution]:
         return RCPSPSolutionPreemptive
 
     def get_attribute_register(self) -> EncodingRegister:
@@ -948,10 +949,10 @@ def generate_schedule_from_permutation_serial_sgs(
 def generate_schedule_from_permutation_serial_sgs_partial_schedule(
     solution: RCPSPSolutionPreemptive,
     rcpsp_problem: RCPSPModelPreemptive,
-    partial_schedule: Dict[Hashable, Dict[str, List[int]]],
+    partial_schedule: dict[Hashable, dict[str, list[int]]],
     current_t: int,
-    completed_tasks: Set[Hashable],
-) -> Tuple[Dict[int, Dict[str, List[int]]], bool]:
+    completed_tasks: set[Hashable],
+) -> tuple[dict[int, dict[str, list[int]]], bool]:
     activity_end_times = {}
     unfeasible_non_renewable_resources = False
     new_horizon = rcpsp_problem.horizon

--- a/discrete_optimization/rcpsp/rcpsp_parser.py
+++ b/discrete_optimization/rcpsp/rcpsp_parser.py
@@ -3,7 +3,8 @@
 #  LICENSE file in the root directory of this source tree.
 
 import os
-from typing import Dict, Hashable, List, Optional, Union
+from collections.abc import Hashable
+from typing import Optional, Union
 
 from discrete_optimization.datasets import get_data_home
 from discrete_optimization.rcpsp.rcpsp_model import RCPSPModel
@@ -11,7 +12,7 @@ from discrete_optimization.rcpsp.rcpsp_model import RCPSPModel
 
 def get_data_available(
     data_folder: Optional[str] = None, data_home: Optional[str] = None
-) -> List[str]:
+) -> list[str]:
     """Get datasets available for rcpsp.
 
     Params:
@@ -59,7 +60,7 @@ def parse_psplib(input_data: str) -> RCPSPModel:
     # Parsing resource information
     tmp1 = lines[res_start_line_index].split()
     tmp2 = lines[res_start_line_index + 1].split()
-    resources: Dict[str, Union[int, List[int]]] = {
+    resources: dict[str, Union[int, list[int]]] = {
         str(tmp1[(i * 2)]) + str(tmp1[(i * 2) + 1]): int(tmp2[i])
         for i in range(len(tmp2))
     }
@@ -69,7 +70,7 @@ def parse_psplib(input_data: str) -> RCPSPModel:
     n_resources = len(resources.keys())
 
     # Parsing precedence relationship
-    successors: Dict[Hashable, List[Hashable]] = {}
+    successors: dict[Hashable, list[Hashable]] = {}
     for i in range(prec_start_line_index, prec_end_line_index + 1):
         tmp = lines[i].split()
         task_id = int(tmp[0])
@@ -77,7 +78,7 @@ def parse_psplib(input_data: str) -> RCPSPModel:
         successors[task_id] = [int(x) for x in tmp[3 : (3 + n_successors)]]
 
     # Parsing mode and duration information
-    mode_details: Dict[Hashable, Dict[int, Dict[str, int]]] = {}
+    mode_details: dict[Hashable, dict[int, dict[str, int]]] = {}
     for i_line in range(duration_start_line_index, duration_end_line_index + 1):
         tmp = lines[i_line].split()
         if len(tmp) == 3 + n_resources:
@@ -92,7 +93,7 @@ def parse_psplib(input_data: str) -> RCPSPModel:
 
         if int(task_id) not in list(mode_details.keys()):
             mode_details[int(task_id)] = {}
-        mode_details[int(task_id)][mode_id] = {}  # Dict[int, Dict[str, int]]
+        mode_details[int(task_id)][mode_id] = {}  # dict[int, dict[str, int]]
         mode_details[int(task_id)][mode_id]["duration"] = duration
         for i in range(n_resources):
             mode_details[int(task_id)][mode_id][
@@ -123,7 +124,7 @@ def parse_patterson(input_data: str) -> RCPSPModel:
     n_renewable_resources = parsed_values[1]
 
     # Creating resource dict with only renewable resources
-    resources: Dict[str, Union[int, List[int]]] = {
+    resources: dict[str, Union[int, list[int]]] = {
         "R" + str(i + 1): parsed_values[2 + i] for i in range(n_renewable_resources)
     }
 
@@ -133,8 +134,8 @@ def parse_patterson(input_data: str) -> RCPSPModel:
     ]
 
     # setting up dict data structure for successor and mode_detail information
-    successors: Dict[Hashable, List[Hashable]] = {}
-    mode_details: Dict[Hashable, Dict[int, Dict[str, int]]] = {}
+    successors: dict[Hashable, list[Hashable]] = {}
+    mode_details: dict[Hashable, dict[int, dict[str, int]]] = {}
 
     # pruning irrelevant content from parsed values
     start_index_activity_information = 2 + n_renewable_resources
@@ -152,7 +153,7 @@ def parse_patterson(input_data: str) -> RCPSPModel:
         mode_details[int(task_id)] = {}
         duration = parsed_values.pop(0)
 
-        mode_details[int(task_id)][mode_id] = {}  # Dict[int, Dict[str, int]]
+        mode_details[int(task_id)][mode_id] = {}  # dict[int, dict[str, int]]
         mode_details[int(task_id)][mode_id]["duration"] = duration
 
         horizon += duration

--- a/discrete_optimization/rcpsp/rcpsp_solution.py
+++ b/discrete_optimization/rcpsp/rcpsp_solution.py
@@ -6,8 +6,9 @@ from __future__ import (
     annotations,  # make annotations be considered as string by default
 )
 
+from collections.abc import Hashable, Iterable
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, Dict, Hashable, Iterable, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
 from numpy import typing as npt
@@ -66,21 +67,21 @@ class RCPSPSolution(Solution):
     def __init__(
         self,
         problem: RCPSPModel,
-        rcpsp_permutation: Optional[List[int]] = None,
-        rcpsp_schedule: Optional[Dict[Hashable, Dict[str, int]]] = None,
-        rcpsp_modes: Optional[List[int]] = None,
+        rcpsp_permutation: Optional[list[int]] = None,
+        rcpsp_schedule: Optional[dict[Hashable, dict[str, int]]] = None,
+        rcpsp_modes: Optional[list[int]] = None,
         rcpsp_schedule_feasible: bool = True,
-        standardised_permutation: Optional[List[int]] = None,
+        standardised_permutation: Optional[list[int]] = None,
         fast: bool = True,
     ):
         self.problem = problem
         self.rcpsp_schedule_feasible = rcpsp_schedule_feasible
         self.fast = fast
 
-        self.rcpsp_modes: List[int]
-        self.rcpsp_schedule: Dict[Hashable, Dict[str, int]]
-        self.rcpsp_permutation: List[int]
-        self.standardised_permutation: List[int]
+        self.rcpsp_modes: list[int]
+        self.rcpsp_schedule: dict[Hashable, dict[str, int]]
+        self.rcpsp_permutation: list[int]
+        self.standardised_permutation: list[int]
 
         # init rcpsp_modes
         if rcpsp_modes is None:
@@ -165,7 +166,7 @@ class RCPSPSolution(Solution):
         val = "RCPSP solution (rcpsp_schedule): " + sched_str
         return val
 
-    def generate_permutation_from_schedule(self) -> List[int]:
+    def generate_permutation_from_schedule(self) -> list[int]:
         sorted_task = [
             self.problem.index_task_non_dummy[i]
             for i in sorted(
@@ -218,7 +219,7 @@ class RCPSPSolution(Solution):
             self.rcpsp_schedule_feasible = True
         else:
             if do_fast:
-                schedule: Dict[int, Tuple[int, int]]
+                schedule: dict[int, tuple[int, int]]
                 if max(self.rcpsp_modes) > self.problem.max_number_of_mode:
                     # non existing modes
                     schedule, unfeasible = {}, True
@@ -255,8 +256,8 @@ class RCPSPSolution(Solution):
     def generate_schedule_from_permutation_serial_sgs_2(
         self,
         current_t: int = 0,
-        completed_tasks: Optional[Dict[Hashable, TaskDetails]] = None,
-        scheduled_tasks_start_times: Optional[Dict[Hashable, int]] = None,
+        completed_tasks: Optional[dict[Hashable, TaskDetails]] = None,
+        scheduled_tasks_start_times: Optional[dict[Hashable, int]] = None,
         do_fast: bool = True,
     ) -> None:
         if completed_tasks is None:
@@ -264,7 +265,7 @@ class RCPSPSolution(Solution):
         if scheduled_tasks_start_times is None:
             scheduled_tasks_start_times = {}
         if do_fast and not self.problem.do_special_constraints:
-            schedule: Dict[int, Tuple[int, int]]
+            schedule: dict[int, tuple[int, int]]
             if max(self.rcpsp_modes) > self.problem.max_number_of_mode:
                 # non existing modes
                 schedule, unfeasible = {}, True
@@ -348,13 +349,13 @@ class RCPSPSolution(Solution):
     def get_end_time(self, task: Hashable) -> int:
         return self.rcpsp_schedule[task]["end_time"]
 
-    def get_start_times_list(self, task: Hashable) -> List[int]:
+    def get_start_times_list(self, task: Hashable) -> list[int]:
         return [self.get_start_time(task)]
 
-    def get_end_times_list(self, task: Hashable) -> List[int]:
+    def get_end_times_list(self, task: Hashable) -> list[int]:
         return [self.get_end_time(task)]
 
-    def get_active_time(self, task: Hashable) -> List[int]:
+    def get_active_time(self, task: Hashable) -> list[int]:
         return list(range(self.get_start_time(task), self.get_end_time(task)))
 
     def get_mode(self, task: Hashable) -> int:
@@ -385,7 +386,7 @@ def permutation_do_to_permutation_sgs_fast(
 
 def generate_schedule_from_permutation_serial_sgs(
     solution: RCPSPSolution, rcpsp_problem: RCPSPModel
-) -> Tuple[Dict[Hashable, Dict[str, int]], bool]:
+) -> tuple[dict[Hashable, dict[str, int]], bool]:
     activity_end_times = {}
     unfeasible_non_renewable_resources = False
     new_horizon = rcpsp_problem.horizon
@@ -487,7 +488,7 @@ def generate_schedule_from_permutation_serial_sgs(
                 minimum_starting_time[s] = max(
                     minimum_starting_time[s], activity_end_times[act_id]
                 )
-    rcpsp_schedule: Dict[Hashable, Dict[str, int]] = {}
+    rcpsp_schedule: dict[Hashable, dict[str, int]] = {}
     for act_id in activity_end_times:
         rcpsp_schedule[act_id] = {}
         rcpsp_schedule[act_id]["start_time"] = (
@@ -509,7 +510,7 @@ def generate_schedule_from_permutation_serial_sgs(
 
 def generate_schedule_from_permutation_serial_sgs_special_constraints(
     solution: RCPSPSolution, rcpsp_problem: RCPSPModel
-) -> Tuple[Dict[Hashable, Dict[str, int]], bool]:
+) -> tuple[dict[Hashable, dict[str, int]], bool]:
     activity_end_times = {}
 
     unfeasible_non_renewable_resources = False
@@ -554,7 +555,7 @@ def generate_schedule_from_permutation_serial_sgs_special_constraints(
         if modes_dict[k] not in rcpsp_problem.mode_details[k]:
             modes_dict[k] = 1
 
-    def look_for_task(perm: List[Hashable], ignore_sc: bool = False) -> List[Hashable]:
+    def look_for_task(perm: list[Hashable], ignore_sc: bool = False) -> list[Hashable]:
         act_ids = []
         for task_id in perm:
             respected = True
@@ -713,7 +714,7 @@ def generate_schedule_from_permutation_serial_sgs_special_constraints(
                             act_id
                         ][s],
                     )
-    rcpsp_schedule: Dict[Hashable, Dict[str, int]] = {}
+    rcpsp_schedule: dict[Hashable, dict[str, int]] = {}
     for act_id in activity_end_times:
         rcpsp_schedule[act_id] = {}
         rcpsp_schedule[act_id]["start_time"] = (
@@ -737,9 +738,9 @@ def generate_schedule_from_permutation_serial_sgs_partial_schedule(
     solution: RCPSPSolution,
     rcpsp_problem: RCPSPModel,
     current_t: int,
-    completed_tasks: Dict[Hashable, TaskDetails],
-    scheduled_tasks_start_times: Dict[Hashable, int],
-) -> Tuple[Dict[Hashable, Dict[str, int]], bool]:
+    completed_tasks: dict[Hashable, TaskDetails],
+    scheduled_tasks_start_times: dict[Hashable, int],
+) -> tuple[dict[Hashable, dict[str, int]], bool]:
     activity_end_times = {}
     unfeasible_non_renewable_resources = False
     new_horizon = rcpsp_problem.horizon
@@ -857,7 +858,7 @@ def generate_schedule_from_permutation_serial_sgs_partial_schedule(
                 minimum_starting_time[s] = max(
                     minimum_starting_time[s], activity_end_times[act_id]
                 )
-    rcpsp_schedule: Dict[Hashable, Dict[str, int]] = {}
+    rcpsp_schedule: dict[Hashable, dict[str, int]] = {}
     for act_id in activity_end_times:
         rcpsp_schedule[act_id] = {}
         rcpsp_schedule[act_id]["start_time"] = (
@@ -885,9 +886,9 @@ def generate_schedule_from_permutation_serial_sgs_partial_schedule_specialized_c
     solution: RCPSPSolution,
     rcpsp_problem: RCPSPModel,
     current_t: int,
-    completed_tasks: Dict[Hashable, TaskDetails],
-    scheduled_tasks_start_times: Dict[Hashable, int],
-) -> Tuple[Dict[Hashable, Dict[str, int]], bool]:
+    completed_tasks: dict[Hashable, TaskDetails],
+    scheduled_tasks_start_times: dict[Hashable, int],
+) -> tuple[dict[Hashable, dict[str, int]], bool]:
     activity_end_times = {}
     unfeasible_non_renewable_resources = False
     new_horizon = rcpsp_problem.horizon
@@ -995,7 +996,7 @@ def generate_schedule_from_permutation_serial_sgs_partial_schedule_specialized_c
                 if pred in perm_extended:
                     respected = False
                     break
-            task_to_start_too: List[Hashable] = []
+            task_to_start_too: list[Hashable] = []
             if respected:
                 task_to_start_too = [
                     k
@@ -1112,7 +1113,7 @@ def generate_schedule_from_permutation_serial_sgs_partial_schedule_specialized_c
                             act_id
                         ][s]
                     )
-    rcpsp_schedule: Dict[Hashable, Dict[str, int]] = {}
+    rcpsp_schedule: dict[Hashable, dict[str, int]] = {}
     for act_id in activity_end_times:
         rcpsp_schedule[act_id] = {}
         rcpsp_schedule[act_id]["start_time"] = (
@@ -1183,18 +1184,18 @@ def compute_mean_resource_reserve(
 class PartialSolution:
     def __init__(
         self,
-        task_mode: Optional[Dict[int, int]] = None,
-        start_times: Optional[Dict[int, int]] = None,
-        end_times: Optional[Dict[int, int]] = None,
-        partial_permutation: Optional[List[int]] = None,
-        list_partial_order: Optional[List[List[int]]] = None,
-        start_together: Optional[List[Tuple[int, int]]] = None,
-        start_at_end: Optional[List[Tuple[int, int]]] = None,
-        start_at_end_plus_offset: Optional[List[Tuple[int, int, int]]] = None,
-        start_after_nunit: Optional[List[Tuple[int, int, int]]] = None,
-        disjunctive_tasks: Optional[List[Tuple[int, int]]] = None,
-        start_times_window: Optional[Dict[Hashable, Tuple[int, int]]] = None,
-        end_times_window: Optional[Dict[Hashable, Tuple[int, int]]] = None,
+        task_mode: Optional[dict[int, int]] = None,
+        start_times: Optional[dict[int, int]] = None,
+        end_times: Optional[dict[int, int]] = None,
+        partial_permutation: Optional[list[int]] = None,
+        list_partial_order: Optional[list[list[int]]] = None,
+        start_together: Optional[list[tuple[int, int]]] = None,
+        start_at_end: Optional[list[tuple[int, int]]] = None,
+        start_at_end_plus_offset: Optional[list[tuple[int, int, int]]] = None,
+        start_after_nunit: Optional[list[tuple[int, int, int]]] = None,
+        disjunctive_tasks: Optional[list[tuple[int, int]]] = None,
+        start_times_window: Optional[dict[Hashable, tuple[int, int]]] = None,
+        end_times_window: Optional[dict[Hashable, tuple[int, int]]] = None,
     ):
         self.task_mode = task_mode
         self.start_times = start_times

--- a/discrete_optimization/rcpsp/rcpsp_solvers.py
+++ b/discrete_optimization/rcpsp/rcpsp_solvers.py
@@ -2,7 +2,7 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, List, Tuple, Type, Union
+from typing import Any, Union
 
 from discrete_optimization.generic_rcpsp_tools.generic_rcpsp_solver import (
     SolverGenericRCPSP,
@@ -51,8 +51,8 @@ from discrete_optimization.rcpsp.specialized_rcpsp.rcpsp_specialized_constraints
     RCPSPModelSpecialConstraintsPreemptive,
 )
 
-solvers: Dict[
-    str, List[Tuple[Union[Type[SolverRCPSP], Type[SolverGenericRCPSP]], Dict[str, Any]]]
+solvers: dict[
+    str, list[tuple[Union[type[SolverRCPSP], type[SolverGenericRCPSP]], dict[str, Any]]]
 ] = {
     "lp": [
         (
@@ -142,8 +142,8 @@ for key in solvers:
     for solver, param in solvers[key]:
         solvers_map[solver] = (key, param)
 
-solvers_compatibility: Dict[
-    Union[Type[SolverRCPSP], Type[SolverGenericRCPSP]], List[Type[ANY_CLASSICAL_RCPSP]]
+solvers_compatibility: dict[
+    Union[type[SolverRCPSP], type[SolverGenericRCPSP]], list[type[ANY_CLASSICAL_RCPSP]]
 ] = {
     LP_RCPSP: [RCPSPModel],
     LP_MRCPSP: [
@@ -197,14 +197,14 @@ solvers_compatibility: Dict[
 
 def look_for_solver(
     domain: ANY_CLASSICAL_RCPSP,
-) -> List[Union[Type[SolverRCPSP], Type[SolverGenericRCPSP]]]:
+) -> list[Union[type[SolverRCPSP], type[SolverGenericRCPSP]]]:
     class_domain = domain.__class__
     return look_for_solver_class(class_domain)
 
 
 def look_for_solver_class(
-    class_domain: Type[ANY_CLASSICAL_RCPSP],
-) -> List[Union[Type[SolverRCPSP], Type[SolverGenericRCPSP]]]:
+    class_domain: type[ANY_CLASSICAL_RCPSP],
+) -> list[Union[type[SolverRCPSP], type[SolverGenericRCPSP]]]:
     available = []
     for solver in solvers_compatibility:
         if class_domain in solvers_compatibility[solver]:
@@ -213,7 +213,7 @@ def look_for_solver_class(
 
 
 def solve(
-    method: Union[Type[SolverRCPSP], Type[SolverGenericRCPSP]],
+    method: Union[type[SolverRCPSP], type[SolverGenericRCPSP]],
     problem: ANY_CLASSICAL_RCPSP,
     **kwargs: Any,
 ) -> ResultStorage:
@@ -222,16 +222,16 @@ def solve(
 
 
 def solve_return_solver(
-    method: Union[Type[SolverRCPSP], Type[SolverGenericRCPSP]],
+    method: Union[type[SolverRCPSP], type[SolverGenericRCPSP]],
     problem: ANY_CLASSICAL_RCPSP,
     **kwargs: Any,
-) -> Tuple[ResultStorage, Union[SolverRCPSP, SolverGenericRCPSP]]:
+) -> tuple[ResultStorage, Union[SolverRCPSP, SolverGenericRCPSP]]:
     solver = return_solver(method=method, problem=problem, **kwargs)
     return solver.solve(**kwargs), solver
 
 
 def return_solver(
-    method: Union[Type[SolverRCPSP], Type[SolverGenericRCPSP]],
+    method: Union[type[SolverRCPSP], type[SolverGenericRCPSP]],
     problem: ANY_CLASSICAL_RCPSP,
     **kwargs: Any,
 ) -> Union[SolverRCPSP, SolverGenericRCPSP]:
@@ -245,8 +245,8 @@ def return_solver(
 
 
 def get_solver_default_arguments(
-    method: Union[Type[SolverRCPSP], Type[SolverGenericRCPSP]]
-) -> Dict[str, Any]:
+    method: Union[type[SolverRCPSP], type[SolverGenericRCPSP]]
+) -> dict[str, Any]:
     try:
         return solvers_map[method][1]
     except KeyError:

--- a/discrete_optimization/rcpsp/rcpsp_utils.py
+++ b/discrete_optimization/rcpsp/rcpsp_utils.py
@@ -7,18 +7,9 @@ from __future__ import (
 )
 
 import logging
+from collections.abc import Hashable, Sequence
 from copy import deepcopy
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Hashable,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -45,9 +36,9 @@ logger = logging.getLogger(__name__)
 def compute_resource_consumption(
     rcpsp_model: RCPSPModel,
     rcpsp_sol: RCPSPSolution,
-    list_resources: Optional[List[str]] = None,
+    list_resources: Optional[list[str]] = None,
     future_view: bool = True,
-) -> Tuple[npt.NDArray[np.int_], npt.NDArray[np.int_]]:
+) -> tuple[npt.NDArray[np.int_], npt.NDArray[np.int_]]:
     modes_extended = deepcopy(rcpsp_sol.rcpsp_modes)
     modes_extended.insert(0, 1)
     modes_extended.append(1)
@@ -83,8 +74,8 @@ def compute_resource_consumption(
 def compute_nice_resource_consumption(
     rcpsp_model: RCPSPModel,
     rcpsp_sol: RCPSPSolution,
-    list_resources: Optional[List[str]] = None,
-) -> Tuple[Dict[int, npt.NDArray[np.int_]], Dict[int, npt.NDArray[np.int_]]]:
+    list_resources: Optional[list[str]] = None,
+) -> tuple[dict[int, npt.NDArray[np.int_]], dict[int, npt.NDArray[np.int_]]]:
     if list_resources is None:
         list_resources = rcpsp_model.resources_list
     c_future, times = compute_resource_consumption(
@@ -93,8 +84,8 @@ def compute_nice_resource_consumption(
     c_past, times = compute_resource_consumption(
         rcpsp_model, rcpsp_sol, list_resources=list_resources, future_view=False
     )
-    merged_times: Dict[int, List[int]] = {i: [] for i in range(len(list_resources))}
-    merged_cons: Dict[int, List[int]] = {i: [] for i in range(len(list_resources))}
+    merged_times: dict[int, list[int]] = {i: [] for i in range(len(list_resources))}
+    merged_cons: dict[int, list[int]] = {i: [] for i in range(len(list_resources))}
     for r in range(len(list_resources)):
         for index_t in range(len(times)):
             merged_times[r] += [times[index_t], times[index_t]]
@@ -108,9 +99,9 @@ def compute_nice_resource_consumption(
 def plot_ressource_view(
     rcpsp_model: RCPSPModel,
     rcpsp_sol: RCPSPSolution,
-    list_resource: Optional[List[str]] = None,
+    list_resource: Optional[list[str]] = None,
     title_figure: str = "",
-    x_lim: Optional[List[int]] = None,
+    x_lim: Optional[list[int]] = None,
     fig: Optional[plt.Figure] = None,
     ax: Optional[npt.NDArray[np.object_]] = None,
 ) -> plt.Figure:
@@ -126,8 +117,8 @@ def plot_ressource_view(
         if len(list_resource) == 1:
             ax = [ax]
         fig.suptitle(title_figure)
-    polygons_ax: Dict[int, List[Polygon]] = {i: [] for i in range(len(list_resource))}
-    labels_ax: Dict[int, List[Hashable]] = {i: [] for i in range(len(list_resource))}
+    polygons_ax: dict[int, list[Polygon]] = {i: [] for i in range(len(list_resource))}
+    labels_ax: dict[int, list[Hashable]] = {i: [] for i in range(len(list_resource))}
     sorted_activities = sorted(
         rcpsp_sol.rcpsp_schedule,
         key=lambda x: rcpsp_sol.rcpsp_schedule[x]["start_time"],
@@ -205,7 +196,7 @@ def plot_task_gantt(
     rcpsp_sol: RCPSPSolution,
     fig: Optional[plt.Figure] = None,
     ax: Optional[plt.Axes] = None,
-    x_lim: Optional[List[int]] = None,
+    x_lim: Optional[list[int]] = None,
     title: Optional[str] = None,
 ) -> plt.Figure:
     if fig is None or ax is None:
@@ -268,8 +259,8 @@ def plot_task_gantt(
 def compute_schedule_per_resource_individual(
     rcpsp_model: RCPSPModel,
     rcpsp_sol: RCPSPSolution,
-    resource_types_to_consider: Optional[List[str]] = None,
-) -> Dict[str, Dict[str, Any]]:
+    resource_types_to_consider: Optional[list[str]] = None,
+) -> dict[str, dict[str, Any]]:
     modes = rcpsp_model.build_mode_dict(rcpsp_sol.rcpsp_modes)
     if resource_types_to_consider is None:
         resources = rcpsp_model.resources_list
@@ -287,7 +278,7 @@ def compute_schedule_per_resource_individual(
     min_time = rcpsp_sol.get_start_time(sorted_task_by_end[0])
     with_calendar = rcpsp_model.is_varying_resource()
 
-    array_ressource_usage: Dict[str, Dict[str, Any]] = {
+    array_ressource_usage: dict[str, dict[str, Any]] = {
         resources[i]: {
             "activity": np.zeros(
                 (
@@ -397,9 +388,9 @@ def compute_schedule_per_resource_individual(
 def plot_resource_individual_gantt(
     rcpsp_model: RCPSPModel,
     rcpsp_sol: RCPSPSolution,
-    resource_types_to_consider: Optional[List[str]] = None,
+    resource_types_to_consider: Optional[list[str]] = None,
     title_figure: str = "",
-    x_lim: Optional[List[int]] = None,
+    x_lim: Optional[list[int]] = None,
     fig: Optional[plt.Figure] = None,
     ax: Optional[npt.NDArray[np.object_]] = None,
     current_t: Optional[int] = None,
@@ -474,7 +465,7 @@ def plot_resource_individual_gantt(
     return fig
 
 
-def kendall_tau_similarity(rcpsp_sols: Tuple[RCPSPSolution, RCPSPSolution]) -> float:
+def kendall_tau_similarity(rcpsp_sols: tuple[RCPSPSolution, RCPSPSolution]) -> float:
     sol1 = rcpsp_sols[0]
     sol2 = rcpsp_sols[1]
 
@@ -485,7 +476,7 @@ def kendall_tau_similarity(rcpsp_sols: Tuple[RCPSPSolution, RCPSPSolution]) -> f
     return ktd
 
 
-def intersect(i1: Sequence[int], i2: Sequence[int]) -> Optional[List[int]]:
+def intersect(i1: Sequence[int], i2: Sequence[int]) -> Optional[list[int]]:
     if i2[0] >= i1[1] or i1[0] >= i2[1]:
         return None
     else:
@@ -495,8 +486,8 @@ def intersect(i1: Sequence[int], i2: Sequence[int]) -> Optional[List[int]]:
 
 
 def all_diff_start_time(
-    rcpsp_sols: Tuple[RCPSPSolution, RCPSPSolution]
-) -> Dict[Hashable, int]:
+    rcpsp_sols: tuple[RCPSPSolution, RCPSPSolution]
+) -> dict[Hashable, int]:
     sol1 = rcpsp_sols[0]
     sol2 = rcpsp_sols[1]
     return {
@@ -522,7 +513,7 @@ def compute_graph_rcpsp(rcpsp_model: RCPSPModel) -> Graph:
     edges = []
     for n in rcpsp_model.successors:
         for succ in rcpsp_model.successors[n]:
-            dict_transition: Dict[str, int] = {
+            dict_transition: dict[str, int] = {
                 str(mode): rcpsp_model.mode_details[n][mode]["duration"]
                 for mode in rcpsp_model.mode_details[n]
             }
@@ -537,7 +528,7 @@ def compute_graph_rcpsp(rcpsp_model: RCPSPModel) -> Graph:
     return Graph(nodes, edges, False)
 
 
-def create_fake_tasks(rcpsp_problem: RCPSPModel) -> List[Dict[str, int]]:
+def create_fake_tasks(rcpsp_problem: RCPSPModel) -> list[dict[str, int]]:
     if not rcpsp_problem.is_varying_resource():
         return []
     else:
@@ -546,7 +537,7 @@ def create_fake_tasks(rcpsp_problem: RCPSPModel) -> List[Dict[str, int]]:
             for r in rcpsp_problem.resources_list
         }
         max_capacity = {r: np.max(ressources_arrays[r]) for r in ressources_arrays}
-        fake_tasks: List[Dict[str, int]] = []
+        fake_tasks: list[dict[str, int]] = []
         for r in ressources_arrays:
             delta = ressources_arrays[r][:-1] - ressources_arrays[r][1:]
             index_non_zero = np.nonzero(delta)[0]
@@ -587,7 +578,7 @@ def get_max_time_solution(
 
 def get_tasks_ending_between_two_times(
     solution: Union[RCPSPSolutionPreemptive, RCPSPSolution], time_1: int, time_2: int
-) -> List[Hashable]:
+) -> list[Hashable]:
     if isinstance(solution, RCPSPSolutionPreemptive):
         return [
             x
@@ -604,7 +595,7 @@ def get_tasks_ending_between_two_times(
 
 def get_start_bounds_from_additional_constraint(
     rcpsp_problem: RCPSPModel, activity: Hashable
-) -> Tuple[int, int]:
+) -> tuple[int, int]:
     assert activity in rcpsp_problem.index_task
     lb = 0
     ub = rcpsp_problem.horizon
@@ -649,7 +640,7 @@ def get_start_bounds_from_additional_constraint(
 
 def get_end_bounds_from_additional_constraint(
     rcpsp_problem: RCPSPModel, activity: Hashable
-) -> Tuple[int, int]:
+) -> tuple[int, int]:
     assert activity in rcpsp_problem.index_task
     lb = 0
     ub = rcpsp_problem.horizon

--- a/discrete_optimization/rcpsp/robust_rcpsp.py
+++ b/discrete_optimization/rcpsp/robust_rcpsp.py
@@ -3,8 +3,9 @@
 #  LICENSE file in the root directory of this source tree.
 
 from collections import defaultdict
+from collections.abc import Hashable, Sequence
 from enum import Enum
-from typing import Any, Dict, Hashable, List, Sequence, Tuple
+from typing import Any
 
 import numpy as np
 from scipy.stats import poisson, randint, rv_discrete
@@ -17,7 +18,7 @@ from discrete_optimization.rcpsp import RCPSPModel
 from discrete_optimization.rcpsp.rcpsp_solution import RCPSPSolution
 
 
-def tree() -> Dict[Any, Any]:
+def tree() -> dict[Any, Any]:
     return defaultdict(tree)
 
 
@@ -73,8 +74,8 @@ class AggregRCPSPModel(RobustProblem, RCPSPModel):
         return model
 
     def evaluate_from_encoding(
-        self, int_vector: List[int], encoding_name: str
-    ) -> Dict[str, float]:
+        self, int_vector: list[int], encoding_name: str
+    ) -> dict[str, float]:
         fits = [
             self.list_problem[i].evaluate_from_encoding(int_vector, encoding_name)
             for i in range(self.nb_problem)
@@ -86,7 +87,7 @@ class AggregRCPSPModel(RobustProblem, RCPSPModel):
             aggreg[k] = self.agg_vec(vals)
         return aggreg
 
-    def evaluate(self, variable: RCPSPSolution) -> Dict[str, float]:  # type: ignore
+    def evaluate(self, variable: RCPSPSolution) -> dict[str, float]:  # type: ignore
         fits = []
         for i in range(self.nb_problem):
             var: RCPSPSolution = variable.lazy_copy()
@@ -122,8 +123,8 @@ class MethodRobustification:
 
 def create_poisson_laws_duration(
     rcpsp_model: RCPSPModel, range_around_mean: int = 3
-) -> Dict[Hashable, Dict[int, Dict[str, Tuple[int, int, int]]]]:
-    poisson_dict: Dict[Hashable, Dict[int, Dict[str, Tuple[int, int, int]]]] = {}
+) -> dict[Hashable, dict[int, dict[str, tuple[int, int, int]]]]:
+    poisson_dict: dict[Hashable, dict[int, dict[str, tuple[int, int, int]]]] = {}
     source = rcpsp_model.source_task
     sink = rcpsp_model.sink_task
     for job in rcpsp_model.mode_details:
@@ -146,8 +147,8 @@ def create_poisson_laws_duration(
 
 def create_poisson_laws_resource(
     rcpsp_model: RCPSPModel, range_around_mean: int = 1
-) -> Dict[Hashable, Dict[int, Dict[str, Tuple[int, int, int]]]]:
-    poisson_dict: Dict[Hashable, Dict[int, Dict[str, Tuple[int, int, int]]]] = {}
+) -> dict[Hashable, dict[int, dict[str, tuple[int, int, int]]]]:
+    poisson_dict: dict[Hashable, dict[int, dict[str, tuple[int, int, int]]]] = {}
     source = rcpsp_model.source_task
     sink = rcpsp_model.sink_task
     limit_resource = rcpsp_model.resources
@@ -188,8 +189,8 @@ def create_poisson_laws(
     range_around_mean_duration: int = 3,
     do_uncertain_resource: bool = True,
     do_uncertain_duration: bool = True,
-) -> Dict[Hashable, Dict[int, Dict[str, Tuple[int, int, int]]]]:
-    poisson_laws: Dict[Hashable, Dict[int, Dict[str, Tuple[int, int, int]]]] = tree()
+) -> dict[Hashable, dict[int, dict[str, tuple[int, int, int]]]]:
+    poisson_laws: dict[Hashable, dict[int, dict[str, tuple[int, int, int]]]] = tree()
     if do_uncertain_duration:
         poisson_laws_duration = create_poisson_laws_duration(
             base_rcpsp_model, range_around_mean=range_around_mean_duration
@@ -213,12 +214,12 @@ class UncertainRCPSPModel:
     def __init__(
         self,
         base_rcpsp_model: RCPSPModel,
-        poisson_laws: Dict[Hashable, Dict[int, Dict[str, Tuple[int, int, int]]]],
+        poisson_laws: dict[Hashable, dict[int, dict[str, tuple[int, int, int]]]],
         uniform_law: bool = True,
     ):
         self.base_rcpsp_model = base_rcpsp_model
         self.poisson_laws = poisson_laws
-        self.probas: Dict[Hashable, Dict[int, Dict[str, Dict[str, Any]]]] = {}
+        self.probas: dict[Hashable, dict[int, dict[str, dict[str, Any]]]] = {}
         for activity in poisson_laws:
             self.probas[activity] = {}
             for mode in poisson_laws[activity]:

--- a/discrete_optimization/rcpsp/sgs_without_array.py
+++ b/discrete_optimization/rcpsp/sgs_without_array.py
@@ -2,8 +2,9 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
+from collections.abc import Hashable
 from copy import deepcopy
-from typing import Dict, Hashable, Optional, Tuple
+from typing import Optional
 
 import numpy as np
 from numpy import typing as npt
@@ -16,7 +17,7 @@ from discrete_optimization.rcpsp.rcpsp_solution import RCPSPSolution
 class SGSWithoutArray:
     def __init__(self, rcpsp_model: RCPSPModel):
         self.rcpsp_model = rcpsp_model
-        self.resource_avail_in_time: Dict[str, npt.NDArray[np.int_]] = {}
+        self.resource_avail_in_time: dict[str, npt.NDArray[np.int_]] = {}
         for res in self.rcpsp_model.resources_list:
             if self.rcpsp_model.is_varying_resource():
                 self.resource_avail_in_time[res] = np.array(
@@ -28,7 +29,7 @@ class SGSWithoutArray:
                     self.rcpsp_model.resources[res],
                     dtype=np.int_,
                 )
-        self.dict_step_ressource: Dict[str, SortedDict] = {}
+        self.dict_step_ressource: dict[str, SortedDict] = {}
         for res in self.resource_avail_in_time:
             self.dict_step_ressource[res] = SGSWithoutArray.create_absolute_dict(
                 self.resource_avail_in_time[res]
@@ -107,7 +108,7 @@ class SGSWithoutArray:
 
     def generate_schedule_from_permutation_serial_sgs(
         self, solution: RCPSPSolution, rcpsp_problem: RCPSPModel
-    ) -> Tuple[Dict[Hashable, Dict[str, int]], bool, Dict[str, SortedDict]]:
+    ) -> tuple[dict[Hashable, dict[str, int]], bool, dict[str, SortedDict]]:
         activity_end_times = {}
         unfeasible_non_renewable_resources = False
         new_horizon = rcpsp_problem.horizon
@@ -228,7 +229,7 @@ class SGSWithoutArray:
                     minimum_starting_time[s] = max(
                         minimum_starting_time[s], activity_end_times[act_id]
                     )
-        rcpsp_schedule: Dict[Hashable, Dict[str, int]] = {}
+        rcpsp_schedule: dict[Hashable, dict[str, int]] = {}
         for act_id in activity_end_times:
             rcpsp_schedule[act_id] = {}
             rcpsp_schedule[act_id]["start_time"] = (

--- a/discrete_optimization/rcpsp/solver/cp_solvers.py
+++ b/discrete_optimization/rcpsp/solver/cp_solvers.py
@@ -5,8 +5,9 @@
 import json
 import logging
 import os
+from collections.abc import Hashable
 from datetime import timedelta
-from typing import Any, Dict, Hashable, List, Optional, Set, Tuple, Union
+from typing import Any, Optional, Union
 
 from deprecation import deprecated
 from minizinc import Instance, Model, Solver
@@ -143,7 +144,7 @@ class CP_RCPSP_MZN(MinizincCPSolver, SolverRCPSP):
             "s"
         ]  # For now, I've put the var name of the CP model (not the rcpsp_model)
         self.stats = []
-        self.keys_in_instance: Optional[List[str]] = None
+        self.keys_in_instance: Optional[list[str]] = None
 
     def init_model(self, **args):
         model_type = args.get("model_type", "single")
@@ -250,7 +251,7 @@ class CP_RCPSP_MZN(MinizincCPSolver, SolverRCPSP):
         s = "constraint (s[" + str(ind) + "]+d[" + str(ind) + "]==objective);\n"
         return [s]
 
-    def constraint_sum_of_ending_time(self, set_subtasks: Set[Hashable]):
+    def constraint_sum_of_ending_time(self, set_subtasks: set[Hashable]):
         indexes = [self.index_in_minizinc[s] for s in set_subtasks]
         s = (
             """int: nb_indexes="""
@@ -263,7 +264,7 @@ class CP_RCPSP_MZN(MinizincCPSolver, SolverRCPSP):
         )
         return [s]
 
-    def constraint_sum_of_starting_time(self, set_subtasks: Set[Hashable]):
+    def constraint_sum_of_starting_time(self, set_subtasks: set[Hashable]):
         indexes = [self.index_in_minizinc[s] for s in set_subtasks]
         s = (
             """int: nb_indexes="""
@@ -371,14 +372,14 @@ class CP_MRCPSP_MZN(MinizincCPSolver, SolverRCPSP):
             "mrun",
         ]  # For now, I've put the var names of the CP model (not the rcpsp_model)
         self.calendar = self.problem.is_varying_resource()
-        self.keys_in_instance: Optional[List[str]] = None
+        self.keys_in_instance: Optional[list[str]] = None
 
         # Utility objects to map minizinc vars and do vars.
-        self.modeindex_map: Optional[Dict[int, Dict[str, Any]]] = None
+        self.modeindex_map: Optional[dict[int, dict[str, Any]]] = None
         self.mode_dict_task_mode_to_index_minizinc: Optional[
-            Dict[Tuple[Hashable, int], int]
+            dict[tuple[Hashable, int], int]
         ] = None
-        self.index_in_minizinc: Optional[Dict[Hashable, int]] = None
+        self.index_in_minizinc: Optional[dict[Hashable, int]] = None
 
     def init_model(self, **args):
         model_type = args.get("model_type", "multi")
@@ -544,7 +545,7 @@ class CP_MRCPSP_MZN(MinizincCPSolver, SolverRCPSP):
             ]
         return s
 
-    def constraint_sum_of_ending_time(self, set_subtasks: Set[Hashable]):
+    def constraint_sum_of_ending_time(self, set_subtasks: set[Hashable]):
         indexes = [self.index_in_minizinc[s] for s in set_subtasks]
         s = (
             """int: nb_indexes="""
@@ -557,7 +558,7 @@ class CP_MRCPSP_MZN(MinizincCPSolver, SolverRCPSP):
         )
         return [s]
 
-    def constraint_sum_of_starting_time(self, set_subtasks: Set[Hashable]):
+    def constraint_sum_of_starting_time(self, set_subtasks: set[Hashable]):
         indexes = [self.index_in_minizinc[s] for s in set_subtasks]
         s = (
             """int: nb_indexes="""
@@ -814,7 +815,7 @@ class CP_MRCPSP_MZN_WITH_FAKE_TASK(CP_MRCPSP_MZN):
             ]
         return s
 
-    def constraint_sum_of_ending_time(self, set_subtasks: Set[Hashable]):
+    def constraint_sum_of_ending_time(self, set_subtasks: set[Hashable]):
         indexes = [self.index_in_minizinc[s] for s in set_subtasks]
         s = (
             """int: nb_indexes="""
@@ -827,7 +828,7 @@ class CP_MRCPSP_MZN_WITH_FAKE_TASK(CP_MRCPSP_MZN):
         )
         return [s]
 
-    def constraint_sum_of_starting_time(self, set_subtasks: Set[Hashable]):
+    def constraint_sum_of_starting_time(self, set_subtasks: set[Hashable]):
         indexes = [self.index_in_minizinc[s] for s in set_subtasks]
         s = (
             """int: nb_indexes="""
@@ -867,11 +868,11 @@ class CP_MRCPSP_MZN_PREEMPTIVE(MinizincCPSolver, SolverRCPSP):
         self.nb_preemptive = None
 
         # Utility objects to map minizinc vars and do vars.
-        self.modeindex_map: Optional[Dict[int, Dict[str, Any]]] = None
+        self.modeindex_map: Optional[dict[int, dict[str, Any]]] = None
         self.mode_dict_task_mode_to_index_minizinc: Optional[
-            Dict[Tuple[Hashable, int], int]
+            dict[tuple[Hashable, int], int]
         ] = None
-        self.index_in_minizinc: Optional[Dict[Hashable, int]] = None
+        self.index_in_minizinc: Optional[dict[Hashable, int]] = None
 
     def init_model(self, **args):
         model_type = args.get("model_type", "multi-preemptive")
@@ -1237,7 +1238,7 @@ class CP_MRCPSP_MZN_PREEMPTIVE(MinizincCPSolver, SolverRCPSP):
         )
         return [s]
 
-    def constraint_sum_of_ending_time(self, set_subtasks: Set[Hashable]):
+    def constraint_sum_of_ending_time(self, set_subtasks: set[Hashable]):
         indexes = [self.index_in_minizinc[s] for s in set_subtasks]
         weights = [10 if s == self.problem.sink_task else 1 for s in set_subtasks]
         s = (
@@ -1254,7 +1255,7 @@ class CP_MRCPSP_MZN_PREEMPTIVE(MinizincCPSolver, SolverRCPSP):
         )
         return [s]
 
-    def constraint_sum_of_starting_time(self, set_subtasks: Set[Hashable]):
+    def constraint_sum_of_starting_time(self, set_subtasks: set[Hashable]):
         indexes = [self.index_in_minizinc[s] for s in set_subtasks]
         weights = [10 if s == self.problem.sink_task else 1 for s in set_subtasks]
 
@@ -1492,7 +1493,7 @@ class CP_MRCPSP_MZN_NOBOOL(MinizincCPSolver, SolverRCPSP):
         if self.problem.is_varying_resource():
             self.calendar = True
 
-        self.index_in_minizinc: Optional[Dict[Hashable, int]] = None
+        self.index_in_minizinc: Optional[dict[Hashable, int]] = None
 
     def init_model(self, **args):
         add_objective_makespan = args.get("add_objective_makespan", True)
@@ -1917,7 +1918,7 @@ def precompute_possible_starting_time_interval(problem: RCPSPModelPreemptive):
 
 
 def hard_start_times(
-    dict_start_times: Dict[Hashable, int],
+    dict_start_times: dict[Hashable, int],
     cp_solver: Union[CP_RCPSP_MZN_PREEMPTIVE, CP_MRCPSP_MZN_PREEMPTIVE, CP_RCPSP_MZN],
 ):
     constraint_strings = []
@@ -1934,7 +1935,7 @@ def hard_start_times(
 
 
 def soft_start_times(
-    dict_start_times: Dict[Hashable, int],
+    dict_start_times: dict[Hashable, int],
     cp_solver: Union[CP_RCPSP_MZN_PREEMPTIVE, CP_MRCPSP_MZN_PREEMPTIVE, CP_RCPSP_MZN],
 ):
     list_task = list(dict_start_times.keys())
@@ -1959,7 +1960,7 @@ def soft_start_times(
 
 
 def hard_start_times_mrcpsp(
-    dict_start_times: Dict[Hashable, int],
+    dict_start_times: dict[Hashable, int],
     cp_solver: Union[CP_MRCPSP_MZN, CP_MRCPSP_MZN_WITH_FAKE_TASK, CP_MRCPSP_MZN_NOBOOL],
 ):
     constraint_strings = []
@@ -1976,7 +1977,7 @@ def hard_start_times_mrcpsp(
 
 
 def soft_start_times_mrcpsp(
-    dict_start_times: Dict[Hashable, int],
+    dict_start_times: dict[Hashable, int],
     cp_solver: Union[CP_MRCPSP_MZN, CP_MRCPSP_MZN_WITH_FAKE_TASK, CP_MRCPSP_MZN_NOBOOL],
 ):
     list_task = list(dict_start_times.keys())
@@ -2001,7 +2002,7 @@ def soft_start_times_mrcpsp(
 
 
 def soft_start_together_mrcpsp(
-    list_start_together: List[Tuple[Hashable, Hashable]],
+    list_start_together: list[tuple[Hashable, Hashable]],
     cp_solver: Union[CP_MRCPSP_MZN, CP_MRCPSP_MZN_WITH_FAKE_TASK, CP_MRCPSP_MZN_NOBOOL],
 ):
     s = (
@@ -2026,7 +2027,7 @@ def soft_start_together_mrcpsp(
 
 
 def hard_start_together_mrcpsp(
-    list_start_together: List[Tuple[Hashable, Hashable]],
+    list_start_together: list[tuple[Hashable, Hashable]],
     cp_solver: Union[CP_MRCPSP_MZN, CP_MRCPSP_MZN_WITH_FAKE_TASK, CP_MRCPSP_MZN_NOBOOL],
 ):
     constraint_strings = []
@@ -2043,7 +2044,7 @@ def hard_start_together_mrcpsp(
 
 
 def soft_start_together(
-    list_start_together: List[Tuple[Hashable, Hashable]],
+    list_start_together: list[tuple[Hashable, Hashable]],
     cp_solver: Union[CP_RCPSP_MZN_PREEMPTIVE, CP_MRCPSP_MZN_PREEMPTIVE, CP_RCPSP_MZN],
 ):
     s = (
@@ -2068,7 +2069,7 @@ def soft_start_together(
 
 
 def hard_start_together(
-    list_start_together: List[Tuple[Hashable, Hashable]],
+    list_start_together: list[tuple[Hashable, Hashable]],
     cp_solver: Union[CP_RCPSP_MZN_PREEMPTIVE, CP_MRCPSP_MZN_PREEMPTIVE, CP_RCPSP_MZN],
 ):
     constraint_strings = []
@@ -2085,7 +2086,7 @@ def hard_start_together(
 
 
 def hard_start_after_nunit(
-    list_start_after_nunit: List[Tuple[Hashable, Hashable, int]],
+    list_start_after_nunit: list[tuple[Hashable, Hashable, int]],
     cp_solver: Union[CP_RCPSP_MZN_PREEMPTIVE, CP_MRCPSP_MZN_PREEMPTIVE, CP_RCPSP_MZN],
 ):
     constraint_strings = []
@@ -2104,7 +2105,7 @@ def hard_start_after_nunit(
 
 
 def soft_start_after_nunit(
-    list_start_after_nunit: List[Tuple[Hashable, Hashable, int]],
+    list_start_after_nunit: list[tuple[Hashable, Hashable, int]],
     cp_solver: Union[CP_RCPSP_MZN_PREEMPTIVE, CP_MRCPSP_MZN_PREEMPTIVE, CP_RCPSP_MZN],
 ):
     s = (
@@ -2143,7 +2144,7 @@ def soft_start_after_nunit(
 
 
 def hard_start_after_nunit_mrcpsp(
-    list_start_after_nunit: List[Tuple[Hashable, Hashable, int]],
+    list_start_after_nunit: list[tuple[Hashable, Hashable, int]],
     cp_solver: Union[CP_MRCPSP_MZN, CP_MRCPSP_MZN_WITH_FAKE_TASK, CP_MRCPSP_MZN_NOBOOL],
 ):
     constraint_strings = []
@@ -2162,7 +2163,7 @@ def hard_start_after_nunit_mrcpsp(
 
 
 def soft_start_after_nunit_mrcpsp(
-    list_start_after_nunit: List[Tuple[Hashable, Hashable, int]],
+    list_start_after_nunit: list[tuple[Hashable, Hashable, int]],
     cp_solver: Union[CP_MRCPSP_MZN, CP_MRCPSP_MZN_WITH_FAKE_TASK, CP_MRCPSP_MZN_NOBOOL],
 ):
     s = (
@@ -2254,7 +2255,7 @@ def hard_start_at_end_plus_offset(
 
 
 def soft_start_at_end_plus_offset_mrcpsp(
-    list_start_at_end_plus_offset: List[Tuple[Hashable, Hashable, int]],
+    list_start_at_end_plus_offset: list[tuple[Hashable, Hashable, int]],
     cp_solver: Union[CP_MRCPSP_MZN, CP_MRCPSP_MZN_WITH_FAKE_TASK, CP_MRCPSP_MZN_NOBOOL],
 ):
     s = (
@@ -2293,7 +2294,7 @@ def soft_start_at_end_plus_offset_mrcpsp(
 
 
 def soft_start_at_end_plus_offset(
-    list_start_at_end_plus_offset: List[Tuple[Hashable, Hashable, int]],
+    list_start_at_end_plus_offset: list[tuple[Hashable, Hashable, int]],
     cp_solver: Union[CP_RCPSP_MZN_PREEMPTIVE, CP_MRCPSP_MZN_PREEMPTIVE, CP_RCPSP_MZN],
 ):
     s = (
@@ -2337,7 +2338,7 @@ def soft_start_at_end_plus_offset(
 
 
 def hard_start_at_end_mrcpsp(
-    list_start_at_end: List[Tuple[Hashable, Hashable]],
+    list_start_at_end: list[tuple[Hashable, Hashable]],
     cp_solver: Union[CP_MRCPSP_MZN, CP_MRCPSP_MZN_WITH_FAKE_TASK, CP_MRCPSP_MZN_NOBOOL],
 ):
     constraint_strings = []
@@ -2356,7 +2357,7 @@ def hard_start_at_end_mrcpsp(
 
 
 def soft_start_at_end_mrcpsp(
-    list_start_at_end: List[Tuple[Hashable, Hashable]],
+    list_start_at_end: list[tuple[Hashable, Hashable]],
     cp_solver: Union[CP_MRCPSP_MZN, CP_MRCPSP_MZN_WITH_FAKE_TASK, CP_MRCPSP_MZN_NOBOOL],
 ):
     s = (
@@ -2381,7 +2382,7 @@ def soft_start_at_end_mrcpsp(
 
 
 def hard_start_at_end(
-    list_start_at_end: List[Tuple[Hashable, Hashable]],
+    list_start_at_end: list[tuple[Hashable, Hashable]],
     cp_solver: Union[CP_RCPSP_MZN, CP_MRCPSP_MZN_PREEMPTIVE, CP_RCPSP_MZN_PREEMPTIVE],
 ):
     constraint_strings = []
@@ -2409,7 +2410,7 @@ def hard_start_at_end(
 
 
 def soft_start_at_end(
-    list_start_at_end: List[Tuple[Hashable, Hashable]],
+    list_start_at_end: list[tuple[Hashable, Hashable]],
     cp_solver: Union[CP_RCPSP_MZN, CP_MRCPSP_MZN_PREEMPTIVE, CP_RCPSP_MZN_PREEMPTIVE],
 ):
     s = (
@@ -2441,7 +2442,7 @@ def soft_start_at_end(
 
 
 def soft_start_window(
-    start_times_window: Dict[Hashable, Tuple[int, int]],
+    start_times_window: dict[Hashable, tuple[int, int]],
     cp_solver: Union[CP_RCPSP_MZN, CP_MRCPSP_MZN_PREEMPTIVE, CP_RCPSP_MZN_PREEMPTIVE],
 ):
     l_low = [
@@ -2491,7 +2492,7 @@ def soft_start_window(
 
 
 def soft_end_window(
-    end_times_window: Dict[Hashable, Tuple[int, int]],
+    end_times_window: dict[Hashable, tuple[int, int]],
     cp_solver: Union[CP_RCPSP_MZN, CP_MRCPSP_MZN_PREEMPTIVE, CP_RCPSP_MZN_PREEMPTIVE],
 ):
     l_low = [
@@ -2548,7 +2549,7 @@ def soft_end_window(
 
 
 def soft_start_window_mrcpsp(
-    start_times_window: Dict[Hashable, Tuple[int, int]],
+    start_times_window: dict[Hashable, tuple[int, int]],
     cp_solver: Union[CP_MRCPSP_MZN, CP_MRCPSP_MZN_WITH_FAKE_TASK, CP_MRCPSP_MZN_NOBOOL],
 ):
     l_low = [
@@ -2598,7 +2599,7 @@ def soft_start_window_mrcpsp(
 
 
 def soft_end_window_mrcpsp(
-    end_times_window: Dict[Hashable, Tuple[int, int]],
+    end_times_window: dict[Hashable, tuple[int, int]],
     cp_solver: Union[CP_MRCPSP_MZN, CP_MRCPSP_MZN_WITH_FAKE_TASK, CP_MRCPSP_MZN_NOBOOL],
 ):
     l_low = [
@@ -2648,7 +2649,7 @@ def soft_end_window_mrcpsp(
 
 
 def hard_start_window(
-    start_times_window: Dict[Hashable, Tuple[int, int]],
+    start_times_window: dict[Hashable, tuple[int, int]],
     cp_solver: Union[
         CP_RCPSP_MZN,
         CP_MRCPSP_MZN_PREEMPTIVE,
@@ -2676,7 +2677,7 @@ def hard_start_window(
 
 
 def hard_end_window(
-    end_times_window: Dict[Hashable, Tuple[int, int]],
+    end_times_window: dict[Hashable, tuple[int, int]],
     cp_solver: Union[
         CP_RCPSP_MZN,
         CP_MRCPSP_MZN_PREEMPTIVE,

--- a/discrete_optimization/rcpsp/solver/cpm.py
+++ b/discrete_optimization/rcpsp/solver/cpm.py
@@ -4,7 +4,7 @@
 
 import logging
 from heapq import heappop, heappush
-from typing import Any, Dict, List
+from typing import Any
 
 import networkx as nx
 import numpy as np
@@ -60,7 +60,7 @@ class CPM(SolverRCPSP):
         self.graph_nx = self.graph.to_networkx()
         self.source = problem.source_task
         self.sink = problem.sink_task
-        self.map_node: Dict[Any, CPMObject] = {
+        self.map_node: dict[Any, CPMObject] = {
             n: CPMObject(None, None, None, None) for n in self.graph_nx.nodes()
         }
         successors = {
@@ -172,9 +172,9 @@ class CPM(SolverRCPSP):
 
     def run_sgs_on_order(
         self,
-        map_nodes: Dict[Any, CPMObject],
-        critical_path: List[Any],
-        total_order: List[Any] = None,
+        map_nodes: dict[Any, CPMObject],
+        critical_path: list[Any],
+        total_order: list[Any] = None,
         cut_sgs_by_critical=True,
     ):
         if total_order is None:
@@ -377,9 +377,9 @@ class CPM(SolverRCPSP):
 
     def run_sgs_time_loop(
         self,
-        map_nodes: Dict[Any, CPMObject],
-        critical_path: List[Any],
-        total_order: List[Any] = None,
+        map_nodes: dict[Any, CPMObject],
+        critical_path: list[Any],
+        total_order: list[Any] = None,
     ):
         if total_order is None:
             total_order = self.return_order_cpm()
@@ -564,7 +564,7 @@ def run_partial_classic_cpm(partial_schedule, cpm_solver):
         }
         for k in cpm_solver.predecessors_map
     }
-    map_node: Dict[Any, CPMObject] = {
+    map_node: dict[Any, CPMObject] = {
         n: CPMObject(None, None, None, None) for n in cpm_solver.graph_nx.nodes()
     }
     forward = True

--- a/discrete_optimization/rcpsp/solver/cpsat_solver.py
+++ b/discrete_optimization/rcpsp/solver/cpsat_solver.py
@@ -5,7 +5,8 @@
 #  Note : Model could most likely be improved with
 #  https://github.com/google/or-tools/blob/stable/examples/python/rcpsp_sat.py
 import logging
-from typing import Any, Dict, Hashable, Iterable, List, Optional, Set, Tuple
+from collections.abc import Hashable, Iterable
+from typing import Any, Optional
 
 from ortools.sat.python.cp_model import (
     Constraint,
@@ -54,17 +55,17 @@ class CPSatRCPSPSolver(OrtoolsCPSatSolver, SolverRCPSP, WarmstartMixin):
         )
         self.cp_model: Optional[CpModel] = None
         self.cp_solver: Optional[CpSolver] = None
-        self.variables: Optional[Dict[str, Any]] = None
+        self.variables: Optional[dict[str, Any]] = None
         self.status_solver: Optional[StatusSolver] = None
 
     def init_temporal_variable(
         self, model: CpModel
-    ) -> Tuple[
-        Dict[Hashable, IntVar],
-        Dict[Hashable, IntVar],
-        Dict[Tuple[Hashable, int], IntVar],
-        Dict[Tuple[Hashable, int], IntervalVar],
-        Dict[Hashable, Set[Tuple[Hashable, int]]],
+    ) -> tuple[
+        dict[Hashable, IntVar],
+        dict[Hashable, IntVar],
+        dict[tuple[Hashable, int], IntVar],
+        dict[tuple[Hashable, int], IntervalVar],
+        dict[Hashable, set[tuple[Hashable, int]]],
     ]:
         starts_var = {}
         ends_var = {}
@@ -99,8 +100,8 @@ class CPSatRCPSPSolver(OrtoolsCPSatSolver, SolverRCPSP, WarmstartMixin):
     def add_classical_precedence_constraints(
         self,
         model: CpModel,
-        starts_var: Dict[Hashable, IntVar],
-        ends_var: Dict[Hashable, IntVar],
+        starts_var: dict[Hashable, IntVar],
+        ends_var: dict[Hashable, IntVar],
     ):
         # Precedence constraints
         for task in self.problem.successors:
@@ -110,20 +111,20 @@ class CPSatRCPSPSolver(OrtoolsCPSatSolver, SolverRCPSP, WarmstartMixin):
     def add_one_mode_selected_per_task(
         self,
         model: CpModel,
-        is_present_var: Dict[Tuple[Hashable, int], IntVar],
-        interval_per_tasks: Dict[Hashable, Set[Tuple[Hashable, int]]],
+        is_present_var: dict[tuple[Hashable, int], IntVar],
+        interval_per_tasks: dict[Hashable, set[tuple[Hashable, int]]],
     ):
         # 1 mode selected
         for task in interval_per_tasks:
             model.AddExactlyOne([is_present_var[k] for k in interval_per_tasks[task]])
 
-    def create_fake_tasks(self) -> List[Dict[str, int]]:
+    def create_fake_tasks(self) -> list[dict[str, int]]:
         """
         Create tasks representing the variable resource availability.
         :return:
         """
         if self.problem.is_calendar:
-            fake_task: List[Dict[str, int]] = create_fake_tasks(
+            fake_task: list[dict[str, int]] = create_fake_tasks(
                 rcpsp_problem=self.problem
             )
         else:
@@ -134,9 +135,9 @@ class CPSatRCPSPSolver(OrtoolsCPSatSolver, SolverRCPSP, WarmstartMixin):
         self,
         model: CpModel,
         resource: str,
-        interval_var: Dict[Tuple[Hashable, int], IntervalVar],
-        is_present_var: Dict[Tuple[Hashable, int], IntVar],
-        fake_task: List[Dict[str, int]],
+        interval_var: dict[tuple[Hashable, int], IntervalVar],
+        is_present_var: dict[tuple[Hashable, int], IntVar],
+        fake_task: list[dict[str, int]],
     ):
         if resource in self.problem.non_renewable_resources:
             task_modes_consuming = [
@@ -190,8 +191,8 @@ class CPSatRCPSPSolver(OrtoolsCPSatSolver, SolverRCPSP, WarmstartMixin):
     def create_mode_pair_constraint(
         self,
         model: CpModel,
-        interval_per_tasks: Dict[Hashable, Set[Tuple[Hashable, int]]],
-        is_present_var: Dict[Tuple[Hashable, int], IntVar],
+        interval_per_tasks: dict[Hashable, set[tuple[Hashable, int]]],
+        is_present_var: dict[tuple[Hashable, int], IntVar],
         pair_mode_constraint: PairModeConstraint,
     ):
         if pair_mode_constraint.allowed_mode_assignment is not None:
@@ -340,10 +341,10 @@ class CPSatRCPSPSolverResource(CPSatRCPSPSolver):
         self,
         model: CpModel,
         resource: str,
-        is_used_resource: Dict[str, IntVar],
-        interval_var: Dict[Tuple[Hashable, int], IntervalVar],
-        is_present_var: Dict[Tuple[Hashable, int], IntVar],
-        fake_task: List[Dict[str, int]],
+        is_used_resource: dict[str, IntVar],
+        interval_var: dict[tuple[Hashable, int], IntervalVar],
+        is_present_var: dict[tuple[Hashable, int], IntVar],
+        fake_task: list[dict[str, int]],
     ):
         if resource in self.problem.non_renewable_resources:
             task_modes_consuming = [
@@ -516,7 +517,7 @@ class CPSatRCPSPSolverResource(CPSatRCPSPSolver):
         }
         return sol
 
-    def get_model_objectives_available(self) -> List[str]:
+    def get_model_objectives_available(self) -> list[str]:
         return ["makespan", "used_resource"]
 
     def get_model_objective_value(self, obj: str, res: ResultStorage) -> float:
@@ -552,10 +553,10 @@ class CPSatRCPSPSolverCumulativeResource(CPSatRCPSPSolver):
         self,
         model: CpModel,
         resource: str,
-        resource_capacity_var: Dict[str, IntVar],
-        interval_var: Dict[Tuple[Hashable, int], IntervalVar],
-        is_present_var: Dict[Tuple[Hashable, int], IntVar],
-        fake_task: List[Dict[str, int]],
+        resource_capacity_var: dict[str, IntVar],
+        interval_var: dict[tuple[Hashable, int], IntervalVar],
+        is_present_var: dict[tuple[Hashable, int], IntVar],
+        fake_task: list[dict[str, int]],
         use_overlap_for_disjunctive_resource: bool,
     ):
         if resource in self.problem.non_renewable_resources:
@@ -744,7 +745,7 @@ class CPSatRCPSPSolverCumulativeResource(CPSatRCPSPSolver):
         }
         return sol
 
-    def get_model_objectives_available(self) -> List[str]:
+    def get_model_objectives_available(self) -> list[str]:
         return ["makespan", "used_resource"]
 
     def get_model_objective_value(self, obj: str, res: ResultStorage) -> float:

--- a/discrete_optimization/rcpsp/solver/rcpsp_lp_lns_solver.py
+++ b/discrete_optimization/rcpsp/solver/rcpsp_lp_lns_solver.py
@@ -4,8 +4,9 @@
 
 import logging
 import random
+from collections.abc import Iterable
 from enum import Enum
-from typing import Any, Iterable, List, Optional
+from typing import Any, Optional
 
 import mip
 import numpy as np
@@ -449,7 +450,7 @@ class LNS_LP_RCPSP_SOLVER(SolverRCPSP):
 
     def solve(
         self,
-        callbacks: Optional[List[Callback]] = None,
+        callbacks: Optional[list[Callback]] = None,
         time_limit_subsolver: Optional[float] = 30.0,
         time_limit_subsolver_iter0: Optional[float] = None,
         **kwargs

--- a/discrete_optimization/rcpsp/solver/rcpsp_lp_solver.py
+++ b/discrete_optimization/rcpsp/solver/rcpsp_lp_solver.py
@@ -3,8 +3,9 @@
 #  LICENSE file in the root directory of this source tree.
 
 import logging
+from collections.abc import Callable, Hashable
 from itertools import product
-from typing import Any, Callable, Dict, Hashable, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 from mip import BINARY, INTEGER, MINIMIZE, Model, Var, xsum
 
@@ -126,7 +127,7 @@ class LP_RCPSP(PymipMilpSolver, SolverRCPSP):
         # we have a better self.T to limit the number of variables :
         self.index_time = range(int(makespan + 1))
         self.model = Model(sense=MINIMIZE, solver_name=self.solver_name)
-        self.x: List[List[Var]] = [
+        self.x: list[list[Var]] = [
             [
                 self.model.add_var(name=f"x({task},{t})", var_type=BINARY)
                 for t in self.index_time
@@ -300,7 +301,7 @@ class LP_RCPSP(PymipMilpSolver, SolverRCPSP):
 
 class _BaseLP_MRCPSP(MilpSolver, SolverRCPSP):
     problem: RCPSPModel
-    x: Dict[Tuple[Hashable, int, int], Any]
+    x: dict[tuple[Hashable, int, int], Any]
     hyperparameters = [
         CategoricalHyperparameter(
             name="greedy_start", choices=[True, False], default=True
@@ -325,7 +326,7 @@ class _BaseLP_MRCPSP(MilpSolver, SolverRCPSP):
         get_obj_value_for_current_solution: Callable[[], float],
     ) -> RCPSPSolution:
         rcpsp_schedule = {}
-        modes: Dict[Hashable, Union[str, int]] = {}
+        modes: dict[Hashable, Union[str, int]] = {}
         for (task, mode, t), x in self.x.items():
             value = get_var_value_for_current_solution(x)
             if value >= 0.5:
@@ -421,7 +422,7 @@ class LP_MRCPSP(PymipMilpSolver, _BaseLP_MRCPSP):
         if self.start_solution.rcpsp_schedule_feasible:
             self.index_time = range(int(makespan + 1))
         self.model = Model(sense=MINIMIZE, solver_name=self.solver_name)
-        self.x: Dict[Tuple[Hashable, int, int], Var] = {}
+        self.x: dict[tuple[Hashable, int, int], Var] = {}
         last_task = self.problem.sink_task
         variable_per_task = {}
         for task in sorted_tasks:
@@ -650,7 +651,7 @@ class LP_MRCPSP_GUROBI(GurobiMilpSolver, _BaseLP_MRCPSP, WarmstartMixin):
         if max_horizon is not None:
             self.index_time = list(range(max_horizon + 1))
         self.model = gurobi.Model("MRCPSP")
-        self.x: Dict[Tuple[Hashable, int, int], gurobi.Var] = {}
+        self.x: dict[tuple[Hashable, int, int], gurobi.Var] = {}
         last_task = self.problem.sink_task
         variable_per_task = {}
         keys_for_t = {}
@@ -906,7 +907,7 @@ class LP_RCPSP_CPLEX(CplexMilpSolver, _BaseLP_MRCPSP):
         if max_horizon is not None:
             self.index_time = list(range(max_horizon + 1))
         self.model: "cplex.Model" = cplex.Model("MRCPSP")
-        self.x: Dict[Tuple[Hashable, int, int], "cplex_var.Var"] = {}
+        self.x: dict[tuple[Hashable, int, int], "cplex_var.Var"] = {}
         last_task = self.problem.sink_task
         variable_per_task = {}
         keys_for_t = {}

--- a/discrete_optimization/rcpsp/solver/rcpsp_lp_solver_gantt.py
+++ b/discrete_optimization/rcpsp/solver/rcpsp_lp_solver_gantt.py
@@ -4,7 +4,8 @@
 
 import logging
 import random
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
+from collections.abc import Callable
+from typing import Any, Optional, Union
 
 import networkx as nx
 from mip import BINARY, MINIMIZE, Model, xsum
@@ -46,7 +47,7 @@ def intersect(i1, i2):
 
 
 class ConstraintTaskIndividual:
-    list_tuple: List[Tuple[str, int, int, bool]]
+    list_tuple: list[tuple[str, int, int, bool]]
     # task, resource, resource_individual, has or has not to do a task
     # indicates constraint for a given resource individual that has to do a task
 
@@ -57,7 +58,7 @@ class ConstraintTaskIndividual:
 class ConstraintWorkDuration:
     ressource: str
     individual: int
-    time_bounds: Tuple[int, int]
+    time_bounds: tuple[int, int]
     working_time_upper_bound: int
 
     def __init__(self, ressource, individual, time_bounds, working_time_upper_bound):
@@ -131,7 +132,7 @@ class _Base_LP_MRCPSP_GANTT(MilpSolver, SolverRCPSP):
         self,
         get_var_value_for_current_solution: Callable[[Any], float],
         get_obj_value_for_current_solution: Callable[[], float],
-    ) -> Tuple[Dict[Any, Dict[Any, Dict[Any, Any]]], float]:
+    ) -> tuple[dict[Any, dict[Any, dict[Any, Any]]], float]:
         objective = get_obj_value_for_current_solution()
         resource_id_usage = {
             k: {
@@ -409,7 +410,7 @@ class LP_MRCPSP_GANTT_GUROBI(GurobiMilpSolver, _Base_LP_MRCPSP_GANTT):
         self,
         get_var_value_for_current_solution: Callable[[Any], float],
         get_obj_value_for_current_solution: Callable[[], float],
-    ) -> Tuple[Dict[Any, Dict[Any, Dict[Any, Any]]], float]:
+    ) -> tuple[dict[Any, dict[Any, dict[Any, Any]]], float]:
         objective = get_obj_value_for_current_solution()
         resource_id_usage = {
             k: {
@@ -427,8 +428,8 @@ class LP_MRCPSP_GANTT_GUROBI(GurobiMilpSolver, _Base_LP_MRCPSP_GANTT):
 
     def build_objective_function_from_a_solution(
         self,
-        ressource_usage: Dict[str, Dict[int, Dict[int, bool]]],
-        ignore_tuple: Set[Tuple[str, int, int]] = None,
+        ressource_usage: dict[str, dict[int, dict[int, bool]]],
+        ignore_tuple: set[tuple[str, int, int]] = None,
     ):
         objective = gurobi.LinExpr(0.0)
         if ignore_tuple is None:

--- a/discrete_optimization/rcpsp/solver/rcpsp_pile.py
+++ b/discrete_optimization/rcpsp/solver/rcpsp_pile.py
@@ -6,7 +6,7 @@ import logging
 import random
 from enum import Enum
 from heapq import heappop, heappush
-from typing import Dict, List, Optional
+from typing import Optional
 
 import networkx as nx
 import numpy as np
@@ -493,7 +493,7 @@ class Executor(PileSolverRCPSP):
         self.resources = rcpsp_model.resources
 
     def compute_schedule_from_priority_list(
-        self, permutation_jobs: List[int], modes_dict: Dict[int, int]
+        self, permutation_jobs: list[int], modes_dict: dict[int, int]
     ):
         current_pred = {
             k: {

--- a/discrete_optimization/rcpsp/special_constraints.py
+++ b/discrete_optimization/rcpsp/special_constraints.py
@@ -2,7 +2,8 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Dict, Hashable, List, Optional, Set, Tuple, Union
+from collections.abc import Hashable
+from typing import Optional, Union
 
 import networkx as nx
 
@@ -24,10 +25,10 @@ class PairModeConstraint:
     def __init__(
         self,
         allowed_mode_assignment: Optional[
-            Dict[Tuple[Hashable, Hashable], Set[Tuple[int, int]]]
+            dict[tuple[Hashable, Hashable], set[tuple[int, int]]]
         ] = None,
-        same_score_mode: Optional[Set[Tuple[Hashable, Hashable]]] = None,
-        score_mode: Dict[Tuple[Hashable, int], int] = None,
+        same_score_mode: Optional[set[tuple[Hashable, Hashable]]] = None,
+        score_mode: dict[tuple[Hashable, int], int] = None,
     ):
         self.allowed_mode_assignment = allowed_mode_assignment
         self.same_score_mode = same_score_mode
@@ -42,22 +43,22 @@ class PairModeConstraint:
 class SpecialConstraintsDescription:
     def __init__(
         self,
-        task_mode: Optional[Dict[Hashable, int]] = None,
-        start_times: Optional[Dict[Hashable, int]] = None,
-        end_times: Optional[Dict[Hashable, int]] = None,
+        task_mode: Optional[dict[Hashable, int]] = None,
+        start_times: Optional[dict[Hashable, int]] = None,
+        end_times: Optional[dict[Hashable, int]] = None,
         start_times_window: Optional[
-            Dict[Hashable, Tuple[Union[int, None], Union[int, None]]]
+            dict[Hashable, tuple[Union[int, None], Union[int, None]]]
         ] = None,
         end_times_window: Optional[
-            Dict[Hashable, Tuple[Union[int, None], Union[int, None]]]
+            dict[Hashable, tuple[Union[int, None], Union[int, None]]]
         ] = None,
-        partial_permutation: Optional[List[Hashable]] = None,
-        list_partial_order: Optional[List[List[Hashable]]] = None,
-        start_together: Optional[List[Tuple[Hashable, Hashable]]] = None,
-        start_at_end: Optional[List[Tuple[Hashable, Hashable]]] = None,
-        start_at_end_plus_offset: Optional[List[Tuple[Hashable, Hashable, int]]] = None,
-        start_after_nunit: Optional[List[Tuple[Hashable, Hashable, int]]] = None,
-        disjunctive_tasks: Optional[List[Tuple[Hashable, Hashable]]] = None,
+        partial_permutation: Optional[list[Hashable]] = None,
+        list_partial_order: Optional[list[list[Hashable]]] = None,
+        start_together: Optional[list[tuple[Hashable, Hashable]]] = None,
+        start_at_end: Optional[list[tuple[Hashable, Hashable]]] = None,
+        start_at_end_plus_offset: Optional[list[tuple[Hashable, Hashable, int]]] = None,
+        start_after_nunit: Optional[list[tuple[Hashable, Hashable, int]]] = None,
+        disjunctive_tasks: Optional[list[tuple[Hashable, Hashable]]] = None,
         pair_mode_constraint: Optional[PairModeConstraint] = None,
     ):
         self.task_mode = task_mode
@@ -93,7 +94,7 @@ class SpecialConstraintsDescription:
             self.disjunctive_tasks = []
         else:
             self.disjunctive_tasks = disjunctive_tasks
-        self.dict_start_together: Dict[Hashable, Set[Hashable]] = {}
+        self.dict_start_together: dict[Hashable, set[Hashable]] = {}
         self.graph_start_together = nx.Graph()
         for i, j in self.start_together:
             if i not in self.graph_start_together:
@@ -107,8 +108,8 @@ class SpecialConstraintsDescription:
         for c in self.components:
             for j in c:
                 self.dict_start_together[j] = set([k for k in c if k != j])
-        self.dict_start_at_end: Dict[Hashable, Set[Hashable]] = {}
-        self.dict_start_at_end_reverse: Dict[Hashable, Set[Hashable]] = {}
+        self.dict_start_at_end: dict[Hashable, set[Hashable]] = {}
+        self.dict_start_at_end_reverse: dict[Hashable, set[Hashable]] = {}
         for i, j in self.start_at_end:
             if i not in self.dict_start_at_end:
                 self.dict_start_at_end[i] = set()
@@ -117,8 +118,8 @@ class SpecialConstraintsDescription:
             self.dict_start_at_end[i].add(j)
             self.dict_start_at_end_reverse[j].add(i)
 
-        self.dict_start_at_end_offset: Dict[Hashable, Dict[Hashable, int]] = {}
-        self.dict_start_at_end_offset_reverse: Dict[Hashable, Dict[Hashable, int]] = {}
+        self.dict_start_at_end_offset: dict[Hashable, dict[Hashable, int]] = {}
+        self.dict_start_at_end_offset_reverse: dict[Hashable, dict[Hashable, int]] = {}
         for i, j, off in self.start_at_end_plus_offset:
             if i not in self.dict_start_at_end_offset:
                 self.dict_start_at_end_offset[i] = {}
@@ -127,8 +128,8 @@ class SpecialConstraintsDescription:
             self.dict_start_at_end_offset_reverse[j][i] = off
             self.dict_start_at_end_offset[i][j] = off
 
-        self.dict_start_after_nunit: Dict[Hashable, Dict[Hashable, int]] = {}
-        self.dict_start_after_nunit_reverse: Dict[Hashable, Dict[Hashable, int]] = {}
+        self.dict_start_after_nunit: dict[Hashable, dict[Hashable, int]] = {}
+        self.dict_start_after_nunit_reverse: dict[Hashable, dict[Hashable, int]] = {}
         for i, j, off in self.start_after_nunit:
             if i not in self.dict_start_after_nunit:
                 self.dict_start_after_nunit[i] = {}
@@ -137,7 +138,7 @@ class SpecialConstraintsDescription:
             self.dict_start_after_nunit[i][j] = off
             self.dict_start_after_nunit_reverse[j][i] = off
 
-        self.dict_disjunctive: Dict[Hashable, Set[Hashable]] = {}
+        self.dict_disjunctive: dict[Hashable, set[Hashable]] = {}
         for i, j in self.disjunctive_tasks:
             if i not in self.dict_disjunctive:
                 self.dict_disjunctive[i] = set()

--- a/discrete_optimization/rcpsp/specialized_rcpsp/rcpsp_specialized_constraints.py
+++ b/discrete_optimization/rcpsp/specialized_rcpsp/rcpsp_specialized_constraints.py
@@ -4,9 +4,10 @@
 
 import logging
 import random
+from collections.abc import Hashable
 from copy import deepcopy
 from functools import partial
-from typing import Dict, Hashable, List, Optional, Set, Type, Union
+from typing import Optional, Union
 
 import numpy as np
 
@@ -94,8 +95,8 @@ class RCPSPSolutionSpecialPreemptive(RCPSPSolutionPreemptive):
     def generate_schedule_from_permutation_serial_sgs_2(
         self,
         current_t: int = 0,
-        completed_tasks: Optional[Set[Hashable]] = None,
-        partial_schedule: Optional[Dict[Hashable, Dict[str, List[int]]]] = None,
+        completed_tasks: Optional[set[Hashable]] = None,
+        partial_schedule: Optional[dict[Hashable, dict[str, list[int]]]] = None,
         do_fast: bool = True,
     ):
         if do_fast:
@@ -125,18 +126,18 @@ class RCPSPSolutionSpecialPreemptive(RCPSPSolutionPreemptive):
 class RCPSPModelSpecialConstraintsPreemptive(RCPSPModelPreemptive):
     def __init__(
         self,
-        resources: Union[Dict[str, int], Dict[str, List[int]]],
-        non_renewable_resources: List[str],
-        mode_details: Dict[Hashable, Dict[Union[str, int], Dict[str, int]]],
-        successors: Dict[Union[int, str], List[Union[str, int]]],
+        resources: Union[dict[str, int], dict[str, list[int]]],
+        non_renewable_resources: list[str],
+        mode_details: dict[Hashable, dict[Union[str, int], dict[str, int]]],
+        successors: dict[Union[int, str], list[Union[str, int]]],
         horizon,
         special_constraints: SpecialConstraintsDescription = None,
-        preemptive_indicator: Dict[Hashable, bool] = None,
+        preemptive_indicator: dict[Hashable, bool] = None,
         relax_the_start_at_end: bool = True,
-        tasks_list: List[Union[int, str]] = None,
+        tasks_list: list[Union[int, str]] = None,
         source_task=None,
         sink_task=None,
-        name_task: Dict[int, str] = None,
+        name_task: dict[int, str] = None,
         **kwargs
     ):
         super().__init__(
@@ -257,7 +258,7 @@ class RCPSPModelSpecialConstraintsPreemptive(RCPSPModelPreemptive):
             penalty = 0
         return makespan, penalty
 
-    def evaluate(self, rcpsp_sol: RCPSPSolutionPreemptive) -> Dict[str, float]:
+    def evaluate(self, rcpsp_sol: RCPSPSolutionPreemptive) -> dict[str, float]:
         obj_makespan, penalty = self.evaluate_function(rcpsp_sol)
         return {"makespan": obj_makespan, "constraint_penalty": penalty}
 
@@ -295,7 +296,7 @@ class RCPSPModelSpecialConstraintsPreemptive(RCPSPModelPreemptive):
         )
         return sol
 
-    def get_solution_type(self) -> Type[Solution]:
+    def get_solution_type(self) -> type[Solution]:
         return RCPSPSolutionSpecialPreemptive
 
 
@@ -898,7 +899,7 @@ def generate_schedule_from_permutation_serial_sgs_preemptive(
 def generate_schedule_from_permutation_serial_sgs_partial_schedule_preempptive(
     solution,
     rcpsp_problem,
-    partial_schedule: Dict[Hashable, Dict[str, List[int]]],
+    partial_schedule: dict[Hashable, dict[str, list[int]]],
     current_t,
     completed_tasks,
 ):

--- a/discrete_optimization/rcpsp_multiskill/multiskill_to_rcpsp.py
+++ b/discrete_optimization/rcpsp_multiskill/multiskill_to_rcpsp.py
@@ -2,8 +2,6 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Dict
-
 import numpy as np
 
 from discrete_optimization.generic_tools.cp_tools import CPSolverName, ParametersCP
@@ -21,8 +19,8 @@ class MultiSkillToRCPSP:
 
     def is_compatible(
         self,
-        task_requirements: Dict[str, int],
-        ressource_availability: Dict[str, np.array],
+        task_requirements: dict[str, int],
+        ressource_availability: dict[str, np.array],
         duration_task,
         horizon,
     ):

--- a/discrete_optimization/rcpsp_multiskill/rcpsp_multiskill.py
+++ b/discrete_optimization/rcpsp_multiskill/rcpsp_multiskill.py
@@ -5,10 +5,11 @@
 import logging
 from abc import abstractmethod
 from collections import defaultdict
+from collections.abc import Hashable
 from copy import deepcopy
 from enum import Enum
 from functools import partial
-from typing import Dict, Hashable, Iterable, List, Optional, Set, Tuple, Type, Union
+from typing import Iterable, Optional, Union
 
 import numpy as np
 import scipy.stats as ss
@@ -51,7 +52,7 @@ class ScheduleGenerationScheme(Enum):
 
 
 class TaskDetails:
-    def __init__(self, start, end, resource_units_used: List[int]):
+    def __init__(self, start, end, resource_units_used: list[int]):
         self.start = start
         self.end = end
         self.resource_units_used = resource_units_used
@@ -70,9 +71,9 @@ class TaskDetails:
 class TaskDetailsPreemptive:
     def __init__(
         self,
-        starts: List[int],
-        ends: List[int],
-        resource_units_used: List[List[Hashable]],
+        starts: list[int],
+        ends: list[int],
+        resource_units_used: list[list[Hashable]],
     ):
         self.starts = starts
         self.ends = ends
@@ -93,12 +94,12 @@ class MS_RCPSPSolution(Solution):
     def __init__(
         self,
         problem: Problem,
-        modes: Dict[Hashable, int],
-        schedule: Dict[
-            Hashable, Dict[str, Union[int, List[int]]]
+        modes: dict[Hashable, int],
+        schedule: dict[
+            Hashable, dict[str, Union[int, list[int]]]
         ],  # (task: {"start_time": start, "end_time": }}
-        employee_usage: Dict[Hashable, Dict[Hashable, Set[str]]],
-    ):  # {task: {employee: Set(skills})}):
+        employee_usage: dict[Hashable, dict[Hashable, set[str]]],
+    ):  # {task: {employee: set(skills})}):
         self.problem: MS_RCPSPModel = problem
         self.modes = modes
         self.schedule = schedule
@@ -153,10 +154,10 @@ class MS_RCPSPSolution_Preemptive(MS_RCPSPSolution):
     def __init__(
         self,
         problem: Problem,
-        modes: Dict[Hashable, int],
-        schedule: Dict[Hashable, Dict[str, List[int]]],
-        employee_usage: Dict[Hashable, List[Dict[Hashable, Set[str]]]],
-    ):  # {task: {employee: Set(skills})}):
+        modes: dict[Hashable, int],
+        schedule: dict[Hashable, dict[str, list[int]]],
+        employee_usage: dict[Hashable, list[dict[Hashable, set[str]]]],
+    ):  # {task: {employee: set(skills})}):
         super().__init__(problem, modes, schedule, None)
         self.employee_usage = employee_usage
 
@@ -253,15 +254,15 @@ class MS_RCPSPSolution_Variant(MS_RCPSPSolution):
     def __init__(
         self,
         problem: Problem,
-        modes_vector: Optional[List[int]] = None,
-        modes_vector_from0: Optional[List[int]] = None,
-        priority_list_task: Optional[List[int]] = None,
-        priority_worker_per_task: Optional[List[List[Hashable]]] = None,
-        modes: Dict[int, int] = None,
-        schedule: Dict[int, Dict[str, int]] = None,
-        employee_usage: Dict[int, Dict[int, Set[str]]] = None,
+        modes_vector: Optional[list[int]] = None,
+        modes_vector_from0: Optional[list[int]] = None,
+        priority_list_task: Optional[list[int]] = None,
+        priority_worker_per_task: Optional[list[list[Hashable]]] = None,
+        modes: dict[int, int] = None,
+        schedule: dict[int, dict[str, int]] = None,
+        employee_usage: dict[int, dict[int, set[str]]] = None,
         fast: bool = True,
-    ):  # {task: {employee: Set(skills})}):
+    ):  # {task: {employee: set(skills})}):
         super().__init__(problem, modes, schedule, employee_usage)
         self.priority_list_task = priority_list_task
         self.modes_vector = modes_vector
@@ -367,8 +368,8 @@ class MS_RCPSPSolution_Variant(MS_RCPSPSolution):
     def run_sgs_partial(
         self,
         current_t,
-        completed_tasks: Dict[Hashable, TaskDetails],
-        scheduled_tasks_start_times: Dict[Hashable, TaskDetails],
+        completed_tasks: dict[Hashable, TaskDetails],
+        scheduled_tasks_start_times: dict[Hashable, TaskDetails],
         fast=True,
     ):
         if not fast:
@@ -486,15 +487,15 @@ class MS_RCPSPSolution_Preemptive_Variant(MS_RCPSPSolution_Preemptive):
     def __init__(
         self,
         problem: Problem,
-        modes_vector: Optional[List[int]] = None,
-        modes_vector_from0: Optional[List[int]] = None,
-        priority_list_task: Optional[List[int]] = None,
-        priority_worker_per_task: Optional[List[List[Hashable]]] = None,
-        modes: Dict[int, int] = None,
-        schedule: Dict[Hashable, Dict[str, List[int]]] = None,
-        employee_usage: Dict[Hashable, List[Dict[Hashable, Set[str]]]] = None,
+        modes_vector: Optional[list[int]] = None,
+        modes_vector_from0: Optional[list[int]] = None,
+        priority_list_task: Optional[list[int]] = None,
+        priority_worker_per_task: Optional[list[list[Hashable]]] = None,
+        modes: dict[int, int] = None,
+        schedule: dict[Hashable, dict[str, list[int]]] = None,
+        employee_usage: dict[Hashable, list[dict[Hashable, set[str]]]] = None,
         fast: bool = True,
-    ):  # {task: {employee: Set(skills})}):
+    ):  # {task: {employee: set(skills})}):
         super().__init__(problem, modes, schedule, employee_usage)
         self.priority_list_task = priority_list_task
         self.modes_vector = modes_vector
@@ -614,8 +615,8 @@ class MS_RCPSPSolution_Preemptive_Variant(MS_RCPSPSolution_Preemptive):
     def run_sgs_partial(
         self,
         current_t,
-        completed_tasks: Dict[Hashable, TaskDetailsPreemptive],
-        scheduled_tasks_start_times: Dict[Hashable, TaskDetailsPreemptive],
+        completed_tasks: dict[Hashable, TaskDetailsPreemptive],
+        scheduled_tasks_start_times: dict[Hashable, TaskDetailsPreemptive],
         fast: bool = True,
     ):
         if not fast:
@@ -1202,8 +1203,8 @@ def sgs_multi_skill_preemptive(solution: MS_RCPSPSolution_Preemptive_Variant):
 def sgs_multi_skill_preemptive_partial_schedule(
     solution: MS_RCPSPSolution_Preemptive_Variant,
     current_t,
-    completed_tasks: Dict[Hashable, TaskDetailsPreemptive],
-    scheduled_tasks_start_times: Dict[Hashable, TaskDetailsPreemptive],
+    completed_tasks: dict[Hashable, TaskDetailsPreemptive],
+    scheduled_tasks_start_times: dict[Hashable, TaskDetailsPreemptive],
 ):
     problem: MS_RCPSPModel = solution.problem
     activity_end_times = {}
@@ -1539,8 +1540,8 @@ def sgs_multi_skill_preemptive_partial_schedule(
 def sgs_multi_skill_partial_schedule(
     solution: MS_RCPSPSolution_Variant,
     current_t,
-    completed_tasks: Dict[Hashable, TaskDetails],
-    scheduled_tasks_start_times: Dict[Hashable, TaskDetails],
+    completed_tasks: dict[Hashable, TaskDetails],
+    scheduled_tasks_start_times: dict[Hashable, TaskDetails],
 ):
     problem: MS_RCPSPModel = solution.problem
     activity_end_times = {}
@@ -1857,13 +1858,13 @@ class SkillDetail:
 
 
 class Employee:
-    dict_skill: Dict[str, SkillDetail]
-    calendar_employee: List[bool]
+    dict_skill: dict[str, SkillDetail]
+    calendar_employee: list[bool]
 
     def __init__(
         self,
-        dict_skill: Dict[str, SkillDetail],
-        calendar_employee: List[bool],
+        dict_skill: dict[str, SkillDetail],
+        calendar_employee: list[bool],
         salary: float = 0.0,
     ):
         self.salary = salary
@@ -1918,17 +1919,17 @@ def intersect(i1, i2):
 
 class MS_RCPSPModel(Problem):
     sgs: ScheduleGenerationScheme
-    skills_set: Set[str]
-    resources_set: Set[str]
-    non_renewable_resources: Set[str]
-    resources_availability: Dict[str, List[int]]
-    employees: Dict[Hashable, Employee]
-    employees_availability: List[int]
+    skills_set: set[str]
+    resources_set: set[str]
+    non_renewable_resources: set[str]
+    resources_availability: dict[str, list[int]]
+    employees: dict[Hashable, Employee]
+    employees_availability: list[int]
     n_jobs_non_dummy: int
-    mode_details: Dict[Hashable, Dict[int, Dict[str, int]]]
-    successors: Dict[Hashable, List[Hashable]]
-    partial_preemption_data: Dict[Hashable, Dict[int, Dict[str, bool]]]
-    resource_blocking_data: List[Tuple[List[Hashable], Set[str]]]
+    mode_details: dict[Hashable, dict[int, dict[str, int]]]
+    successors: dict[Hashable, list[Hashable]]
+    partial_preemption_data: dict[Hashable, dict[int, dict[str, bool]]]
+    resource_blocking_data: list[tuple[list[Hashable], set[str]]]
     # List task 1, task 2, resource : resource should be blocked between start of task 1 and end of task 2
     # {task_id: {mode: {ressource: is_releasable during preemption }
     strictly_disjunctive_subtasks: bool
@@ -1936,28 +1937,28 @@ class MS_RCPSPModel(Problem):
 
     def __init__(
         self,
-        skills_set: Set[str],
-        resources_set: Set[str],
-        non_renewable_resources: Set[str],
-        resources_availability: Dict[str, List[int]],
-        employees: Dict[Hashable, Employee],
-        mode_details: Dict[Hashable, Dict[int, Dict[str, int]]],
-        successors: Dict[Hashable, List[Hashable]],
+        skills_set: set[str],
+        resources_set: set[str],
+        non_renewable_resources: set[str],
+        resources_availability: dict[str, list[int]],
+        employees: dict[Hashable, Employee],
+        mode_details: dict[Hashable, dict[int, dict[str, int]]],
+        successors: dict[Hashable, list[Hashable]],
         horizon,
-        employees_availability: List[int] = None,
-        tasks_list: List[Hashable] = None,
-        employees_list: List[Hashable] = None,
+        employees_availability: list[int] = None,
+        tasks_list: list[Hashable] = None,
+        employees_list: list[Hashable] = None,
         horizon_multiplier=1,
         sink_task: Optional[Hashable] = None,
         source_task: Optional[Hashable] = None,
         one_unit_per_task_max: bool = False,
         preemptive: bool = False,
-        preemptive_indicator: Dict[Hashable, bool] = None,
+        preemptive_indicator: dict[Hashable, bool] = None,
         special_constraints: SpecialConstraintsDescription = None,
-        partial_preemption_data: Dict[Hashable, Dict[int, Dict[str, bool]]] = None,
-        always_releasable_resources: Set[str] = None,
-        never_releasable_resources: Set[str] = None,
-        resource_blocking_data: List[Tuple[List[Hashable], Set[str]]] = None,
+        partial_preemption_data: dict[Hashable, dict[int, dict[str, bool]]] = None,
+        always_releasable_resources: set[str] = None,
+        never_releasable_resources: set[str] = None,
+        resource_blocking_data: list[tuple[list[Hashable], set[str]]] = None,
         strictly_disjunctive_subtasks: bool = True,
     ):
         self.skills_set = skills_set
@@ -2262,7 +2263,7 @@ class MS_RCPSPModel(Problem):
     def evaluate_from_encoding(self, int_vector, encoding_name):
         ...
 
-    def evaluate(self, rcpsp_sol: MS_RCPSPSolution) -> Dict[str, float]:
+    def evaluate(self, rcpsp_sol: MS_RCPSPSolution) -> dict[str, float]:
         obj_makespan = self.evaluate_function(rcpsp_sol)
         d = {"makespan": obj_makespan}
         if self.includes_special_constraint():
@@ -2275,7 +2276,7 @@ class MS_RCPSPModel(Problem):
     def evaluate_mobj(self, rcpsp_sol: MS_RCPSPSolution):
         return self.evaluate_mobj_from_dict(self.evaluate(rcpsp_sol))
 
-    def evaluate_mobj_from_dict(self, dict_values: Dict[str, float]) -> TupleFitness:
+    def evaluate_mobj_from_dict(self, dict_values: dict[str, float]) -> TupleFitness:
         return TupleFitness(np.array([-dict_values["makespan"]]), 1)
 
     def satisfy(self, variable: Solution) -> bool:
@@ -2597,19 +2598,19 @@ class MS_RCPSPModel(Problem):
         val += "\nSpecial constraints : " + str(self.do_special_constraints)
         return val
 
-    def get_solution_type(self) -> Type[Solution]:
+    def get_solution_type(self) -> type[Solution]:
         return MS_RCPSPSolution
 
     def get_attribute_register(self) -> EncodingRegister:
         dict_register = {
-            "modes": {"name": "modes", "type": [Dict[int, int]]},
+            "modes": {"name": "modes", "type": [dict[int, int]]},
             "schedule": {
                 "name": "schedule",
-                "type": [Dict[int, Dict[str, int]]],
+                "type": [dict[int, dict[str, int]]],
             },
             "employee_usage": {
                 "name": "employee_usage",
-                "type": [Dict[int, Dict[int, Set[str]]]],
+                "type": [dict[int, dict[int, set[str]]]],
             },
         }
         return EncodingRegister(dict_register)
@@ -2688,28 +2689,28 @@ class MS_RCPSPModel(Problem):
 class MS_RCPSPModel_Variant(MS_RCPSPModel):
     def __init__(
         self,
-        skills_set: Set[str],
-        resources_set: Set[str],
-        non_renewable_resources: Set[str],
-        resources_availability: Dict[str, List[int]],
-        employees: Dict[Hashable, Employee],
-        employees_availability: List[int],
-        mode_details: Dict[Hashable, Dict[int, Dict[str, int]]],
-        successors: Dict[Hashable, List[Hashable]],
+        skills_set: set[str],
+        resources_set: set[str],
+        non_renewable_resources: set[str],
+        resources_availability: dict[str, list[int]],
+        employees: dict[Hashable, Employee],
+        employees_availability: list[int],
+        mode_details: dict[Hashable, dict[int, dict[str, int]]],
+        successors: dict[Hashable, list[Hashable]],
         horizon,
-        tasks_list: List[Hashable] = None,
-        employees_list: List[Hashable] = None,
+        tasks_list: list[Hashable] = None,
+        employees_list: list[Hashable] = None,
         horizon_multiplier=1,
         sink_task: Optional[Hashable] = None,
         source_task: Optional[Hashable] = None,
         one_unit_per_task_max: bool = False,
         preemptive: bool = False,
-        preemptive_indicator: Dict[Hashable, bool] = None,
+        preemptive_indicator: dict[Hashable, bool] = None,
         special_constraints: SpecialConstraintsDescription = None,
-        partial_preemption_data: Dict[Hashable, Dict[int, Dict[str, bool]]] = None,
-        always_releasable_resources: Set[str] = None,
-        never_releasable_resources: Set[str] = None,
-        resource_blocking_data: List[Tuple[List[Hashable], Set[str]]] = None,
+        partial_preemption_data: dict[Hashable, dict[int, dict[str, bool]]] = None,
+        always_releasable_resources: set[str] = None,
+        never_releasable_resources: set[str] = None,
+        resource_blocking_data: list[tuple[list[Hashable], set[str]]] = None,
         strictly_disjunctive_subtasks: bool = True,
     ):
         MS_RCPSPModel.__init__(
@@ -2762,7 +2763,7 @@ class MS_RCPSPModel_Variant(MS_RCPSPModel):
         }
         dict_register["priority_worker_per_task"] = {
             "name": "priority_worker_per_task",
-            "type": [List[List[int]]],
+            "type": [list[list[int]]],
         }
         dict_register["modes_vector"] = {
             "name": "modes_vector",
@@ -2796,11 +2797,11 @@ class MS_RCPSPModel_Variant(MS_RCPSPModel):
 
         dict_register["schedule"] = {
             "name": "schedule",
-            "type": [Dict[int, Dict[str, int]]],
+            "type": [dict[int, dict[str, int]]],
         }
         dict_register["employee_usage"] = {
             "name": "employee_usage",
-            "type": [Dict[int, Dict[int, Set[str]]]],
+            "type": [dict[int, dict[int, set[str]]]],
         }
         return EncodingRegister(dict_register)
 
@@ -2915,7 +2916,7 @@ class MS_RCPSPModel_Variant(MS_RCPSPModel):
         objectives = self.evaluate(rcpsp_sol)
         return objectives
 
-    def get_solution_type(self) -> Type[Solution]:
+    def get_solution_type(self) -> type[Solution]:
         if not self.preemptive:
             return MS_RCPSPSolution_Variant
         else:
@@ -2949,8 +2950,8 @@ def priority_worker_per_task_do_to_permutation_sgs_fast(
 
 def build_partial_vectors(
     problem: MS_RCPSPModel,
-    completed_tasks: Dict[Hashable, TaskDetails],
-    scheduled_tasks_start_times: Dict[Hashable, TaskDetails],
+    completed_tasks: dict[Hashable, TaskDetails],
+    scheduled_tasks_start_times: dict[Hashable, TaskDetails],
 ):
     scheduled_task_indicator = np.zeros(problem.n_jobs)
     scheduled_tasks_start_times_vector = np.zeros(problem.n_jobs, dtype=np.int_)
@@ -2976,8 +2977,8 @@ def build_partial_vectors(
 
 def build_partial_vectors_preemptive(
     problem: MS_RCPSPModel,
-    completed_tasks: Dict[Hashable, TaskDetailsPreemptive],
-    scheduled_tasks_start_times: Dict[Hashable, TaskDetailsPreemptive],
+    completed_tasks: dict[Hashable, TaskDetailsPreemptive],
+    scheduled_tasks_start_times: dict[Hashable, TaskDetailsPreemptive],
 ):
     scheduled_task_indicator = np.zeros(problem.n_jobs)
     scheduled_tasks_start_times_array = np.zeros((problem.n_jobs, 10), dtype=np.int_)

--- a/discrete_optimization/rcpsp_multiskill/rcpsp_multiskill_mslib_parser.py
+++ b/discrete_optimization/rcpsp_multiskill/rcpsp_multiskill_mslib_parser.py
@@ -3,7 +3,7 @@
 #  LICENSE file in the root directory of this source tree.
 import logging
 import os
-from typing import Dict, Optional
+from typing import Optional
 
 from discrete_optimization.datasets import fetch_data_from_mslib, get_data_home
 from discrete_optimization.rcpsp_multiskill.rcpsp_multiskill import (
@@ -99,7 +99,7 @@ def parse_file_mslib(file_path, skill_level_version: bool = True):
         )
         workers_list = [f"w-{i}" for i in range(number_units)]
         skills_list = [f"sk-{i}" for i in range(number_skills)]
-        workers: Dict[str, Employee] = {
+        workers: dict[str, Employee] = {
             w: Employee(
                 dict_skill={}, calendar_employee=[True] * (2 * horizon_1 + 1), salary=0
             )

--- a/discrete_optimization/rcpsp_multiskill/rcpsp_multiskill_parser.py
+++ b/discrete_optimization/rcpsp_multiskill/rcpsp_multiskill_parser.py
@@ -3,7 +3,7 @@
 #  LICENSE file in the root directory of this source tree.
 
 import os
-from typing import Dict, Optional, Tuple
+from typing import Optional
 
 from discrete_optimization.datasets import get_data_home
 from discrete_optimization.rcpsp_multiskill.rcpsp_multiskill import (
@@ -206,7 +206,7 @@ def parse_imopse(
 
 def parse_file(
     file_path, max_horizon=None, one_unit_per_task=True, preemptive=False
-) -> Tuple[MS_RCPSPModel, Dict]:
+) -> tuple[MS_RCPSPModel, dict]:
     with open(file_path, "r", encoding="utf-8") as input_data_file:
         input_data = input_data_file.read()
         rcpsp_model, new_tame_to_original_task_id = parse_imopse(

--- a/discrete_optimization/rcpsp_multiskill/solvers/cp_solver_mspsp_instlib.py
+++ b/discrete_optimization/rcpsp_multiskill/solvers/cp_solver_mspsp_instlib.py
@@ -7,7 +7,8 @@
 
 import logging
 import os
-from typing import Any, Hashable, Optional, Set
+from collections.abc import Hashable
+from typing import Any, Optional
 
 from minizinc import Instance, Model, Solver
 
@@ -273,7 +274,7 @@ class CP_MSPSP_MZN(MinizincCPSolver):
             ]
         return s
 
-    def constraint_sum_of_ending_time(self, set_subtasks: Set[Hashable]):
+    def constraint_sum_of_ending_time(self, set_subtasks: set[Hashable]):
         indexes = [self.index_in_minizinc[s] for s in set_subtasks]
         weights = [10 if s == self.problem.sink_task else 1 for s in set_subtasks]
         s = (
@@ -290,7 +291,7 @@ class CP_MSPSP_MZN(MinizincCPSolver):
         )
         return [s]
 
-    def constraint_sum_of_starting_time(self, set_subtasks: Set[Hashable]):
+    def constraint_sum_of_starting_time(self, set_subtasks: set[Hashable]):
         indexes = [self.index_in_minizinc[s] for s in set_subtasks]
         weights = [10 if s == self.problem.sink_task else 1 for s in set_subtasks]
         s = (

--- a/discrete_optimization/rcpsp_multiskill/solvers/cp_solvers.py
+++ b/discrete_optimization/rcpsp_multiskill/solvers/cp_solvers.py
@@ -5,9 +5,10 @@
 import logging
 import math
 import os
+from collections.abc import Hashable
 from datetime import timedelta
 from enum import Enum
-from typing import Any, Dict, Hashable, List, Optional, Set, Tuple, Union
+from typing import Any, Optional, Union
 
 from minizinc import Instance, Model, Solver
 
@@ -384,7 +385,7 @@ class CP_MS_MRCPSP_MZN(MinizincCPSolver):
         s = "constraint s[" + str(ind) + "]==objective;\n"
         return [s]
 
-    def constraint_sum_of_ending_time(self, set_subtasks: Set[Hashable]):
+    def constraint_sum_of_ending_time(self, set_subtasks: set[Hashable]):
         indexes = [self.index_in_minizinc[s] for s in set_subtasks]
         s = (
             """int: nb_indexes="""
@@ -397,7 +398,7 @@ class CP_MS_MRCPSP_MZN(MinizincCPSolver):
         )
         return [s]
 
-    def constraint_sum_of_starting_time(self, set_subtasks: Set[Hashable]):
+    def constraint_sum_of_starting_time(self, set_subtasks: set[Hashable]):
         indexes = [self.index_in_minizinc[s] for s in set_subtasks]
         s = (
             """int: nb_indexes="""
@@ -873,7 +874,7 @@ class CP_MS_MRCPSP_MZN_PREEMPTIVE(MinizincCPSolver):
         )
         return [s]
 
-    def constraint_sum_of_ending_time(self, set_subtasks: Set[Hashable]):
+    def constraint_sum_of_ending_time(self, set_subtasks: set[Hashable]):
         indexes = [self.index_in_minizinc[s] for s in set_subtasks]
         weights = [10 if s == self.problem.sink_task else 1 for s in set_subtasks]
         s = (
@@ -890,7 +891,7 @@ class CP_MS_MRCPSP_MZN_PREEMPTIVE(MinizincCPSolver):
         )
         return [s]
 
-    def constraint_sum_of_starting_time(self, set_subtasks: Set[Hashable]):
+    def constraint_sum_of_starting_time(self, set_subtasks: set[Hashable]):
         indexes = [self.index_in_minizinc[s] for s in set_subtasks]
         weights = [10 if s == self.problem.sink_task else 1 for s in set_subtasks]
 
@@ -1456,7 +1457,7 @@ def stick_to_solution_preemptive(
 
 
 def hard_start_times(
-    dict_start_times: Dict[Hashable, int],
+    dict_start_times: dict[Hashable, int],
     cp_solver: Union[CP_MS_MRCPSP_MZN, CP_MS_MRCPSP_MZN_PREEMPTIVE],
 ):
     constraint_strings = []
@@ -1473,7 +1474,7 @@ def hard_start_times(
 
 
 def soft_start_times(
-    dict_start_times: Dict[Hashable, int],
+    dict_start_times: dict[Hashable, int],
     cp_solver: Union[CP_MS_MRCPSP_MZN, CP_MS_MRCPSP_MZN_PREEMPTIVE],
 ):
     list_task = list(dict_start_times.keys())
@@ -1498,7 +1499,7 @@ def soft_start_times(
 
 
 def soft_start_together(
-    list_start_together: List[Tuple[Hashable, Hashable]],
+    list_start_together: list[tuple[Hashable, Hashable]],
     cp_solver: Union[CP_MS_MRCPSP_MZN, CP_MS_MRCPSP_MZN_PREEMPTIVE],
 ):
     s = (
@@ -1523,7 +1524,7 @@ def soft_start_together(
 
 
 def hard_start_together(
-    list_start_together: List[Tuple[Hashable, Hashable]],
+    list_start_together: list[tuple[Hashable, Hashable]],
     cp_solver: Union[CP_MS_MRCPSP_MZN, CP_MS_MRCPSP_MZN_PREEMPTIVE],
 ):
     constraint_strings = []
@@ -1540,7 +1541,7 @@ def hard_start_together(
 
 
 def hard_start_after_nunit(
-    list_start_after_nunit: List[Tuple[Hashable, Hashable, int]],
+    list_start_after_nunit: list[tuple[Hashable, Hashable, int]],
     cp_solver: Union[CP_MS_MRCPSP_MZN, CP_MS_MRCPSP_MZN_PREEMPTIVE],
 ):
     constraint_strings = []
@@ -1559,7 +1560,7 @@ def hard_start_after_nunit(
 
 
 def soft_start_after_nunit(
-    list_start_after_nunit: List[Tuple[Hashable, Hashable, int]],
+    list_start_after_nunit: list[tuple[Hashable, Hashable, int]],
     cp_solver: Union[CP_MS_MRCPSP_MZN, CP_MS_MRCPSP_MZN_PREEMPTIVE],
 ):
     s = (
@@ -1630,7 +1631,7 @@ def hard_start_at_end_plus_offset(
 
 
 def soft_start_at_end_plus_offset(
-    list_start_at_end_plus_offset: List[Tuple[Hashable, Hashable, int]],
+    list_start_at_end_plus_offset: list[tuple[Hashable, Hashable, int]],
     cp_solver: Union[CP_MS_MRCPSP_MZN, CP_MS_MRCPSP_MZN_PREEMPTIVE],
 ):
     s = (
@@ -1674,7 +1675,7 @@ def soft_start_at_end_plus_offset(
 
 
 def hard_start_at_end(
-    list_start_at_end: List[Tuple[Hashable, Hashable]],
+    list_start_at_end: list[tuple[Hashable, Hashable]],
     cp_solver: Union[CP_MS_MRCPSP_MZN, CP_MS_MRCPSP_MZN_PREEMPTIVE],
 ):
     constraint_strings = []
@@ -1702,7 +1703,7 @@ def hard_start_at_end(
 
 
 def soft_start_at_end(
-    list_start_at_end: List[Tuple[Hashable, Hashable]],
+    list_start_at_end: list[tuple[Hashable, Hashable]],
     cp_solver: Union[CP_MS_MRCPSP_MZN, CP_MS_MRCPSP_MZN_PREEMPTIVE],
 ):
     s = (
@@ -1734,7 +1735,7 @@ def soft_start_at_end(
 
 
 def soft_start_window(
-    start_times_window: Dict[Hashable, Tuple[int, int]],
+    start_times_window: dict[Hashable, tuple[int, int]],
     cp_solver: Union[CP_MS_MRCPSP_MZN, CP_MS_MRCPSP_MZN_PREEMPTIVE],
 ):
     l_low = [
@@ -1785,7 +1786,7 @@ def soft_start_window(
 
 
 def soft_end_window(
-    end_times_window: Dict[Hashable, Tuple[int, int]],
+    end_times_window: dict[Hashable, tuple[int, int]],
     cp_solver: Union[CP_MS_MRCPSP_MZN, CP_MS_MRCPSP_MZN_PREEMPTIVE],
 ):
     l_low = [
@@ -1842,7 +1843,7 @@ def soft_end_window(
 
 
 def hard_start_window(
-    start_times_window: Dict[Hashable, Tuple[int, int]],
+    start_times_window: dict[Hashable, tuple[int, int]],
     cp_solver: Union[CP_MS_MRCPSP_MZN, CP_MS_MRCPSP_MZN_PREEMPTIVE],
 ):
     l = []
@@ -1863,7 +1864,7 @@ def hard_start_window(
 
 
 def hard_end_window(
-    end_times_window: Dict[Hashable, Tuple[int, int]],
+    end_times_window: dict[Hashable, tuple[int, int]],
     cp_solver: Union[CP_MS_MRCPSP_MZN, CP_MS_MRCPSP_MZN_PREEMPTIVE],
 ):
     l = []

--- a/discrete_optimization/rcpsp_multiskill/solvers/lp_model.py
+++ b/discrete_optimization/rcpsp_multiskill/solvers/lp_model.py
@@ -4,8 +4,9 @@
 
 import logging
 import time
+from collections.abc import Callable
 from itertools import product
-from typing import Any, Callable, Optional
+from typing import Any, Optional
 
 from mip import BINARY, INTEGER, MINIMIZE, Model, xsum
 

--- a/discrete_optimization/rcpsp_multiskill/solvers/ms_rcpsp_lp_lns_solver.py
+++ b/discrete_optimization/rcpsp_multiskill/solvers/ms_rcpsp_lp_lns_solver.py
@@ -3,7 +3,8 @@
 #  LICENSE file in the root directory of this source tree.
 
 import random
-from typing import Any, Iterable
+from collections.abc import Iterable
+from typing import Any
 
 from discrete_optimization.generic_tools.do_problem import (
     ParamsObjectiveFunction,

--- a/discrete_optimization/rcpsp_multiskill/solvers/multimode_transposition.py
+++ b/discrete_optimization/rcpsp_multiskill/solvers/multimode_transposition.py
@@ -3,7 +3,7 @@
 #  LICENSE file in the root directory of this source tree.
 
 import logging
-from typing import Dict, Set, Union
+from typing import Union
 
 import numpy as np
 
@@ -43,7 +43,7 @@ class MultimodeTranspositionSolver(SolverDO):
         self,
         problem: MS_RCPSPModel,
         multimode_problem: Union[RCPSPModel, RCPSPModelPreemptive] = None,
-        worker_type_to_worker: Dict[str, Set[Union[str, int]]] = None,
+        worker_type_to_worker: dict[str, set[Union[str, int]]] = None,
         params_objective_function: ParamsObjectiveFunction = None,
         solver_multimode_rcpsp: SolverDO = None,
         **kwargs
@@ -80,7 +80,7 @@ class MultimodeTranspositionSolver(SolverDO):
 def rebuild_multiskill_solution(
     multiskill_rcpsp_model: MS_RCPSPModel,
     multimode_rcpsp_model: Union[RCPSPModel, RCPSPModelPreemptive],
-    worker_type_to_worker: Dict[str, Set[Union[str, int]]],
+    worker_type_to_worker: dict[str, set[Union[str, int]]],
     solution_rcpsp: Union[RCPSPSolution, RCPSPSolutionPreemptive],
 ):
     new_horizon = multimode_rcpsp_model.horizon
@@ -209,7 +209,7 @@ def rebuild_multiskill_solution(
 def rebuild_multiskill_solution_cp_based(
     multiskill_rcpsp_model: MS_RCPSPModel,
     multimode_rcpsp_model: Union[RCPSPModel, RCPSPModelPreemptive],
-    worker_type_to_worker: Dict[str, Set[Union[str, int]]],
+    worker_type_to_worker: dict[str, set[Union[str, int]]],
     solution_rcpsp: Union[RCPSPSolution, RCPSPSolutionPreemptive],
 ):
     if isinstance(solution_rcpsp, RCPSPSolution):

--- a/discrete_optimization/tsp/common_tools_tsp.py
+++ b/discrete_optimization/tsp/common_tools_tsp.py
@@ -2,7 +2,7 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Callable, Iterable, List, Sequence, Tuple
+from collections.abc import Callable, Iterable, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -15,8 +15,8 @@ def length_1(point1: Point2D, point2: Point2D) -> float:
 
 
 def compute_length(
-    solution: List[int], list_points: Sequence[Point2D], nodeCount: int
-) -> Tuple[List[float], float]:
+    solution: list[int], list_points: Sequence[Point2D], nodeCount: int
+) -> tuple[list[float], float]:
     obj = length(list_points[solution[-1]], list_points[solution[0]])
     lengths = []
     pp = obj
@@ -30,7 +30,7 @@ def compute_length(
 
 def baseline_in_order(
     nodeCount: int, points: Sequence[Point2D]
-) -> Tuple[Iterable[int], float, int]:
+) -> tuple[Iterable[int], float, int]:
     # build a trivial solution
     # visit the nodes in the order they appear in the file
     solution = range(0, nodeCount)
@@ -58,7 +58,7 @@ def build_matrice_distance(
 
 def build_matrice_distance_np(
     nodeCount: int, points: Sequence[Point2D]
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     matrix_x = np.ones((nodeCount, nodeCount), dtype=np.int_)
     matrix_y = np.ones((nodeCount, nodeCount), dtype=np.int_)
     for i in range(nodeCount):
@@ -73,7 +73,7 @@ def build_matrice_distance_np(
 
 def closest_greedy(
     nodeCount: int, points: Sequence[Point2D]
-) -> Tuple[List[int], float, int]:
+) -> tuple[list[int], float, int]:
     sd, d = build_matrice_distance_np(nodeCount, points)
     sol = [0]
     length_circuit = 0.0

--- a/discrete_optimization/tsp/mutation/mutation_tsp.py
+++ b/discrete_optimization/tsp/mutation/mutation_tsp.py
@@ -3,7 +3,8 @@
 #  LICENSE file in the root directory of this source tree.
 
 import random
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+from collections.abc import Iterable, Sequence
+from typing import Any, Optional
 
 from discrete_optimization.generic_tools.do_mutation import (
     LocalMove,
@@ -32,9 +33,9 @@ def find_intersection(
     points: Sequence[Point2D],
     test_all: bool = False,
     nb_tests: int = 10,
-) -> List[Tuple[int, int]]:
+) -> list[tuple[int, int]]:
     perm = variable.permutation
-    intersects: List[Tuple[int, int]] = []
+    intersects: list[tuple[int, int]] = []
     its = (
         range(len(perm))
         if test_all
@@ -64,7 +65,7 @@ def find_intersection(
 
 def get_points_index(
     it: int, jt: int, variable: SolutionTSP, length_permutation: int
-) -> Tuple[int, int, int, int]:
+) -> tuple[int, int, int, int]:
     perm = variable.permutation
     i = perm[it]
     j = perm[jt]
@@ -109,7 +110,7 @@ class Mutation2Opt(Mutation):
 
     def get_points(
         self, it: int, jt: int, variable: SolutionTSP
-    ) -> Tuple[Point2D, Point2D, Point2D, Point2D]:
+    ) -> tuple[Point2D, Point2D, Point2D, Point2D]:
         perm = variable.permutation
         if it == 0:
             point_before_i = self.points[variable.start_index]
@@ -125,7 +126,7 @@ class Mutation2Opt(Mutation):
 
     def get_points_index(
         self, it: int, jt: int, variable: SolutionTSP
-    ) -> Tuple[int, int, int, int]:
+    ) -> tuple[int, int, int, int]:
         perm = variable.permutation
         i = perm[it]
         j = perm[jt]
@@ -139,7 +140,7 @@ class Mutation2Opt(Mutation):
             j_after = perm[jt + 1]
         return i_before, i, j, j_after
 
-    def mutate_and_compute_obj(self, variable: SolutionTSP) -> Tuple[SolutionTSP, LocalMove, Dict[str, float]]:  # type: ignore # avoid isinstance checks for efficiency
+    def mutate_and_compute_obj(self, variable: SolutionTSP) -> tuple[SolutionTSP, LocalMove, dict[str, float]]:  # type: ignore # avoid isinstance checks for efficiency
         if variable.length is None or variable.lengths is None:
             raise RuntimeError(
                 "length and lengths variable's attributes should not be None at this point."
@@ -211,7 +212,7 @@ class Mutation2Opt(Mutation):
                 {"length": variable.length},
             )
 
-    def mutate(self, variable: SolutionTSP) -> Tuple[SolutionTSP, LocalMove]:  # type: ignore # avoid isinstance checks for efficiency
+    def mutate(self, variable: SolutionTSP) -> tuple[SolutionTSP, LocalMove]:  # type: ignore # avoid isinstance checks for efficiency
         v, move, f = self.mutate_and_compute_obj(variable)
         return v, move
 
@@ -230,7 +231,7 @@ class Mutation2OptIntersection(Mutation2Opt):
         test_all: bool = True,
         nb_test: Optional[int] = None,
         return_only_improvement: bool = False,
-        i_j_pairs: Optional[List[Tuple[int, int]]] = None,
+        i_j_pairs: Optional[list[tuple[int, int]]] = None,
         **kwargs: Any
     ):
         Mutation2Opt.__init__(
@@ -239,7 +240,7 @@ class Mutation2OptIntersection(Mutation2Opt):
         self.tsp_model = tsp_model
         self.i_j_pairs = i_j_pairs
 
-    def mutate_and_compute_obj(self, variable: SolutionTSP) -> Tuple[SolutionTSP, LocalMove, Dict[str, float]]:  # type: ignore # avoid isinstance checks for efficiency
+    def mutate_and_compute_obj(self, variable: SolutionTSP) -> tuple[SolutionTSP, LocalMove, dict[str, float]]:  # type: ignore # avoid isinstance checks for efficiency
         if variable.length is None or variable.lengths is None:
             raise RuntimeError(
                 "length and lengths variable's attributes should not be None at this point."
@@ -304,7 +305,7 @@ class Mutation2OptIntersection(Mutation2Opt):
 
 
 class SwapTSPMove(LocalMove):
-    def __init__(self, attribute: str, tsp_model: TSPModel, swap: Tuple[int, int]):
+    def __init__(self, attribute: str, tsp_model: TSPModel, swap: tuple[int, int]):
         self.attribute = attribute
         self.tsp_model = tsp_model
         self.swap = swap
@@ -362,7 +363,7 @@ class MutationSwapTSP(Mutation):
         self.tsp_model = tsp_model
         self.length_permutation = tsp_model.length_permutation
 
-    def mutate(self, solution: SolutionTSP) -> Tuple[SolutionTSP, LocalMove]:  # type: ignore # avoid isinstance checks for efficiency
+    def mutate(self, solution: SolutionTSP) -> tuple[SolutionTSP, LocalMove]:  # type: ignore # avoid isinstance checks for efficiency
         i = random.randint(0, self.length_permutation - 3)
         j = random.randint(i + 2, min(self.length_permutation - 1, i + 1 + 4))
         two_opt_move = SwapTSPMove("permutation", self.tsp_model, (i, j))
@@ -371,7 +372,7 @@ class MutationSwapTSP(Mutation):
 
     def mutate_and_compute_obj(  # type: ignore # avoid isinstance checks for efficiency
         self, solution: SolutionTSP
-    ) -> Tuple[SolutionTSP, LocalMove, Dict[str, float]]:
+    ) -> tuple[SolutionTSP, LocalMove, dict[str, float]]:
         sol, move = self.mutate(solution)
         if sol.length is None or sol.lengths is None:
             raise RuntimeError(

--- a/discrete_optimization/tsp/solver/tsp_cp_solver.py
+++ b/discrete_optimization/tsp/solver/tsp_cp_solver.py
@@ -4,7 +4,7 @@
 
 import logging
 import os
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 from minizinc import Instance, Model, Solver
 
@@ -92,7 +92,7 @@ class TSP_CP_Solver(MinizincCPSolver, SolverTSP):
         circuit = kwargs["x"]
         return self._retrieve_solution_from_circuit(circuit)
 
-    def _retrieve_solution_from_circuit(self, circuit: List[int]) -> SolutionTSP:
+    def _retrieve_solution_from_circuit(self, circuit: list[int]) -> SolutionTSP:
         path = []
         cur_pos = self.start_index
         init = False

--- a/discrete_optimization/tsp/solver/tsp_cpsat_lns.py
+++ b/discrete_optimization/tsp/solver/tsp_cpsat_lns.py
@@ -4,7 +4,8 @@
 
 import logging
 import random
-from typing import Any, Iterable, Optional
+from collections.abc import Iterable
+from typing import Any
 
 from ortools.sat.python.cp_model import Constraint
 

--- a/discrete_optimization/tsp/tsp_parser.py
+++ b/discrete_optimization/tsp/tsp_parser.py
@@ -3,7 +3,7 @@
 #  LICENSE file in the root directory of this source tree.
 
 import os
-from typing import List, Optional
+from typing import Optional
 
 from discrete_optimization.datasets import get_data_home
 from discrete_optimization.tsp.tsp_model import Point2D, TSPModel2D
@@ -11,7 +11,7 @@ from discrete_optimization.tsp.tsp_model import Point2D, TSPModel2D
 
 def get_data_available(
     data_folder: Optional[str] = None, data_home: Optional[str] = None
-) -> List[str]:
+) -> list[str]:
     """Get datasets available for tsp.
 
     Params:

--- a/discrete_optimization/tsp/tsp_solvers.py
+++ b/discrete_optimization/tsp/tsp_solvers.py
@@ -2,7 +2,7 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, List, Tuple, Type
+from typing import Any
 
 from discrete_optimization.generic_tools.cp_tools import CPSolverName
 from discrete_optimization.generic_tools.do_problem import Problem
@@ -23,7 +23,7 @@ from discrete_optimization.tsp.tsp_model import (
     TSPModelDistanceMatrix,
 )
 
-solvers: Dict[str, List[Tuple[Type[SolverTSP], Dict[str, Any]]]] = {
+solvers: dict[str, list[tuple[type[SolverTSP], dict[str, Any]]]] = {
     "lp": [
         (
             LP_TSP_Iterative,
@@ -47,18 +47,18 @@ for key in solvers:
     for solver, param in solvers[key]:
         solvers_map[solver] = (key, param)
 
-solvers_compatibility: Dict[Type[SolverTSP], List[Type[Problem]]] = {}
+solvers_compatibility: dict[type[SolverTSP], list[type[Problem]]] = {}
 for x in solvers:
     for y in solvers[x]:
         solvers_compatibility[y[0]] = [TSPModel2D, TSPModelDistanceMatrix]
 
 
-def look_for_solver(domain: TSPModel) -> List[Type[SolverTSP]]:
+def look_for_solver(domain: TSPModel) -> list[type[SolverTSP]]:
     class_domain = domain.__class__
     return look_for_solver_class(class_domain)
 
 
-def look_for_solver_class(class_domain: Type["TSPModel"]) -> List[Type[SolverTSP]]:
+def look_for_solver_class(class_domain: type["TSPModel"]) -> list[type[SolverTSP]]:
     available = []
     for solver in solvers_compatibility:
         if class_domain in solvers_compatibility[solver]:
@@ -66,7 +66,7 @@ def look_for_solver_class(class_domain: Type["TSPModel"]) -> List[Type[SolverTSP
     return available
 
 
-def solve(method: Type[SolverTSP], problem: TSPModel, **kwargs: Any) -> ResultStorage:
+def solve(method: type[SolverTSP], problem: TSPModel, **kwargs: Any) -> ResultStorage:
     solver = method(problem=problem, **kwargs)
     try:
         solver.init_model(**kwargs)
@@ -76,7 +76,7 @@ def solve(method: Type[SolverTSP], problem: TSPModel, **kwargs: Any) -> ResultSt
 
 
 def return_solver(
-    method: Type[SolverTSP], problem: TSPModel, **kwargs: Any
+    method: type[SolverTSP], problem: TSPModel, **kwargs: Any
 ) -> SolverTSP:
     solver = method(problem, **kwargs)
     try:

--- a/discrete_optimization/vrp/mutation/mutation_vrp.py
+++ b/discrete_optimization/vrp/mutation/mutation_vrp.py
@@ -3,7 +3,8 @@
 #  LICENSE file in the root directory of this source tree.
 
 import random
-from typing import Any, Dict, Iterable, Optional, Tuple
+from collections.abc import Iterable
+from typing import Any, Optional
 
 from discrete_optimization.generic_tools.do_mutation import (
     LocalMove,
@@ -136,7 +137,7 @@ class MutationRelocate(Mutation):
         self.customer_count = vrp_model.customer_count
         self.vehicle_count = vrp_model.vehicle_count
 
-    def mutate(self, solution: VrpSolution) -> Tuple[VrpSolution, LocalMove]:  # type: ignore # avoid isinstance checks for efficiency
+    def mutate(self, solution: VrpSolution) -> tuple[VrpSolution, LocalMove]:  # type: ignore # avoid isinstance checks for efficiency
         vehicles_used = [
             v
             for v in range(self.vrp_model.vehicle_count)
@@ -161,7 +162,7 @@ class MutationRelocate(Mutation):
 
     def mutate_and_compute_obj(  # type: ignore # avoid isinstance checks for efficiency
         self, solution: VrpSolution
-    ) -> Tuple[VrpSolution, LocalMove, Dict[str, float]]:
+    ) -> tuple[VrpSolution, LocalMove, dict[str, float]]:
         sol, move = self.mutate(solution)
         f = self.vrp_model.evaluate(sol)
         return sol, move, f
@@ -286,7 +287,7 @@ class MutationSwap(Mutation):
         self.customer_count = vrp_model.customer_count
         self.vehicle_count = vrp_model.vehicle_count
 
-    def mutate(self, solution: VrpSolution) -> Tuple[VrpSolution, LocalMove]:  # type: ignore # avoid isinstance checks for efficiency
+    def mutate(self, solution: VrpSolution) -> tuple[VrpSolution, LocalMove]:  # type: ignore # avoid isinstance checks for efficiency
         vehicles_used = [
             v
             for v in range(self.vrp_model.vehicle_count)
@@ -330,7 +331,7 @@ class MutationSwap(Mutation):
 
     def mutate_and_compute_obj(  # type: ignore # avoid isinstance checks for efficiency
         self, solution: VrpSolution
-    ) -> Tuple[Solution, LocalMove, Dict[str, float]]:
+    ) -> tuple[Solution, LocalMove, dict[str, float]]:
         sol, move = self.mutate(solution)
         f = self.vrp_model.evaluate(sol)
         return sol, move, f
@@ -366,7 +367,7 @@ class MutationTwoOptVRP(Mutation):
 
     def get_points(
         self, vehicle: int, it: int, jt: int, variable: VrpSolution
-    ) -> Tuple[BasicCustomer, BasicCustomer, BasicCustomer, BasicCustomer]:
+    ) -> tuple[BasicCustomer, BasicCustomer, BasicCustomer, BasicCustomer]:
         perm = variable.list_paths[vehicle]
         if it == 0:
             point_before_i = self.points[variable.list_start_index[vehicle]]
@@ -382,7 +383,7 @@ class MutationTwoOptVRP(Mutation):
 
     def get_points_index(
         self, vehicle: int, it: int, jt: int, variable: VrpSolution
-    ) -> Tuple[int, int, int, int]:
+    ) -> tuple[int, int, int, int]:
         i_before = None
         j_after = None
         perm = variable.list_paths[vehicle]
@@ -398,7 +399,7 @@ class MutationTwoOptVRP(Mutation):
             j_after = perm[jt + 1]
         return i_before, i, j, j_after
 
-    def mutate_and_compute_obj(self, variable: VrpSolution) -> Tuple[VrpSolution, LocalMove, Dict[str, float]]:  # type: ignore # avoid isinstance checks for efficiency
+    def mutate_and_compute_obj(self, variable: VrpSolution) -> tuple[VrpSolution, LocalMove, dict[str, float]]:  # type: ignore # avoid isinstance checks for efficiency
         if (
             variable.length is None
             or variable.lengths is None
@@ -490,6 +491,6 @@ class MutationTwoOptVRP(Mutation):
                 self.vrp_model.evaluate(variable),
             )
 
-    def mutate(self, variable: VrpSolution) -> Tuple[VrpSolution, LocalMove]:  # type: ignore # avoid isinstance checks for efficiency
+    def mutate(self, variable: VrpSolution) -> tuple[VrpSolution, LocalMove]:  # type: ignore # avoid isinstance checks for efficiency
         v, move, f = self.mutate_and_compute_obj(variable)
         return v, move

--- a/discrete_optimization/vrp/solver/solver_ortools.py
+++ b/discrete_optimization/vrp/solver/solver_ortools.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 
 import logging
 from enum import Enum
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 import numpy as np
 from ortools.constraint_solver import pywrapcp, routing_enums_pb2
@@ -138,8 +138,8 @@ class VrpORToolsSolver(SolverVrp):
             raise RuntimeError(
                 "self.manager should be not None when calling self.retrieve()."
             )
-        vehicle_tours: List[List[int]] = []
-        vehicle_tours_all: List[List[int]] = []
+        vehicle_tours: list[list[int]] = []
+        vehicle_tours_all: list[list[int]] = []
         vehicle_count: int = self.problem.vehicle_count
         objective = 0.0
         route_distance = 0.0

--- a/discrete_optimization/vrp/solver/vrp_cpsat_lns.py
+++ b/discrete_optimization/vrp/solver/vrp_cpsat_lns.py
@@ -2,7 +2,8 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 import random
-from typing import Any, Iterable
+from collections.abc import Iterable
+from typing import Any
 
 from ortools.sat.python.cp_model import Constraint
 

--- a/discrete_optimization/vrp/vrp_model.py
+++ b/discrete_optimization/vrp/vrp_model.py
@@ -4,9 +4,10 @@
 
 import math
 from abc import abstractmethod
+from collections.abc import Callable, Sequence
 from copy import deepcopy
 from functools import partial
-from typing import Callable, Dict, List, Optional, Sequence, Tuple, Type, Union
+from typing import Optional, Union
 
 import numpy as np
 from numba import njit
@@ -53,12 +54,12 @@ class VrpSolution(Solution):
     def __init__(
         self,
         problem: "VrpProblem",
-        list_start_index: List[int],
-        list_end_index: List[int],
-        list_paths: List[List[int]],
-        capacities: Optional[List[float]] = None,
+        list_start_index: list[int],
+        list_end_index: list[int],
+        list_paths: list[list[int]],
+        capacities: Optional[list[float]] = None,
         length: Optional[float] = None,
-        lengths: Optional[List[List[float]]] = None,
+        lengths: Optional[list[list[float]]] = None,
     ):
         self.problem = problem
         self.list_start_index = list_start_index
@@ -89,11 +90,11 @@ class VrpProblem(Problem):
     def __init__(
         self,
         vehicle_count: int,
-        vehicle_capacities: List[float],
+        vehicle_capacities: list[float],
         customer_count: int,
         customers: Sequence[BasicCustomer],
-        start_indexes: List[int],
-        end_indexes: List[int],
+        start_indexes: list[int],
+        end_indexes: list[int],
     ):
         self.vehicle_count = vehicle_count
         self.vehicle_capacities = vehicle_capacities
@@ -108,14 +109,14 @@ class VrpProblem(Problem):
     @abstractmethod
     def evaluate_function(
         self, var_tsp: VrpSolution
-    ) -> Tuple[List[List[float]], List[float], float, List[float]]:
+    ) -> tuple[list[list[float]], list[float], float, list[float]]:
         ...
 
     @abstractmethod
     def evaluate_function_indexes(self, index_1: int, index_2: int) -> float:
         ...
 
-    def evaluate(self, variable: VrpSolution) -> Dict[str, float]:  # type: ignore # avoid isinstance checks for efficiency
+    def evaluate(self, variable: VrpSolution) -> dict[str, float]:  # type: ignore # avoid isinstance checks for efficiency
         if (
             variable.lengths is None
             or variable.length is None
@@ -140,7 +141,7 @@ class VrpProblem(Problem):
         }
         return EncodingRegister(dict_encoding)
 
-    def get_solution_type(self) -> Type[Solution]:
+    def get_solution_type(self) -> type[Solution]:
         return VrpSolution
 
     def get_objective_register(self) -> ObjectiveRegister:
@@ -192,11 +193,11 @@ class VrpProblem2D(VrpProblem):
     def __init__(
         self,
         vehicle_count: int,
-        vehicle_capacities: List[float],
+        vehicle_capacities: list[float],
         customer_count: int,
         customers: Sequence[Customer2D],
-        start_indexes: List[int],
-        end_indexes: List[int],
+        start_indexes: list[int],
+        end_indexes: list[int],
     ):
         super().__init__(
             vehicle_count=vehicle_count,
@@ -210,17 +211,17 @@ class VrpProblem2D(VrpProblem):
 
     def evaluate_function(
         self, vrp_sol: VrpSolution
-    ) -> Tuple[List[List[float]], List[float], float, List[float]]:
+    ) -> tuple[list[list[float]], list[float], float, list[float]]:
         return self.evaluate_function_2d(vrp_sol)
 
     def evaluate_function_indexes(self, index_1: int, index_2: int) -> float:
         return length(self.customers[index_1], self.customers[index_2])
 
 
-def trivial_solution(vrp_model: VrpProblem) -> Tuple[VrpSolution, Dict[str, float]]:
+def trivial_solution(vrp_model: VrpProblem) -> tuple[VrpSolution, dict[str, float]]:
     # build a trivial solution
     # assign customers to vehicles starting by the largest customer demands
-    vehicle_tours: List[List[int]] = []
+    vehicle_tours: list[list[int]] = []
     customers = range(vrp_model.customer_count)
     nb_vehicles = vrp_model.vehicle_count
     nb_customers = vrp_model.customer_count
@@ -285,10 +286,10 @@ def trivial_solution(vrp_model: VrpProblem) -> Tuple[VrpSolution, Dict[str, floa
     return solution, fit
 
 
-def stupid_solution(vrp_model: VrpProblem) -> Tuple[VrpSolution, Dict[str, float]]:
+def stupid_solution(vrp_model: VrpProblem) -> tuple[VrpSolution, dict[str, float]]:
     # build a trivial solution
     # assign customers to vehicles starting by the largest customer demands
-    vehicle_tours: List[List[int]] = []
+    vehicle_tours: list[list[int]] = []
     customers = range(vrp_model.customer_count)
     nb_vehicles = vrp_model.vehicle_count
     remaining_capacity_vehicle = {
@@ -323,10 +324,10 @@ def stupid_solution(vrp_model: VrpProblem) -> Tuple[VrpSolution, Dict[str, float
 def compute_length(
     start_index: int,
     end_index: int,
-    solution: List[int],
+    solution: list[int],
     list_customers: Sequence[BasicCustomer],
     method: Callable[[int, int], float],
-) -> Tuple[List[float], float, float]:
+) -> tuple[list[float], float, float]:
     if len(solution) > 0:
         obj = method(start_index, solution[0])
         lengths = [obj]
@@ -355,9 +356,9 @@ def compute_length(
 def compute_length_np(
     start_index: int,
     end_index: int,
-    solution: Union[List[int], np.ndarray],
+    solution: Union[list[int], np.ndarray],
     np_points: np.ndarray,
-) -> Tuple[Union[List[float], np.ndarray], float]:
+) -> tuple[Union[list[float], np.ndarray], float]:
     obj = np.sqrt(
         (np_points[start_index, 0] - np_points[solution[0], 0]) ** 2
         + (np_points[start_index, 1] - np_points[solution[0], 1]) ** 2
@@ -382,10 +383,10 @@ def compute_length_np(
 
 def sequential_computing(
     vrp_sol: VrpSolution, vrp_model: VrpProblem
-) -> Tuple[List[List[float]], List[float], float, List[float]]:
-    lengths_list: List[List[float]] = []
-    obj_list: List[float] = []
-    capacity_list: List[float] = []
+) -> tuple[list[list[float]], list[float], float, list[float]]:
+    lengths_list: list[list[float]] = []
+    obj_list: list[float] = []
+    capacity_list: list[float] = []
     sum_obj = 0.0
     for i in range(len(vrp_sol.list_paths)):
         lengths, obj, capacity = compute_length(
@@ -404,5 +405,5 @@ def sequential_computing(
 
 def build_evaluate_function(
     vrp_model: VrpProblem,
-) -> Callable[[VrpSolution], Tuple[List[List[float]], List[float], float, List[float]]]:
+) -> Callable[[VrpSolution], tuple[list[list[float]], list[float], float, list[float]]]:
     return partial(sequential_computing, vrp_model=vrp_model)

--- a/discrete_optimization/vrp/vrp_parser.py
+++ b/discrete_optimization/vrp/vrp_parser.py
@@ -3,7 +3,7 @@
 #  LICENSE file in the root directory of this source tree.
 
 import os
-from typing import List, Optional
+from typing import Optional
 
 from discrete_optimization.datasets import get_data_home
 from discrete_optimization.vrp.vrp_model import Customer2D, VrpProblem2D
@@ -11,7 +11,7 @@ from discrete_optimization.vrp.vrp_model import Customer2D, VrpProblem2D
 
 def get_data_available(
     data_folder: Optional[str] = None, data_home: Optional[str] = None
-) -> List[str]:
+) -> list[str]:
     """Get datasets available for vrp.
 
     Params:
@@ -55,7 +55,7 @@ def parse_input(
         customers.append(
             Customer2D(i - 1, int(parts[0]), float(parts[1]), float(parts[2]))
         )
-    vehicle_capacities: List[float] = [vehicle_capacity] * vehicle_count
+    vehicle_capacities: list[float] = [vehicle_capacity] * vehicle_count
     start_indexes = [start_index] * vehicle_count
     end_indexes = [end_index] * vehicle_count
     return VrpProblem2D(

--- a/discrete_optimization/vrp/vrp_solvers.py
+++ b/discrete_optimization/vrp/vrp_solvers.py
@@ -2,7 +2,7 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, List, Tuple, Type
+from typing import Any
 
 from discrete_optimization.generic_tools.result_storage.result_storage import (
     ResultStorage,
@@ -13,7 +13,7 @@ from discrete_optimization.vrp.solver.solver_ortools import VrpORToolsSolver
 from discrete_optimization.vrp.solver.vrp_solver import SolverVrp
 from discrete_optimization.vrp.vrp_model import VrpProblem, VrpProblem2D
 
-solvers: Dict[str, List[Tuple[Type[SolverVrp], Dict[str, Any]]]] = {
+solvers: dict[str, list[tuple[type[SolverVrp], dict[str, Any]]]] = {
     "ortools": [(VrpORToolsSolver, {"time_limit": 100})],
     "lp": [(VRPIterativeLP, {}), (VRPIterativeLP_Pymip, {})],
 }
@@ -23,18 +23,18 @@ for key in solvers:
     for solver, param in solvers[key]:
         solvers_map[solver] = (key, param)
 
-solvers_compatibility: Dict[Type[SolverVrp], List[Type[VrpProblem]]] = {}
+solvers_compatibility: dict[type[SolverVrp], list[type[VrpProblem]]] = {}
 for x in solvers:
     for y in solvers[x]:
         solvers_compatibility[y[0]] = [VrpProblem2D]
 
 
-def look_for_solver(domain: VrpProblem) -> List[Type[SolverVrp]]:
+def look_for_solver(domain: VrpProblem) -> list[type[SolverVrp]]:
     class_domain = domain.__class__
     return look_for_solver_class(class_domain)
 
 
-def look_for_solver_class(class_domain: Type[VrpProblem]) -> List[Type[SolverVrp]]:
+def look_for_solver_class(class_domain: type[VrpProblem]) -> list[type[SolverVrp]]:
     available = []
     for solver in solvers_compatibility:
         if class_domain in solvers_compatibility[solver]:
@@ -42,7 +42,7 @@ def look_for_solver_class(class_domain: Type[VrpProblem]) -> List[Type[SolverVrp
     return available
 
 
-def solve(method: Type[SolverVrp], problem: VrpProblem, **kwargs: Any) -> ResultStorage:
+def solve(method: type[SolverVrp], problem: VrpProblem, **kwargs: Any) -> ResultStorage:
     solver = method(problem, **kwargs)
     try:
         solver.init_model(**kwargs)
@@ -52,7 +52,7 @@ def solve(method: Type[SolverVrp], problem: VrpProblem, **kwargs: Any) -> Result
 
 
 def return_solver(
-    method: Type[SolverVrp], problem: VrpProblem, **kwargs: Any
+    method: type[SolverVrp], problem: VrpProblem, **kwargs: Any
 ) -> SolverVrp:
     solver = method(problem, **kwargs)
     try:

--- a/discrete_optimization/vrp/vrp_toolbox.py
+++ b/discrete_optimization/vrp/vrp_toolbox.py
@@ -3,7 +3,6 @@
 #  LICENSE file in the root directory of this source tree.
 
 import logging
-from typing import Tuple
 
 import networkx as nx
 import numpy as np
@@ -13,7 +12,7 @@ from discrete_optimization.vrp.vrp_model import VrpProblem
 logger = logging.getLogger(__name__)
 
 
-def compute_length_matrix(vrp_model: VrpProblem) -> Tuple[np.ndarray, np.ndarray]:
+def compute_length_matrix(vrp_model: VrpProblem) -> tuple[np.ndarray, np.ndarray]:
     nb_customers = vrp_model.customer_count
     matrix_distance = np.zeros((nb_customers, nb_customers))
     for f in range(nb_customers):
@@ -26,7 +25,7 @@ def compute_length_matrix(vrp_model: VrpProblem) -> Tuple[np.ndarray, np.ndarray
 
 def prune_search_space(
     vrp_model: VrpProblem, n_shortest: int = 10
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     closest, matrix_distance = compute_length_matrix(vrp_model)
     matrix_adjacency = np.zeros(matrix_distance.shape, dtype=np.int_)
     nb_customers = vrp_model.customer_count
@@ -41,7 +40,7 @@ def prune_search_space(
     return matrix_adjacency, matrix_distance
 
 
-def build_graph(vrp_model: VrpProblem) -> Tuple[nx.Graph, np.ndarray]:
+def build_graph(vrp_model: VrpProblem) -> tuple[nx.Graph, np.ndarray]:
     matrix_adjacency, matrix_distance = prune_search_space(
         vrp_model=vrp_model, n_shortest=vrp_model.customer_count
     )

--- a/examples/coloring/optuna_all_solvers_coloring_with_pruning_based_on_time.py
+++ b/examples/coloring/optuna_all_solvers_coloring_with_pruning_based_on_time.py
@@ -11,7 +11,7 @@ Results can be viewed on optuna-dashboard with:
 import logging
 import time
 from collections import defaultdict
-from typing import Any, Dict, List, Type
+from typing import Any
 
 import optuna
 from optuna.storages import JournalFileStorage, JournalStorage
@@ -70,13 +70,13 @@ if not gurobi_available or not gurobi_full_license_available:
     solvers_to_remove.add(ColoringLP)
 if not toulbar2_available:
     solvers_to_remove.add(ToulbarColoringSolver)
-solvers_to_test: List[Type[SolverDO]] = [
+solvers_to_test: list[type[SolverDO]] = [
     s for s in solvers_map if s not in solvers_to_remove
 ]
 # solvers_to_test = [ColoringLP]
 p = ParametersCP.default_cpsat()
 p.nb_process = 6
-kwargs_fixed_by_solver: Dict[Type[SolverDO], Dict[str, Any]] = defaultdict(
+kwargs_fixed_by_solver: dict[type[SolverDO], dict[str, Any]] = defaultdict(
     dict,  # default kwargs for unspecified solvers
     {
         ColoringCPSatSolver: dict(parameters_cp=p, time_limit=max_time_per_solver),
@@ -89,7 +89,7 @@ kwargs_fixed_by_solver: Dict[Type[SolverDO], Dict[str, Any]] = defaultdict(
 
 # we need to map the classes to a unique string, to be seen as a categorical hyperparameter by optuna
 # by default, we use the class name, but if there are identical names, f"{cls.__module__}.{cls.__name__}" could be used.
-solvers_by_name: Dict[str, Type[SolverDO]] = {
+solvers_by_name: dict[str, type[SolverDO]] = {
     cls.__name__: cls for cls in solvers_to_test
 }
 

--- a/examples/coloring/optuna_all_solvers_coloring_without_pruning.py
+++ b/examples/coloring/optuna_all_solvers_coloring_without_pruning.py
@@ -14,7 +14,7 @@ Results can be viewed on optuna-dashboard with:
 import logging
 import time
 from collections import defaultdict
-from typing import Any, Dict, List, Type
+from typing import Any
 
 import optuna
 from optuna.storages import JournalFileStorage, JournalStorage
@@ -69,13 +69,13 @@ if not gurobi_available or not gurobi_full_license_available:
     solvers_to_remove.add(ColoringLP)
 if not toulbar2_available:
     solvers_to_remove.add(ToulbarColoringSolver)
-solvers_to_test: List[Type[SolverDO]] = [
+solvers_to_test: list[type[SolverDO]] = [
     s for s in solvers_map if s not in solvers_to_remove
 ]
 # solvers_to_test = [ColoringLP]
 p = ParametersCP.default_cpsat()
 p.nb_process = 6
-kwargs_fixed_by_solver: Dict[Type[SolverDO], Dict[str, Any]] = defaultdict(
+kwargs_fixed_by_solver: dict[type[SolverDO], dict[str, Any]] = defaultdict(
     dict,  # default kwargs for unspecified solvers
     {
         ColoringCPSatSolver: dict(parameters_cp=p, time_limit=max_time_per_solver),
@@ -88,7 +88,7 @@ kwargs_fixed_by_solver: Dict[Type[SolverDO], Dict[str, Any]] = defaultdict(
 
 # we need to map the classes to a unique string, to be seen as a categorical hyperparameter by optuna
 # by default, we use the class name, but if there are identical names, f"{cls.__module__}.{cls.__name__}" could be used.
-solvers_by_name: Dict[str, Type[SolverDO]] = {
+solvers_by_name: dict[str, type[SolverDO]] = {
     cls.__name__: cls for cls in solvers_to_test
 }
 

--- a/examples/coloring/optuna_full_example_all_solvers_timed_pruning.py
+++ b/examples/coloring/optuna_full_example_all_solvers_timed_pruning.py
@@ -17,7 +17,7 @@ Results can be viewed on optuna-dashboard with:
 """
 import logging
 from collections import defaultdict
-from typing import Any, Dict, List, Type
+from typing import Any
 
 from discrete_optimization.coloring.coloring_parser import (
     get_data_available,
@@ -69,13 +69,13 @@ if not gurobi_available or not gurobi_full_license_available:
     solvers_to_remove.add(ColoringLP)
 if not toulbar2_available:
     solvers_to_remove.add(ToulbarColoringSolver)
-solvers_to_test: List[Type[SolverDO]] = [
+solvers_to_test: list[type[SolverDO]] = [
     s for s in solvers_map if s not in solvers_to_remove
 ]
 # fixed kwargs per solver: either hyperparameters we do not want to search, or other parameters like time limits
 p = ParametersCP.default_cpsat()
 p.nb_process = 6
-kwargs_fixed_by_solver: Dict[Type[SolverDO], Dict[str, Any]] = defaultdict(
+kwargs_fixed_by_solver: dict[type[SolverDO], dict[str, Any]] = defaultdict(
     dict,  # default kwargs for unspecified solvers
     {
         ColoringCPSatSolver: dict(parameters_cp=p, time_limit=max_time_per_solver),
@@ -87,8 +87,8 @@ kwargs_fixed_by_solver: Dict[Type[SolverDO], Dict[str, Any]] = defaultdict(
 )
 
 # restrict some hyperparameters choices, for some solvers (making use of `kwargs_by_name` of `suggest_with_optuna`)
-suggest_optuna_kwargs_by_name_by_solver: Dict[
-    Type[SolverDO], Dict[str, Dict[str, Any]]
+suggest_optuna_kwargs_by_name_by_solver: dict[
+    type[SolverDO], dict[str, dict[str, Any]]
 ] = defaultdict(
     dict,  # default kwargs_by_name for unspecified solvers
     {

--- a/examples/coloring/optuna_full_example_coloring.py
+++ b/examples/coloring/optuna_full_example_coloring.py
@@ -10,7 +10,7 @@ Results can be viewed on optuna-dashboard with:
 """
 import logging
 from collections import defaultdict
-from typing import Any, Dict, List, Type
+from typing import Any
 
 import optuna
 from optuna.storages import JournalFileStorage, JournalStorage
@@ -42,18 +42,18 @@ study_name = f"coloring_cpsat-auto-250_7"
 storage_path = "./optuna-journal.log"  # NFS path for distributed optimization
 
 # Solvers to test and their associated kwargs
-solvers_to_test: List[Type[SolverDO]] = [ColoringCPSatSolver]
+solvers_to_test: list[type[SolverDO]] = [ColoringCPSatSolver]
 
 p = ParametersCP.default_cpsat()
 p.nb_process = 6
-kwargs_fixed_by_solver: Dict[Type[SolverDO], Dict[str, Any]] = defaultdict(
+kwargs_fixed_by_solver: dict[type[SolverDO], dict[str, Any]] = defaultdict(
     dict,  # default kwargs for unspecified solvers
     {ColoringCPSatSolver: dict(parameters_cp=p, time_limit=10)},
 )
 
 # we need to map the classes to a unique string, to be seen as a categorical hyperparameter by optuna
 # by default, we use the class name, but if there are identical names, f"{cls.__module__}.{cls.__name__}" could be used.
-solvers_by_name: Dict[str, Type[SolverDO]] = {
+solvers_by_name: dict[str, type[SolverDO]] = {
     cls.__name__: cls for cls in solvers_to_test
 }
 

--- a/examples/coloring/optuna_ortools_cpsat_finetuning.py
+++ b/examples/coloring/optuna_ortools_cpsat_finetuning.py
@@ -17,7 +17,7 @@ Results can be viewed on optuna-dashboard with:
 """
 import logging
 from collections import defaultdict
-from typing import Any, Dict, List, Type
+from typing import Any
 
 from ortools.sat.sat_parameters_pb2 import SatParameters
 
@@ -73,11 +73,11 @@ modelfilename = "gc_70_9"  # filename of the model used
 study_basename = f"coloring-ortools-cpsat-finetune-{modelfilename}"
 
 # solvers to test
-solvers_to_test: List[Type[SolverDO]] = [ColoringCPSatSolver]
+solvers_to_test: list[type[SolverDO]] = [ColoringCPSatSolver]
 # fixed kwargs per solver: either hyperparameters we do not want to search, or other parameters like time limits
 p = ParametersCP.default_cpsat()
 p.nb_process = 6
-kwargs_fixed_by_solver: Dict[Type[SolverDO], Dict[str, Any]] = defaultdict(
+kwargs_fixed_by_solver: dict[type[SolverDO], dict[str, Any]] = defaultdict(
     dict,  # default kwargs for unspecified solvers
     {
         ColoringCPSatSolver: dict(parameters_cp=p, time_limit=max_time_per_solver),
@@ -88,8 +88,8 @@ kwargs_fixed_by_solver: Dict[Type[SolverDO], Dict[str, Any]] = defaultdict(
     },
 )
 # restrict some hyperparameters choices, for some solvers (making use of `kwargs_by_name` of `suggest_with_optuna`)
-suggest_optuna_kwargs_by_name_by_solver: Dict[
-    Type[SolverDO], Dict[str, Dict[str, Any]]
+suggest_optuna_kwargs_by_name_by_solver: dict[
+    type[SolverDO], dict[str, dict[str, Any]]
 ] = defaultdict(
     dict,  # default kwargs_by_name for unspecified solvers
     {

--- a/examples/knapsack/optuna_example.py
+++ b/examples/knapsack/optuna_example.py
@@ -10,7 +10,7 @@ Results can be viewed on optuna-dashboard with:
 """
 import logging
 from collections import defaultdict
-from typing import Any, Dict, List, Type
+from typing import Any
 
 import optuna
 from optuna.storages import JournalFileStorage, JournalStorage
@@ -56,12 +56,12 @@ storage_path = "./optuna-journal.log"  # NFS path for distributed optimization
 
 
 # Solvers to test
-kwargs_fixed: Dict[str, Any] = dict(
+kwargs_fixed: dict[str, Any] = dict(
     initial_solver=SubBrick(
         cls=GreedyDummy, kwargs={}
     ),  # Start from empty solution : make the experiment more interesting :)
 )
-kwargs_fixed_by_root_subsolver: Dict[Type[SolverDO], Dict[str, Any]] = defaultdict(
+kwargs_fixed_by_root_subsolver: dict[type[SolverDO], dict[str, Any]] = defaultdict(
     dict,  # default kwargs factory for unspecified solvers
     {
         CPKnapsackMZN2: dict(time_limit=5),
@@ -69,7 +69,7 @@ kwargs_fixed_by_root_subsolver: Dict[Type[SolverDO], Dict[str, Any]] = defaultdi
         KnapsackASPSolver: dict(time_limit=5),
     },
 )
-suggest_optuna_kwargs_by_name: Dict[str, Any] = {
+suggest_optuna_kwargs_by_name: dict[str, Any] = {
     "root_solver": dict(
         # limit choices to some solvers
         choices=[KnapsackDynProg, CPKnapsackMZN, CPKnapsackMZN2, KnapsackASPSolver],

--- a/examples/maximum_independent_set/optuna_example.py
+++ b/examples/maximum_independent_set/optuna_example.py
@@ -20,7 +20,7 @@ os.environ["DO_SKIP_MZN_CHECK"] = "1"
 import logging
 import time
 from collections import defaultdict
-from typing import Any, Dict, List, Type
+from typing import Any
 
 import optuna
 from optuna import Trial
@@ -80,14 +80,14 @@ if not gurobi_available or not gurobi_full_license_available:
     solvers_to_remove.add(MisQuadraticSolver)
 if not kamis_available:
     solvers_to_remove.add(MisKamisSolver)
-solvers_to_test: List[Type[SolverDO]] = [
+solvers_to_test: list[type[SolverDO]] = [
     s for s in solvers_map if s not in solvers_to_remove
 ]
 
 p = ParametersCP.default_cpsat()
 p.nb_process = 6
 
-kwargs_fixed_by_solver: Dict[Type[SolverDO], Dict[str, Any]] = defaultdict(
+kwargs_fixed_by_solver: dict[type[SolverDO], dict[str, Any]] = defaultdict(
     dict,  # default kwargs for unspecified solvers
     {
         MisMilpSolver: dict(time_limit=max_time_per_solver),
@@ -99,7 +99,7 @@ kwargs_fixed_by_solver: Dict[Type[SolverDO], Dict[str, Any]] = defaultdict(
 
 # we need to map the classes to a unique string, to be seen as a categorical hyperparameter by optuna
 # by default, we use the class name, but if there are identical names, f"{cls.__module__}.{cls.__name__}" could be used.
-solvers_by_name: Dict[str, Type[SolverDO]] = {
+solvers_by_name: dict[str, type[SolverDO]] = {
     cls.__name__: cls for cls in solvers_to_test
 }
 

--- a/examples/pickup_vrp/cp_solver_gpdp_example.py
+++ b/examples/pickup_vrp/cp_solver_gpdp_example.py
@@ -8,7 +8,7 @@ import os
 import random
 from datetime import timedelta
 from enum import Enum
-from typing import Optional, Tuple
+from typing import Optional
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -67,16 +67,16 @@ class GPDPOutput:
         return True
 
 
-def ccw(A: Tuple[float, float], B: Tuple[float, float], C: Tuple[float, float]):
+def ccw(A: tuple[float, float], B: tuple[float, float], C: tuple[float, float]):
     return (C[1] - A[1]) * (B[0] - A[0]) > (B[1] - A[1]) * (C[0] - A[0])
 
 
 # Return true if line segments AB and CD intersect
 def intersect(
-    A: Tuple[float, float],
-    B: Tuple[float, float],
-    C: Tuple[float, float],
-    D: Tuple[float, float],
+    A: tuple[float, float],
+    B: tuple[float, float],
+    C: tuple[float, float],
+    D: tuple[float, float],
 ):
     return ccw(A, C, D) != ccw(B, C, D) and ccw(A, B, C) != ccw(A, B, D)
 

--- a/examples/pickup_vrp/optuna_full_example.py
+++ b/examples/pickup_vrp/optuna_full_example.py
@@ -10,7 +10,7 @@ Results can be viewed on optuna-dashboard with:
 """
 import logging
 from collections import defaultdict
-from typing import Any, Dict, List, Type
+from typing import Any
 
 import optuna
 from optuna.storages import JournalFileStorage, JournalStorage
@@ -44,8 +44,8 @@ storage_path = "./optuna-journal.log"  # NFS path for distributed optimization
 
 
 # Solvers to test
-solvers_to_test: List[Type[SolverDO]] = [ORToolsGPDP]
-kwargs_fixed_by_solver: Dict[Type[SolverDO], Dict[str, Any]] = defaultdict(
+solvers_to_test: list[type[SolverDO]] = [ORToolsGPDP]
+kwargs_fixed_by_solver: dict[type[SolverDO], dict[str, Any]] = defaultdict(
     dict,  # default kwargs factory for unspecified solvers
     {
         ORToolsGPDP: dict(
@@ -62,7 +62,7 @@ kwargs_fixed_by_solver: Dict[Type[SolverDO], Dict[str, Any]] = defaultdict(
 )
 # we need to map the classes to a unique string, to be seen as a categoricale hyperparameter by optuna
 # by default, we use the class name, but if there are identical names, f"{cls.__module__}.{cls.__name__}" could be used.
-solvers_by_name: Dict[str, Type[SolverDO]] = {
+solvers_by_name: dict[str, type[SolverDO]] = {
     cls.__name__: cls for cls in solvers_to_test
 }
 

--- a/examples/pickup_vrp/plots_wip/animated_plot.py
+++ b/examples/pickup_vrp/plots_wip/animated_plot.py
@@ -5,7 +5,7 @@
 import os
 from copy import deepcopy
 from functools import reduce
-from typing import Dict, List, Optional, Tuple
+from typing import Optional
 
 import cartopy
 import cartopy.crs as ccrs
@@ -17,9 +17,9 @@ from discrete_optimization.pickup_vrp.gpdp import GPDP
 
 class VehicleStatus:
     time: float
-    position: Tuple[float, float]
+    position: tuple[float, float]
     distance: float
-    capacity: Dict[str, int]
+    capacity: dict[str, int]
     status: str
 
     def __init__(self, time, position, distance, capacity, status, name_node):
@@ -46,7 +46,7 @@ class VehicleStatus:
 
 def post_process_solution(result, problem: GPDP, delta_time: int = 10):
     path_aircraft = {}
-    current_vehicle_status: Dict[int, VehicleStatus] = {
+    current_vehicle_status: dict[int, VehicleStatus] = {
         v: None for v in range(problem.number_vehicle)
     }
     vehicle_status_history = {v: [] for v in range(problem.number_vehicle)}
@@ -119,7 +119,7 @@ def post_process_solution(result, problem: GPDP, delta_time: int = 10):
     return path_aircraft, vehicle_status_history
 
 
-def compute_bounds(history: Dict[int, List[VehicleStatus]]):
+def compute_bounds(history: dict[int, list[VehicleStatus]]):
     x_0_min = min(
         [history[v][k].position[0] for v in history for k in range(len(history[v]))]
     )
@@ -136,7 +136,7 @@ def compute_bounds(history: Dict[int, List[VehicleStatus]]):
 
 
 def plot_flights(
-    history: Dict[int, List[VehicleStatus]],
+    history: dict[int, list[VehicleStatus]],
     problem: GPDP,
     plot_all_flight: bool = False,
     plot_network: bool = False,

--- a/examples/qiskit_examples/qiskit_optuna_coloring.py
+++ b/examples/qiskit_examples/qiskit_optuna_coloring.py
@@ -15,7 +15,7 @@ os.environ["DO_SKIP_MZN_CHECK"] = "1"
 
 import logging
 import time
-from typing import Any, Dict, List, Tuple, Type
+from typing import Any
 
 import optuna
 from optuna import Trial
@@ -62,7 +62,7 @@ storage_path = "./optuna-journal.log"  # NFS path for distributed optimization
 elapsed_time_attr = "elapsed_time"  # name of the user attribute used to store duration of trials (updated during intermediate reports)
 
 
-solvers: Dict[str, List[Tuple[Type[QiskitSolver], Dict[str, Any]]]] = {
+solvers: dict[str, list[tuple[type[QiskitSolver], dict[str, Any]]]] = {
     "qaoa": [
         (
             QAOAColoringSolver_MinimizeNbColor,
@@ -82,11 +82,11 @@ for key in solvers:
     for solver, param in solvers[key]:
         solvers_map[solver] = (key, param)
 
-solvers_to_test: List[Type[SolverDO]] = [s for s in solvers_map]
+solvers_to_test: list[type[SolverDO]] = [s for s in solvers_map]
 
 # we need to map the classes to a unique string, to be seen as a categorical hyperparameter by optuna
 # by default, we use the class name, but if there are identical names, f"{cls.__module__}.{cls.__name__}" could be used.
-solvers_by_name: Dict[str, Type[SolverDO]] = {
+solvers_by_name: dict[str, type[SolverDO]] = {
     cls.__name__: cls for cls in solvers_to_test
 }
 

--- a/examples/qiskit_examples/qiskit_optuna_knapsack.py
+++ b/examples/qiskit_examples/qiskit_optuna_knapsack.py
@@ -15,7 +15,7 @@ os.environ["DO_SKIP_MZN_CHECK"] = "1"
 
 import logging
 import time
-from typing import Any, Dict, List, Tuple, Type
+from typing import Any
 
 import optuna
 from optuna import Trial
@@ -66,7 +66,7 @@ storage_path = "./optuna-journal.log"  # NFS path for distributed optimization
 elapsed_time_attr = "elapsed_time"  # name of the user attribute used to store duration of trials (updated during intermediate reports)
 
 
-solvers: Dict[str, List[Tuple[Type[QiskitSolver], Dict[str, Any]]]] = {
+solvers: dict[str, list[tuple[type[QiskitSolver], dict[str, Any]]]] = {
     "qaoa": [
         (
             QAOAKnapsackSolver,
@@ -86,11 +86,11 @@ for key in solvers:
     for solver, param in solvers[key]:
         solvers_map[solver] = (key, param)
 
-solvers_to_test: List[Type[SolverDO]] = [s for s in solvers_map]
+solvers_to_test: list[type[SolverDO]] = [s for s in solvers_map]
 
 # we need to map the classes to a unique string, to be seen as a categorical hyperparameter by optuna
 # by default, we use the class name, but if there are identical names, f"{cls.__module__}.{cls.__name__}" could be used.
-solvers_by_name: Dict[str, Type[SolverDO]] = {
+solvers_by_name: dict[str, type[SolverDO]] = {
     cls.__name__: cls for cls in solvers_to_test
 }
 

--- a/examples/qiskit_examples/qiskit_optuna_mis.py
+++ b/examples/qiskit_examples/qiskit_optuna_mis.py
@@ -15,7 +15,7 @@ os.environ["DO_SKIP_MZN_CHECK"] = "1"
 
 import logging
 import time
-from typing import Any, Dict, List, Tuple, Type
+from typing import Any
 
 import networkx as nx
 import optuna
@@ -69,7 +69,7 @@ storage_path = "./optuna-journal.log"  # NFS path for distributed optimization
 elapsed_time_attr = "elapsed_time"  # name of the user attribute used to store duration of trials (updated during intermediate reports)
 
 
-solvers: Dict[str, List[Tuple[Type[QiskitSolver], Dict[str, Any]]]] = {
+solvers: dict[str, list[tuple[type[QiskitSolver], dict[str, Any]]]] = {
     "qaoa": [
         (
             QAOAMisSolver,
@@ -89,11 +89,11 @@ for key in solvers:
     for solver, param in solvers[key]:
         solvers_map[solver] = (key, param)
 
-solvers_to_test: List[Type[SolverDO]] = [s for s in solvers_map]
+solvers_to_test: list[type[SolverDO]] = [s for s in solvers_map]
 
 # we need to map the classes to a unique string, to be seen as a categorical hyperparameter by optuna
 # by default, we use the class name, but if there are identical names, f"{cls.__module__}.{cls.__name__}" could be used.
-solvers_by_name: Dict[str, Type[SolverDO]] = {
+solvers_by_name: dict[str, type[SolverDO]] = {
     cls.__name__: cls for cls in solvers_to_test
 }
 

--- a/examples/qiskit_examples/qiskit_optuna_tsp.py
+++ b/examples/qiskit_examples/qiskit_optuna_tsp.py
@@ -15,7 +15,7 @@ os.environ["DO_SKIP_MZN_CHECK"] = "1"
 
 import logging
 import time
-from typing import Any, Dict, List, Tuple, Type
+from typing import Any
 
 import optuna
 from optuna import Trial
@@ -60,7 +60,7 @@ storage_path = "./optuna-journal.log"  # NFS path for distributed optimization
 elapsed_time_attr = "elapsed_time"  # name of the user attribute used to store duration of trials (updated during intermediate reports)
 
 
-solvers: Dict[str, List[Tuple[Type[QiskitSolver], Dict[str, Any]]]] = {
+solvers: dict[str, list[tuple[type[QiskitSolver], dict[str, Any]]]] = {
     "qaoa": [
         (
             QAOATSPSolver,
@@ -80,11 +80,11 @@ for key in solvers:
     for solver, param in solvers[key]:
         solvers_map[solver] = (key, param)
 
-solvers_to_test: List[Type[SolverDO]] = [s for s in solvers_map]
+solvers_to_test: list[type[SolverDO]] = [s for s in solvers_map]
 
 # we need to map the classes to a unique string, to be seen as a categorical hyperparameter by optuna
 # by default, we use the class name, but if there are identical names, f"{cls.__module__}.{cls.__name__}" could be used.
-solvers_by_name: Dict[str, Type[SolverDO]] = {
+solvers_by_name: dict[str, type[SolverDO]] = {
     cls.__name__: cls for cls in solvers_to_test
 }
 

--- a/examples/rcpsp/optuna_all_solvers_multiple_instances.py
+++ b/examples/rcpsp/optuna_all_solvers_multiple_instances.py
@@ -13,7 +13,7 @@ import logging
 import re
 from collections import defaultdict
 from os.path import basename
-from typing import Any, Dict, Type
+from typing import Any
 
 from discrete_optimization.generic_rcpsp_tools.large_neighborhood_search_scheduling import (
     LargeNeighborhoodSearchScheduling,
@@ -64,7 +64,7 @@ solvers_to_test = look_for_solver(problems[0])
 # Fixed parameters
 parameters_cp = ParametersCP.default_cpsat()
 parameters_cp.nb_process = 6
-kwargs_fixed_by_solver: Dict[Type[SolverDO], Dict[str, Any]] = defaultdict(
+kwargs_fixed_by_solver: dict[type[SolverDO], dict[str, Any]] = defaultdict(
     dict,  # default kwargs for unspecified solvers
     {
         LargeNeighborhoodSearchScheduling: dict(
@@ -78,8 +78,8 @@ kwargs_fixed_by_solver: Dict[Type[SolverDO], Dict[str, Any]] = defaultdict(
 )
 
 # Restrict some hyperparameters choices, for some solvers (making use of `kwargs_by_name` of `suggest_with_optuna`)
-suggest_optuna_kwargs_by_name_by_solver: Dict[
-    Type[SolverDO], Dict[str, Dict[str, Any]]
+suggest_optuna_kwargs_by_name_by_solver: dict[
+    type[SolverDO], dict[str, dict[str, Any]]
 ] = defaultdict(
     dict,  # default kwargs_by_name for unspecified solvers
     {},

--- a/examples/rcpsp_multiskill/sgs_runs.py
+++ b/examples/rcpsp_multiskill/sgs_runs.py
@@ -3,7 +3,6 @@
 #  LICENSE file in the root directory of this source tree.
 
 import time
-from typing import Dict, List, Set
 
 import matplotlib.pyplot as plt
 
@@ -26,11 +25,11 @@ from discrete_optimization.rcpsp_multiskill.rcpsp_multiskill_parser import (
 
 
 def create_toy_msrcpsp_variant():
-    skills_set: Set[str] = {"S1", "S2", "S3"}
-    resources_set: Set[str] = {"R1", "R2", "R3"}
+    skills_set: set[str] = {"S1", "S2", "S3"}
+    resources_set: set[str] = {"R1", "R2", "R3"}
     non_renewable_resources = set()
     resources_availability = {"R1": [2] * 100, "R2": [4] * 100, "R3": [3] * 100}
-    employee: Dict[int, Employee] = {
+    employee: dict[int, Employee] = {
         1: Employee(
             dict_skill={"S1": SkillDetail(1.0, 1.0, 1.0)},
             calendar_employee=[True] * 100,
@@ -53,8 +52,8 @@ def create_toy_msrcpsp_variant():
             employee[emp].calendar_employee[i] = False
         index += 1
 
-    employees_availability: List[int] = [3] * 1000
-    mode_details: Dict[int, Dict[int, Dict[str, int]]] = {
+    employees_availability: list[int] = [3] * 1000
+    mode_details: dict[int, dict[int, dict[str, int]]] = {
         1: {1: {"R1": 0, "R2": 0, "R3": 0, "duration": 0}},
         2: {
             1: {"S1": 1, "R1": 2, "R2": 0, "R3": 0, "duration": 2},
@@ -70,7 +69,7 @@ def create_toy_msrcpsp_variant():
         },
         8: {1: {"R1": 0, "R2": 0, "R3": 0, "duration": 0}},
     }
-    successors: Dict[int, List[int]] = {
+    successors: dict[int, list[int]] = {
         1: [2, 3],
         2: [5],
         3: [4],

--- a/examples/rcpsp_multiskill/solvers/rcpsp_multiskills_runs.py
+++ b/examples/rcpsp_multiskill/solvers/rcpsp_multiskills_runs.py
@@ -4,7 +4,6 @@
 
 import random
 import time
-from typing import Dict, List, Set
 
 import matplotlib.pyplot as plt
 
@@ -32,11 +31,11 @@ from discrete_optimization.rcpsp_multiskill.solvers.lp_model import (
 
 
 def run_lp_debug():
-    skills_set: Set[str] = {"S1", "S2", "S3"}
-    resources_set: Set[str] = {"R1", "R2", "R3"}
+    skills_set: set[str] = {"S1", "S2", "S3"}
+    resources_set: set[str] = {"R1", "R2", "R3"}
     non_renewable_resources = set()
     resources_availability = {"R1": [2] * 100, "R2": [4] * 100, "R3": [3] * 100}
-    employee: Dict[int, Employee] = {
+    employee: dict[int, Employee] = {
         1: Employee(
             dict_skill={"S1": SkillDetail(1.0, 1.0, 1.0)},
             calendar_employee=[True] * 1000,
@@ -50,15 +49,15 @@ def run_lp_debug():
             calendar_employee=[True] * 1000,
         ),
     }
-    employees_availability: List[int] = [3] * 1000
-    mode_details: Dict[int, Dict[int, Dict[str, int]]] = {
+    employees_availability: list[int] = [3] * 1000
+    mode_details: dict[int, dict[int, dict[str, int]]] = {
         1: {1: {"R1": 0, "R2": 0, "R3": 0, "duration": 0}},
         2: {1: {"S1": 1, "R1": 2, "R2": 0, "R3": 0, "duration": 2}},
         3: {1: {"S2": 1, "R1": 1, "R2": 2, "R3": 0, "duration": 4}},
         4: {1: {"S3": 1, "R1": 2, "R2": 0, "R3": 0, "duration": 5}},
         5: {1: {"R1": 0, "R2": 0, "R3": 0, "duration": 0}},
     }
-    successors: Dict[int, List[int]] = {1: [2, 3], 2: [5], 3: [4], 4: [5], 5: []}
+    successors: dict[int, list[int]] = {1: [2, 3], 2: [5], 3: [4], 4: [5], 5: []}
 
     model = MS_RCPSPModel(
         skills_set=skills_set,
@@ -78,11 +77,11 @@ def run_lp_debug():
 
 
 def run_lp_debug_bis():
-    skills_set: Set[str] = {"S1", "S2", "S3"}
-    resources_set: Set[str] = {"R1", "R2", "R3"}
+    skills_set: set[str] = {"S1", "S2", "S3"}
+    resources_set: set[str] = {"R1", "R2", "R3"}
     non_renewable_resources = set()
     resources_availability = {"R1": [2] * 100, "R2": [4] * 100, "R3": [3] * 100}
-    employee: Dict[int, Employee] = {
+    employee: dict[int, Employee] = {
         1: Employee(
             dict_skill={"S1": SkillDetail(1.0, 1.0, 1.0)},
             calendar_employee=[True] * 100,
@@ -105,8 +104,8 @@ def run_lp_debug_bis():
             employee[emp].calendar_employee[i] = False
         index += 1
 
-    employees_availability: List[int] = [3] * 1000
-    mode_details: Dict[int, Dict[int, Dict[str, int]]] = {
+    employees_availability: list[int] = [3] * 1000
+    mode_details: dict[int, dict[int, dict[str, int]]] = {
         1: {1: {"R1": 0, "R2": 0, "R3": 0, "duration": 0}},
         2: {
             1: {"S1": 1, "R1": 2, "R2": 0, "R3": 0, "duration": 2},
@@ -122,7 +121,7 @@ def run_lp_debug_bis():
         },
         8: {1: {"R1": 0, "R2": 0, "R3": 0, "duration": 0}},
     }
-    successors: Dict[int, List[int]] = {
+    successors: dict[int, list[int]] = {
         1: [2, 3],
         2: [5],
         3: [4],
@@ -154,11 +153,11 @@ def run_lp_debug_bis():
 
 
 def create_toy_msrcpsp():
-    skills_set: Set[str] = {"S1", "S2", "S3"}
-    resources_set: Set[str] = {"R1", "R2", "R3"}
+    skills_set: set[str] = {"S1", "S2", "S3"}
+    resources_set: set[str] = {"R1", "R2", "R3"}
     non_renewable_resources = set()
     resources_availability = {"R1": [2] * 100, "R2": [4] * 100, "R3": [3] * 100}
-    employee: Dict[int, Employee] = {
+    employee: dict[int, Employee] = {
         1: Employee(
             dict_skill={"S1": SkillDetail(1.0, 1.0, 1.0)},
             calendar_employee=[True] * 100,
@@ -181,8 +180,8 @@ def create_toy_msrcpsp():
             employee[emp].calendar_employee[i] = False
         index += 1
 
-    employees_availability: List[int] = [3] * 1000
-    mode_details: Dict[int, Dict[int, Dict[str, int]]] = {
+    employees_availability: list[int] = [3] * 1000
+    mode_details: dict[int, dict[int, dict[str, int]]] = {
         1: {1: {"R1": 0, "R2": 0, "R3": 0, "duration": 0}},
         2: {
             1: {"S1": 1, "R1": 2, "R2": 0, "R3": 0, "duration": 2},
@@ -198,7 +197,7 @@ def create_toy_msrcpsp():
         },
         8: {1: {"R1": 0, "R2": 0, "R3": 0, "duration": 0}},
     }
-    successors: Dict[int, List[int]] = {
+    successors: dict[int, list[int]] = {
         1: [2, 3],
         2: [5],
         3: [4],
@@ -225,11 +224,11 @@ def create_toy_msrcpsp():
 
 
 def create_toy_msrcpsp_variant():
-    skills_set: Set[str] = {"S1", "S2", "S3"}
-    resources_set: Set[str] = {"R1", "R2", "R3"}
+    skills_set: set[str] = {"S1", "S2", "S3"}
+    resources_set: set[str] = {"R1", "R2", "R3"}
     non_renewable_resources = set()
     resources_availability = {"R1": [2] * 100, "R2": [4] * 100, "R3": [3] * 100}
-    employee: Dict[int, Employee] = {
+    employee: dict[int, Employee] = {
         1: Employee(
             dict_skill={"S1": SkillDetail(1.0, 1.0, 1.0)},
             calendar_employee=[True] * 100,
@@ -252,8 +251,8 @@ def create_toy_msrcpsp_variant():
             employee[emp].calendar_employee[i] = False
         index += 1
 
-    employees_availability: List[int] = [3] * 1000
-    mode_details: Dict[int, Dict[int, Dict[str, int]]] = {
+    employees_availability: list[int] = [3] * 1000
+    mode_details: dict[int, dict[int, dict[str, int]]] = {
         1: {1: {"R1": 0, "R2": 0, "R3": 0, "duration": 0}},
         2: {
             1: {"S1": 1, "R1": 2, "R2": 0, "R3": 0, "duration": 2},
@@ -269,7 +268,7 @@ def create_toy_msrcpsp_variant():
         },
         8: {1: {"R1": 0, "R2": 0, "R3": 0, "duration": 0}},
     }
-    successors: Dict[int, List[int]] = {
+    successors: dict[int, list[int]] = {
         1: [2, 3],
         2: [5],
         3: [4],

--- a/notebooks/RCPSP tutorials/RCPSP-1 Introduction.ipynb
+++ b/notebooks/RCPSP tutorials/RCPSP-1 Introduction.ipynb
@@ -527,7 +527,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.18"
+   "version": "3.12.2"
   },
   "toc": {
    "base_numbering": 1,

--- a/notebooks/z_Advanced/callbacks.ipynb
+++ b/notebooks/z_Advanced/callbacks.ipynb
@@ -458,7 +458,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.18"
+   "version": "3.12.2"
   }
  },
  "nbformat": 4,

--- a/notebooks/z_Advanced/optuna.ipynb
+++ b/notebooks/z_Advanced/optuna.ipynb
@@ -926,7 +926,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.18"
+   "version": "3.12.2"
   },
   "toc": {
    "base_numbering": 1,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Topic :: Software Development",
     "Topic :: Scientific/Engineering",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "shapely>=1.7",
     "mip>=1.13",

--- a/tests/generic_tools/callbacks/test_timed_callbacks_n_pruner.py
+++ b/tests/generic_tools/callbacks/test_timed_callbacks_n_pruner.py
@@ -5,7 +5,7 @@
 
 import random
 from time import sleep
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 import numpy as np
 import pytest
@@ -54,7 +54,7 @@ class FakeSolver(SolverDO):
     nb_colors_series = [100 - i for i in range(96)]
 
     def solve(
-        self, callbacks: Optional[List[Callback]] = None, **kwargs: Any
+        self, callbacks: Optional[list[Callback]] = None, **kwargs: Any
     ) -> ResultStorage:
         kwargs = self.complete_with_default_hyperparameters(kwargs)
         param = kwargs["param"]

--- a/tests/generic_tools/hyperparameters/test_hyperparameter.py
+++ b/tests/generic_tools/hyperparameters/test_hyperparameter.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 import optuna
 import pytest
@@ -45,7 +45,7 @@ class DummySolver(SolverDO):
     ]
 
     def solve(
-        self, callbacks: Optional[List[Callback]] = None, **kwargs: Any
+        self, callbacks: Optional[list[Callback]] = None, **kwargs: Any
     ) -> ResultStorage:
         return self.create_result_storage()
 
@@ -78,7 +78,7 @@ class DummySolverWithFloatSuggestingBound(SolverDO):
     ]
 
     def solve(
-        self, callbacks: Optional[List[Callback]] = None, **kwargs: Any
+        self, callbacks: Optional[list[Callback]] = None, **kwargs: Any
     ) -> ResultStorage:
         return self.create_result_storage()
 
@@ -107,7 +107,7 @@ class DummySolverWithCallableHyperparameter(SolverDO):
     ]
 
     def solve(
-        self, callbacks: Optional[List[Callback]] = None, **kwargs: Any
+        self, callbacks: Optional[list[Callback]] = None, **kwargs: Any
     ) -> ResultStorage:
         return self.create_result_storage()
 
@@ -126,7 +126,7 @@ class DummySolverWithEnumSubset(SolverDO):
     ]
 
     def solve(
-        self, callbacks: Optional[List[Callback]] = None, **kwargs: Any
+        self, callbacks: Optional[list[Callback]] = None, **kwargs: Any
     ) -> ResultStorage:
         return self.create_result_storage()
 
@@ -148,7 +148,7 @@ class DummySolverWithDependencies(SolverDO):
     ]
 
     def solve(
-        self, callbacks: Optional[List[Callback]] = None, **kwargs: Any
+        self, callbacks: Optional[list[Callback]] = None, **kwargs: Any
     ) -> ResultStorage:
         return self.create_result_storage()
 
@@ -179,7 +179,7 @@ class DummySolverWithNameInKwargs(SolverDO):
     ]
 
     def solve(
-        self, callbacks: Optional[List[Callback]] = None, **kwargs: Any
+        self, callbacks: Optional[list[Callback]] = None, **kwargs: Any
     ) -> ResultStorage:
         return self.create_result_storage()
 
@@ -192,7 +192,7 @@ class DummySolver2(SolverDO):
     ]
 
     def solve(
-        self, callbacks: Optional[List[Callback]] = None, **kwargs: Any
+        self, callbacks: Optional[list[Callback]] = None, **kwargs: Any
     ) -> ResultStorage:
         return self.create_result_storage()
 
@@ -204,7 +204,7 @@ class BaseMetaSolver(SolverDO):
     ]
 
     def solve(
-        self, callbacks: Optional[List[Callback]] = None, **kwargs: Any
+        self, callbacks: Optional[list[Callback]] = None, **kwargs: Any
     ) -> ResultStorage:
         return self.create_result_storage()
 
@@ -233,7 +233,7 @@ class MetaSolverFixedSubsolver(SolverDO):
     ]
 
     def solve(
-        self, callbacks: Optional[List[Callback]] = None, **kwargs: Any
+        self, callbacks: Optional[list[Callback]] = None, **kwargs: Any
     ) -> ResultStorage:
         return self.create_result_storage()
 
@@ -248,7 +248,7 @@ class MetaMetaSolver(SolverDO):
     ]
 
     def solve(
-        self, callbacks: Optional[List[Callback]] = None, **kwargs: Any
+        self, callbacks: Optional[list[Callback]] = None, **kwargs: Any
     ) -> ResultStorage:
         return self.create_result_storage()
 
@@ -267,7 +267,7 @@ class MetaSolverWithListWithoutReplacement(SolverDO):
     ]
 
     def solve(
-        self, callbacks: Optional[List[Callback]] = None, **kwargs: Any
+        self, callbacks: Optional[list[Callback]] = None, **kwargs: Any
     ) -> ResultStorage:
         return self.create_result_storage()
 

--- a/tests/generic_tools/optuna/test_optuna_utils.py
+++ b/tests/generic_tools/optuna/test_optuna_utils.py
@@ -3,7 +3,7 @@
 #  LICENSE file in the root directory of this source tree.
 
 import random
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 import numpy as np
 import pytest
@@ -64,7 +64,7 @@ class FakeSolver(SolverDO, WarmstartMixin):
         self.nb_colors_warm_start = solution.nb_color
 
     def solve(
-        self, callbacks: Optional[List[Callback]] = None, **kwargs: Any
+        self, callbacks: Optional[list[Callback]] = None, **kwargs: Any
     ) -> ResultStorage:
         kwargs = self.complete_with_default_hyperparameters(kwargs)
         param = kwargs["param"]
@@ -96,7 +96,7 @@ class FakeSolver2(SolverDO):
     nb_colors_series = [100 - i for i in range(96)]
 
     def solve(
-        self, callbacks: Optional[List[Callback]] = None, **kwargs: Any
+        self, callbacks: Optional[list[Callback]] = None, **kwargs: Any
     ) -> ResultStorage:
         kwargs = self.complete_with_default_hyperparameters(kwargs)
         param = kwargs["param2"]
@@ -339,7 +339,7 @@ class FakeMetaSolver(SolverDO):
     ]
 
     def solve(
-        self, callbacks: Optional[List[Callback]] = None, **kwargs: Any
+        self, callbacks: Optional[list[Callback]] = None, **kwargs: Any
     ) -> ResultStorage:
         subbrick = kwargs["subsolver"]
         subsolver_kwargs = dict(subbrick.kwargs)

--- a/tests/knapsack/test_knapsack_lexico_ortools_solver.py
+++ b/tests/knapsack/test_knapsack_lexico_ortools_solver.py
@@ -2,7 +2,7 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 import logging
-from typing import Dict, List, Optional
+from typing import Optional
 
 import numpy as np
 import pytest
@@ -46,13 +46,13 @@ from discrete_optimization.knapsack.solvers.knapsack_cpsat_solver import (
 )
 
 
-def fit2dict(solver: SolverDO, fit: TupleFitness) -> Dict[str, float]:
+def fit2dict(solver: SolverDO, fit: TupleFitness) -> dict[str, float]:
     return dict(zip(solver.problem.get_objective_names(), fit.vector_fitness))
 
 
 class MyCallback(Callback):
     def __init__(self):
-        self.res_by_step: List[List[Dict[str, float]]] = []
+        self.res_by_step: list[list[dict[str, float]]] = []
 
     def on_step_end(
         self, step: int, res: ResultStorage, solver: SolverDO

--- a/tests/knapsack/test_knapsack_lns_cp_solver.py
+++ b/tests/knapsack/test_knapsack_lns_cp_solver.py
@@ -2,7 +2,6 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 from time import sleep
-from typing import Any, Hashable, Mapping, Optional
 
 import pytest
 from ortools.sat.python.cp_model import Constraint

--- a/tests/maximum_independent_set/test_lns_optuna.py
+++ b/tests/maximum_independent_set/test_lns_optuna.py
@@ -3,7 +3,7 @@
 #  LICENSE file in the root directory of this source tree.
 import logging
 import random
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 import numpy as np
 import pytest
@@ -83,7 +83,7 @@ class LNS_OrtoolsCPSat_Mix(LNS_OrtoolsCPSat):
 
     """
 
-    generated_constraint_handlers: List[ConstraintHandlerMix] = []
+    generated_constraint_handlers: list[ConstraintHandlerMix] = []
 
     hyperparameters = [
         h for h in LNS_OrtoolsCPSat.hyperparameters if h.name != "constraint_handler"
@@ -109,7 +109,7 @@ class LNS_OrtoolsCPSat_Mix(LNS_OrtoolsCPSat):
     def __init__(
         self,
         problem: Problem,
-        list_constraint_handlers: Optional[List[ConstraintHandler]] = None,
+        list_constraint_handlers: Optional[list[ConstraintHandler]] = None,
         subsolver: Optional[OrtoolsCPSatSolver] = None,
         initial_solution_provider: Optional[InitialSolution] = None,
         post_process_solution: Optional[PostProcessSolution] = None,

--- a/tests/rcpsp/solver/test_rcpsp_ortools_lexico.py
+++ b/tests/rcpsp/solver/test_rcpsp_ortools_lexico.py
@@ -3,7 +3,7 @@
 #  LICENSE file in the root directory of this source tree.
 
 
-from typing import List, Optional
+from typing import Optional
 
 import numpy as np
 import pytest
@@ -25,7 +25,7 @@ from discrete_optimization.rcpsp.solver.cpsat_solver import (
 
 class RetrieveSubRes(Callback):
     def __init__(self):
-        self.sol_per_step: List[List[Solution]] = []
+        self.sol_per_step: list[list[Solution]] = []
         self.all_sols = set()
 
     def on_step_end(

--- a/tests/rcpsp/test_rcpsp_model.py
+++ b/tests/rcpsp/test_rcpsp_model.py
@@ -3,8 +3,8 @@
 #  LICENSE file in the root directory of this source tree.
 
 import random
+from collections.abc import Hashable
 from math import isclose
-from typing import Dict, Hashable, Tuple
 
 import pytest
 
@@ -111,7 +111,7 @@ def test_feasible_modes_solution():
 
 def create_task_details_classic(
     solution: RCPSPSolution, time_to_cut: int
-) -> Tuple[Dict[Hashable, TaskDetails], Dict[Hashable, TaskDetails]]:
+) -> tuple[dict[Hashable, TaskDetails], dict[Hashable, TaskDetails]]:
     finished = set(
         [t for t in solution.rcpsp_schedule if solution.get_end_time(t) <= time_to_cut]
     )

--- a/tests/rcpsp_multiskill/test_rcpsp_ms_cp.py
+++ b/tests/rcpsp_multiskill/test_rcpsp_ms_cp.py
@@ -2,8 +2,6 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Dict, List, Set
-
 from discrete_optimization.generic_tools.cp_tools import CPSolverName, ParametersCP
 from discrete_optimization.rcpsp_multiskill.rcpsp_multiskill import (
     Employee,
@@ -22,11 +20,11 @@ from discrete_optimization.rcpsp_multiskill.solvers.cp_solvers import (
 
 
 def create_toy_msrcpsp():
-    skills_set: Set[str] = {"S1", "S2", "S3"}
-    resources_set: Set[str] = {"R1", "R2", "R3"}
+    skills_set: set[str] = {"S1", "S2", "S3"}
+    resources_set: set[str] = {"R1", "R2", "R3"}
     non_renewable_resources = set()
     resources_availability = {"R1": [2] * 100, "R2": [4] * 100, "R3": [3] * 100}
-    employee: Dict[int, Employee] = {
+    employee: dict[int, Employee] = {
         1: Employee(
             dict_skill={"S1": SkillDetail(1.0, 1.0, 1.0)},
             calendar_employee=[True] * 100,
@@ -66,8 +64,8 @@ def create_toy_msrcpsp():
             employee[emp].calendar_employee[i] = True
         index += 1
 
-    employees_availability: List[int] = [3] * 1000
-    mode_details: Dict[int, Dict[int, Dict[str, int]]] = {
+    employees_availability: list[int] = [3] * 1000
+    mode_details: dict[int, dict[int, dict[str, int]]] = {
         1: {1: {"R1": 0, "R2": 0, "R3": 0, "duration": 0}},
         2: {
             1: {"S1": 1, "R1": 2, "R2": 0, "R3": 0, "duration": 2},
@@ -83,7 +81,7 @@ def create_toy_msrcpsp():
         },
         8: {1: {"R1": 0, "R2": 0, "R3": 0, "duration": 0}},
     }
-    successors: Dict[int, List[int]] = {
+    successors: dict[int, list[int]] = {
         1: [2, 3],
         2: [5],
         3: [4],
@@ -109,12 +107,12 @@ def create_toy_msrcpsp():
 
 
 def create_toy_v2():
-    skills_set: Set[str] = {"S1", "S2", "S3"}
-    resources_set: Set[str] = {"R1", "R2", "R3"}
+    skills_set: set[str] = {"S1", "S2", "S3"}
+    resources_set: set[str] = {"R1", "R2", "R3"}
     non_renewable_resources = set()
     resources_availability = {"R1": [200] * 100, "R2": [400] * 100, "R3": [300] * 100}
 
-    employee: Dict[int, Employee] = {
+    employee: dict[int, Employee] = {
         1: Employee(
             dict_skill={
                 "S1": SkillDetail(10, 0, 0),
@@ -140,8 +138,8 @@ def create_toy_v2():
             employee[emp].calendar_employee[i] = True
         index += 1
 
-    employees_availability: List[int] = [3] * 1000
-    mode_details: Dict[int, Dict[int, Dict[str, int]]] = {
+    employees_availability: list[int] = [3] * 1000
+    mode_details: dict[int, dict[int, dict[str, int]]] = {
         1: {1: {"R1": 0, "R2": 0, "R3": 0, "duration": 0}},
         2: {1: {"S1": 1, "S3": 1, "R1": 1, "R2": 0, "R3": 0, "duration": 2}},
         3: {1: {"S2": 1, "R1": 1, "R2": 2, "R3": 0, "duration": 4}},
@@ -155,7 +153,7 @@ def create_toy_v2():
         8: {1: {"R1": 0, "R2": 0, "R3": 0, "duration": 0}},
     }
 
-    successors: Dict[int, List[int]] = {
+    successors: dict[int, list[int]] = {
         1: [],
         2: [],
         3: [],

--- a/tests/rcpsp_multiskill/test_rcpsp_ms_ga.py
+++ b/tests/rcpsp_multiskill/test_rcpsp_ms_ga.py
@@ -3,7 +3,6 @@
 #  LICENSE file in the root directory of this source tree.
 
 import random
-from typing import Dict, List, Set
 
 import numpy as np
 import pytest
@@ -30,11 +29,11 @@ def random_seed():
 
 
 def create_toy_msrcpsp():
-    skills_set: Set[str] = {"S1", "S2", "S3"}
-    resources_set: Set[str] = {"R1", "R2", "R3"}
+    skills_set: set[str] = {"S1", "S2", "S3"}
+    resources_set: set[str] = {"R1", "R2", "R3"}
     non_renewable_resources = set()
     resources_availability = {"R1": [2] * 100, "R2": [4] * 100, "R3": [3] * 100}
-    employee: Dict[int, Employee] = {
+    employee: dict[int, Employee] = {
         1: Employee(
             dict_skill={"S1": SkillDetail(1.0, 1.0, 1.0)},
             calendar_employee=[True] * 100,
@@ -57,8 +56,8 @@ def create_toy_msrcpsp():
             employee[emp].calendar_employee[i] = False
         index += 1
 
-    employees_availability: List[int] = [3] * 1000
-    mode_details: Dict[int, Dict[int, Dict[str, int]]] = {
+    employees_availability: list[int] = [3] * 1000
+    mode_details: dict[int, dict[int, dict[str, int]]] = {
         1: {1: {"R1": 0, "R2": 0, "R3": 0, "duration": 0}},
         2: {
             1: {"S1": 1, "R1": 2, "R2": 0, "R3": 0, "duration": 2},
@@ -74,7 +73,7 @@ def create_toy_msrcpsp():
         },
         8: {1: {"R1": 0, "R2": 0, "R3": 0, "duration": 0}},
     }
-    successors: Dict[int, List[int]] = {
+    successors: dict[int, list[int]] = {
         1: [2, 3],
         2: [5],
         3: [4],
@@ -101,11 +100,11 @@ def create_toy_msrcpsp():
 
 
 def create_toy_msrcpsp_variant():
-    skills_set: Set[str] = {"S1", "S2", "S3"}
-    resources_set: Set[str] = {"R1", "R2", "R3"}
+    skills_set: set[str] = {"S1", "S2", "S3"}
+    resources_set: set[str] = {"R1", "R2", "R3"}
     non_renewable_resources = set()
     resources_availability = {"R1": [2] * 100, "R2": [4] * 100, "R3": [3] * 100}
-    employee: Dict[int, Employee] = {
+    employee: dict[int, Employee] = {
         1: Employee(
             dict_skill={"S1": SkillDetail(1.0, 1.0, 1.0)},
             calendar_employee=[True] * 100,
@@ -128,8 +127,8 @@ def create_toy_msrcpsp_variant():
             employee[emp].calendar_employee[i] = False
         index += 1
 
-    employees_availability: List[int] = [3] * 1000
-    mode_details: Dict[int, Dict[int, Dict[str, int]]] = {
+    employees_availability: list[int] = [3] * 1000
+    mode_details: dict[int, dict[int, dict[str, int]]] = {
         1: {1: {"R1": 0, "R2": 0, "R3": 0, "duration": 0}},
         2: {
             1: {"S1": 1, "R1": 2, "R2": 0, "R3": 0, "duration": 2},
@@ -145,7 +144,7 @@ def create_toy_msrcpsp_variant():
         },
         8: {1: {"R1": 0, "R2": 0, "R3": 0, "duration": 0}},
     }
-    successors: Dict[int, List[int]] = {
+    successors: dict[int, list[int]] = {
         1: [2, 3],
         2: [5],
         3: [4],

--- a/tests/rcpsp_multiskill/test_rcpsp_ms_lp.py
+++ b/tests/rcpsp_multiskill/test_rcpsp_ms_lp.py
@@ -2,7 +2,6 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 import platform
-from typing import Dict, List, Set
 
 import pytest
 
@@ -26,11 +25,11 @@ if platform.machine() == "arm64":
 
 
 def test_lp():
-    skills_set: Set[str] = {"S1", "S2", "S3"}
-    resources_set: Set[str] = {"R1", "R2", "R3"}
+    skills_set: set[str] = {"S1", "S2", "S3"}
+    resources_set: set[str] = {"R1", "R2", "R3"}
     non_renewable_resources = set()
     resources_availability = {"R1": [2] * 100, "R2": [4] * 100, "R3": [3] * 100}
-    employee: Dict[int, Employee] = {
+    employee: dict[int, Employee] = {
         1: Employee(
             dict_skill={"S1": SkillDetail(1.0, 1.0, 1.0)},
             calendar_employee=[True] * 1000,
@@ -44,15 +43,15 @@ def test_lp():
             calendar_employee=[True] * 1000,
         ),
     }
-    employees_availability: List[int] = [3] * 1000
-    mode_details: Dict[int, Dict[int, Dict[str, int]]] = {
+    employees_availability: list[int] = [3] * 1000
+    mode_details: dict[int, dict[int, dict[str, int]]] = {
         1: {1: {"R1": 0, "R2": 0, "R3": 0, "duration": 0}},
         2: {1: {"S1": 1, "R1": 2, "R2": 0, "R3": 0, "duration": 2}},
         3: {1: {"S2": 1, "R1": 1, "R2": 2, "R3": 0, "duration": 4}},
         4: {1: {"S3": 1, "R1": 2, "R2": 0, "R3": 0, "duration": 5}},
         5: {1: {"R1": 0, "R2": 0, "R3": 0, "duration": 0}},
     }
-    successors: Dict[int, List[int]] = {1: [2, 3], 2: [5], 3: [4], 4: [5], 5: []}
+    successors: dict[int, list[int]] = {1: [2, 3], 2: [5], 3: [4], 4: [5], 5: []}
 
     model = MS_RCPSPModel(
         skills_set=skills_set,
@@ -73,11 +72,11 @@ def test_lp():
 
 
 def test_lp_bis():
-    skills_set: Set[str] = {"S1", "S2", "S3"}
-    resources_set: Set[str] = {"R1", "R2", "R3"}
+    skills_set: set[str] = {"S1", "S2", "S3"}
+    resources_set: set[str] = {"R1", "R2", "R3"}
     non_renewable_resources = set()
     resources_availability = {"R1": [2] * 100, "R2": [4] * 100, "R3": [3] * 100}
-    employee: Dict[int, Employee] = {
+    employee: dict[int, Employee] = {
         1: Employee(
             dict_skill={"S1": SkillDetail(1.0, 1.0, 1.0)},
             calendar_employee=[True] * 1000,
@@ -100,8 +99,8 @@ def test_lp_bis():
             employee[emp].calendar_employee[i] = False
         index += 1
 
-    employees_availability: List[int] = [3] * 1000
-    mode_details: Dict[int, Dict[int, Dict[str, int]]] = {
+    employees_availability: list[int] = [3] * 1000
+    mode_details: dict[int, dict[int, dict[str, int]]] = {
         1: {1: {"R1": 0, "R2": 0, "R3": 0, "duration": 0}},
         2: {
             1: {"S1": 1, "R1": 2, "R2": 0, "R3": 0, "duration": 2},
@@ -117,7 +116,7 @@ def test_lp_bis():
         },
         8: {1: {"R1": 0, "R2": 0, "R3": 0, "duration": 0}},
     }
-    successors: Dict[int, List[int]] = {
+    successors: dict[int, list[int]] = {
         1: [2, 3],
         2: [5],
         3: [4],

--- a/tests/rcpsp_multiskill/test_rcpsp_ms_ls.py
+++ b/tests/rcpsp_multiskill/test_rcpsp_ms_ls.py
@@ -2,7 +2,6 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Dict, List, Set
 
 from discrete_optimization.generic_rcpsp_tools.ls_solver import (
     LS_SOLVER,
@@ -24,11 +23,11 @@ from discrete_optimization.rcpsp_multiskill.rcpsp_multiskill_parser import (
 
 
 def create_toy_msrcpsp():
-    skills_set: Set[str] = {"S1", "S2", "S3"}
-    resources_set: Set[str] = {"R1", "R2", "R3"}
+    skills_set: set[str] = {"S1", "S2", "S3"}
+    resources_set: set[str] = {"R1", "R2", "R3"}
     non_renewable_resources = set()
     resources_availability = {"R1": [2] * 100, "R2": [4] * 100, "R3": [3] * 100}
-    employee: Dict[int, Employee] = {
+    employee: dict[int, Employee] = {
         1: Employee(
             dict_skill={"S1": SkillDetail(1.0, 1.0, 1.0)},
             calendar_employee=[True] * 100,
@@ -51,8 +50,8 @@ def create_toy_msrcpsp():
             employee[emp].calendar_employee[i] = False
         index += 1
 
-    employees_availability: List[int] = [3] * 1000
-    mode_details: Dict[int, Dict[int, Dict[str, int]]] = {
+    employees_availability: list[int] = [3] * 1000
+    mode_details: dict[int, dict[int, dict[str, int]]] = {
         1: {1: {"R1": 0, "R2": 0, "R3": 0, "duration": 0}},
         2: {
             1: {"S1": 1, "R1": 2, "R2": 0, "R3": 0, "duration": 2},
@@ -68,7 +67,7 @@ def create_toy_msrcpsp():
         },
         8: {1: {"R1": 0, "R2": 0, "R3": 0, "duration": 0}},
     }
-    successors: Dict[int, List[int]] = {
+    successors: dict[int, list[int]] = {
         1: [2, 3],
         2: [5],
         3: [4],

--- a/tests/rcpsp_multiskill/test_rcpsp_ms_model.py
+++ b/tests/rcpsp_multiskill/test_rcpsp_ms_model.py
@@ -3,7 +3,7 @@
 #  LICENSE file in the root directory of this source tree.
 
 import random
-from typing import Dict, Hashable, Tuple
+from collections.abc import Hashable
 
 import pytest
 
@@ -49,7 +49,7 @@ def test_multiskill(rcpsp_model_file):
 
 def create_task_details_classic(
     solution: MS_RCPSPSolution_Variant, time_to_cut: int
-) -> Tuple[Dict[Hashable, TaskDetails], Dict[Hashable, TaskDetails]]:
+) -> tuple[dict[Hashable, TaskDetails], dict[Hashable, TaskDetails]]:
     finished = set(
         [t for t in solution.schedule if solution.get_end_time(t) <= time_to_cut]
     )
@@ -75,8 +75,8 @@ def create_task_details_classic(
 
 def create_task_details_preemptive(
     solution: MS_RCPSPSolution_Preemptive_Variant, time_to_cut: int
-) -> Tuple[
-    Dict[Hashable, TaskDetailsPreemptive], Dict[Hashable, TaskDetailsPreemptive]
+) -> tuple[
+    dict[Hashable, TaskDetailsPreemptive], dict[Hashable, TaskDetailsPreemptive]
 ]:
     finished = set(
         [t for t in solution.schedule if solution.get_end_time(t) <= time_to_cut]

--- a/tests/rcpsp_multiskill/test_rcpsp_ms_partially_preemptive.py
+++ b/tests/rcpsp_multiskill/test_rcpsp_ms_partially_preemptive.py
@@ -2,8 +2,6 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from typing import Dict, List
-
 import pytest
 
 from discrete_optimization.generic_rcpsp_tools.ls_solver import (
@@ -35,7 +33,7 @@ def model():
     skills_set = {"l1", "l2", "l3", "l4"}
     resource_set = {"R1"}
     resources_availability = {"R1": [2] * 100}
-    employee: Dict[int, Employee] = {
+    employee: dict[int, Employee] = {
         1: Employee(
             dict_skill={
                 "l1": SkillDetail(1.0, 1.0, 1.0),
@@ -53,7 +51,7 @@ def model():
         ),
     }
 
-    employees_availability: List[int] = [2] * 1000
+    employees_availability: list[int] = [2] * 1000
     mode_details = {
         "A0": {1: {"R1": 0, "duration": 0}},
         "A1": {1: {"R1": 1, "l1": 1, "duration": 5}},
@@ -62,7 +60,7 @@ def model():
         "A4": {1: {"R1": 0, "l3": 1, "duration": 2}},
         "A5": {1: {"R1": 0, "duration": 0}},
     }
-    successors: Dict[str, List[str]] = {
+    successors: dict[str, list[str]] = {
         "A0": ["A" + str(i) for i in range(1, 6)],
         "A1": ["A5"],
         "A2": ["A5"],

--- a/tests/rcpsp_multiskill/test_rcpsp_ms_rcpsp_based_solver.py
+++ b/tests/rcpsp_multiskill/test_rcpsp_ms_rcpsp_based_solver.py
@@ -3,7 +3,6 @@
 #  LICENSE file in the root directory of this source tree.
 
 import platform
-from typing import Dict, List, Set
 
 import pytest
 
@@ -28,11 +27,11 @@ if platform.machine() == "arm64":
 
 
 def create_toy_msrcpsp():
-    skills_set: Set[str] = {"S1", "S2", "S3"}
-    resources_set: Set[str] = {"R1", "R2", "R3"}
+    skills_set: set[str] = {"S1", "S2", "S3"}
+    resources_set: set[str] = {"R1", "R2", "R3"}
     non_renewable_resources = set()
     resources_availability = {"R1": [2] * 100, "R2": [4] * 100, "R3": [3] * 100}
-    employee: Dict[int, Employee] = {
+    employee: dict[int, Employee] = {
         1: Employee(
             dict_skill={"S1": SkillDetail(1.0, 1.0, 1.0)},
             calendar_employee=[True] * 100,
@@ -55,8 +54,8 @@ def create_toy_msrcpsp():
             employee[emp].calendar_employee[i] = False
         index += 1
 
-    employees_availability: List[int] = [3] * 1000
-    mode_details: Dict[int, Dict[int, Dict[str, int]]] = {
+    employees_availability: list[int] = [3] * 1000
+    mode_details: dict[int, dict[int, dict[str, int]]] = {
         1: {1: {"R1": 0, "R2": 0, "R3": 0, "duration": 0}},
         2: {
             1: {"S1": 1, "R1": 2, "R2": 0, "R3": 0, "duration": 2},
@@ -72,7 +71,7 @@ def create_toy_msrcpsp():
         },
         8: {1: {"R1": 0, "R2": 0, "R3": 0, "duration": 0}},
     }
-    successors: Dict[int, List[int]] = {
+    successors: dict[int, list[int]] = {
         1: [2, 3],
         2: [5],
         3: [4],


### PR DESCRIPTION
Why?
- python 3.8 is entering  end-of-life status (https://devguide.python.org/versions/#status-of-python-versions)
- ortools.mathopt is not supporting python 3.8 (as using new annotations style)

We take the opportunity to use >=3.9 type annotations style (List[] -> list[], ..., use Iterable, Sequence,... from collections.abc).