### PR TITLE
Fix quantum solvers `__init__()` and `init_model()`

### DIFF
--- a/discrete_optimization/coloring/solvers/coloring_quantum.py
+++ b/discrete_optimization/coloring/solvers/coloring_quantum.py
@@ -152,12 +152,12 @@ class QAOAColoringSolver_MinimizeNbColor(SolverColoring, QiskitQAOASolver):
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
         **kwargs
     ):
-        super().__init__(problem, params_objective_function)
+        super().__init__(problem, params_objective_function, **kwargs)
         self.coloring_qiskit = ColoringQiskit_MinimizeNbColor(
             problem, nb_max_color=nb_max_color
         )
 
-    def init_model(self):
+    def init_model(self, **kwargs):
         self.quadratic_programm = self.coloring_qiskit.to_quadratic_program()
 
     def retrieve_current_solution(self, result) -> Solution:
@@ -172,12 +172,12 @@ class VQEColoringSolver_MinimizeNbColor(SolverColoring, QiskitVQESolver):
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
         **kwargs
     ):
-        super().__init__(problem, params_objective_function)
+        super().__init__(problem, params_objective_function, **kwargs)
         self.coloring_qiskit = ColoringQiskit_MinimizeNbColor(
             problem, nb_max_color=nb_max_color
         )
 
-    def init_model(self):
+    def init_model(self, **kwargs):
         self.quadratic_programm = self.coloring_qiskit.to_quadratic_program()
 
     def retrieve_current_solution(self, result) -> Solution:
@@ -262,12 +262,12 @@ class QAOAColoringSolver_FeasibleNbColor(SolverColoring, QiskitQAOASolver):
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
         **kwargs
     ):
-        super().__init__(problem, params_objective_function)
+        super().__init__(problem, params_objective_function, **kwargs)
         self.coloring_qiskit = ColoringQiskit_FeasibleNbColor(
             problem, nb_color=nb_color
         )
 
-    def init_model(self):
+    def init_model(self, **kwargs):
         self.quadratic_programm = self.coloring_qiskit.to_quadratic_program()
 
     def retrieve_current_solution(self, result) -> Solution:
@@ -282,12 +282,12 @@ class VQEColoringSolver_FeasibleNbColor(SolverColoring, QiskitVQESolver):
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
         **kwargs
     ):
-        super().__init__(problem, params_objective_function)
+        super().__init__(problem, params_objective_function, **kwargs)
         self.coloring_qiskit = ColoringQiskit_FeasibleNbColor(
             problem, nb_color=nb_color
         )
 
-    def init_model(self):
+    def init_model(self, **kwargs):
         self.quadratic_programm = self.coloring_qiskit.to_quadratic_program()
 
     def retrieve_current_solution(self, result) -> Solution:

--- a/discrete_optimization/facility/solvers/facility_quantum.py
+++ b/discrete_optimization/facility/solvers/facility_quantum.py
@@ -187,11 +187,12 @@ class QAOAFacilitySolver(SolverFacility, QiskitQAOASolver):
         self,
         problem: FacilityProblem,
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
+        **kwargs
     ):
-        super().__init__(problem, params_objective_function)
+        super().__init__(problem, params_objective_function, **kwargs)
         self.facility_qiskit = FacilityQiskit(problem)
 
-    def init_model(self):
+    def init_model(self, **kwargs):
         self.quadratic_programm = self.facility_qiskit.to_quadratic_program()
 
     def retrieve_current_solution(self, result) -> Solution:
@@ -203,11 +204,12 @@ class VQEFacilitySolver(SolverFacility, QiskitVQESolver):
         self,
         problem: FacilityProblem,
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
+        **kwargs
     ):
-        super().__init__(problem, params_objective_function)
+        super().__init__(problem, params_objective_function, **kwargs)
         self.facility_qiskit = FacilityQiskit(problem)
 
-    def init_model(self):
+    def init_model(self, **kwargs):
         self.quadratic_programm = self.facility_qiskit.to_quadratic_program()
 
     def retrieve_current_solution(self, result) -> Solution:

--- a/discrete_optimization/generic_tools/qiskit_tools.py
+++ b/discrete_optimization/generic_tools/qiskit_tools.py
@@ -246,7 +246,7 @@ class QiskitSolver(SolverDO):
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
         **kwargs,
     ):
-        super().__init__(problem, params_objective_function)
+        super().__init__(problem, params_objective_function, **kwargs)
         self.executed_ansatz = None
         self.final_ansatz = None
 
@@ -275,8 +275,9 @@ class QiskitQAOASolver(QiskitSolver, Hyperparametrizable):
         problem: Problem,
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
         backend: Optional = None,
+        **kwargs,
     ):
-        super().__init__(problem, params_objective_function)
+        super().__init__(problem, params_objective_function, **kwargs)
         self.quadratic_programm = None
         self.backend = backend
         self.ansatz = None
@@ -396,8 +397,9 @@ class QiskitVQESolver(QiskitSolver):
         problem: Problem,
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
         backend: Optional = None,
+        **kwargs,
     ):
-        super().__init__(problem, params_objective_function)
+        super().__init__(problem, params_objective_function, **kwargs)
         self.quadratic_programm = None
         self.backend = backend
         self.ansatz = None
@@ -481,6 +483,7 @@ class GeneralQAOASolver(QiskitQAOASolver):
         retrieve_solution: Callable,
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
         backend: Optional = None,
+        **kwargs,
     ):
         super().__init__(problem, params_objective_function, backend=backend)
         self.quadratic_programm = None
@@ -494,7 +497,7 @@ class GeneralQAOASolver(QiskitQAOASolver):
         if isinstance(self.model, Model):
             self.quadratic_programm = gurobi_to_qubo(self.model)
         else:
-            self.model.init_model(kwargs=kwargs)
+            self.model.init_model(**kwargs)
             self.quadratic_programm = gurobi_to_qubo(self.model.model)
 
 
@@ -506,8 +509,9 @@ class GeneralVQESolver(QiskitVQESolver):
         retrieve_solution: Callable,
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
         backend: Optional = None,
+        **kwargs,
     ):
-        super().__init__(problem, params_objective_function, backend=backend)
+        super().__init__(problem, params_objective_function, backend=backend, **kwargs)
         self.quadratic_programm = None
         self.model = model
         self.retrieve_solution = retrieve_solution
@@ -519,7 +523,7 @@ class GeneralVQESolver(QiskitVQESolver):
         if isinstance(self.model, Model):
             self.quadratic_programm = gurobi_to_qubo(self.model)
         else:
-            self.model.init_model(kwargs=kwargs)
+            self.model.init_model(**kwargs)
             self.quadratic_programm = gurobi_to_qubo(self.model.model)
 
 

--- a/discrete_optimization/generic_tools/quantum_solvers.py
+++ b/discrete_optimization/generic_tools/quantum_solvers.py
@@ -164,7 +164,7 @@ def solve(
     solver_ = method(problem, **kwargs)
     try:
 
-        solver_.init_model()
+        solver_.init_model(**kwargs)
     except AttributeError:
         pass
     return solver_.solve(**kwargs)
@@ -184,10 +184,10 @@ def solve_coloring(
     Returns: a ResultsStorage objecting obtained by the solver.
 
     """
-    solver_ = method(problem, nb_color)
+    solver_ = method(problem, nb_color, **kwargs)
     try:
 
-        solver_.init_model()
+        solver_.init_model(**kwargs)
     except AttributeError:
         pass
     return solver_.solve(**kwargs)

--- a/discrete_optimization/knapsack/solvers/knapsack_quantum.py
+++ b/discrete_optimization/knapsack/solvers/knapsack_quantum.py
@@ -158,10 +158,10 @@ class QAOAKnapsackSolver(SolverKnapsack, QiskitQAOASolver):
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
         **kwargs
     ):
-        super().__init__(problem, params_objective_function)
+        super().__init__(problem, params_objective_function, **kwargs)
         self.knapsack_qiskit = KnapsackQiskit(problem)
 
-    def init_model(self):
+    def init_model(self, **kwargs):
         self.quadratic_programm = self.knapsack_qiskit.to_quadratic_program()
 
     def retrieve_current_solution(self, result) -> Solution:
@@ -175,10 +175,10 @@ class VQEKnapsackSolver(SolverKnapsack, QiskitVQESolver):
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
         **kwargs
     ):
-        super().__init__(problem, params_objective_function)
+        super().__init__(problem, params_objective_function, **kwargs)
         self.knapsack_qiskit = KnapsackQiskit(problem)
 
-    def init_model(self):
+    def init_model(self, **kwargs):
         self.quadratic_programm = self.knapsack_qiskit.to_quadratic_program()
 
     def retrieve_current_solution(self, result) -> Solution:

--- a/discrete_optimization/maximum_independent_set/solvers/mis_quantum.py
+++ b/discrete_optimization/maximum_independent_set/solvers/mis_quantum.py
@@ -84,10 +84,10 @@ class QAOAMisSolver(MisSolver, QiskitQAOASolver):
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
         **kwargs,
     ):
-        super().__init__(problem, params_objective_function, kwargs)
+        super().__init__(problem, params_objective_function, **kwargs)
         self.mis_qiskit = MisQiskit(problem)
 
-    def init_model(self):
+    def init_model(self, **kwargs):
         self.quadratic_programm = self.mis_qiskit.to_quadratic_program()
 
     def retrieve_current_solution(self, result):
@@ -101,10 +101,10 @@ class VQEMisSolver(MisSolver, QiskitVQESolver):
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
         **kwargs,
     ):
-        super().__init__(problem, params_objective_function, kwargs)
+        super().__init__(problem, params_objective_function, **kwargs)
         self.mis_qiskit = MisQiskit(problem)
 
-    def init_model(self):
+    def init_model(self, **kwargs):
         self.quadratic_programm = self.mis_qiskit.to_quadratic_program()
 
     def retrieve_current_solution(self, result) -> Solution:

--- a/discrete_optimization/tsp/solver/tsp_quantum.py
+++ b/discrete_optimization/tsp/solver/tsp_quantum.py
@@ -152,10 +152,10 @@ class QAOATSPSolver(SolverTSP, QiskitQAOASolver):
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
         **kwargs
     ):
-        super().__init__(problem, params_objective_function, kwargs)
+        super().__init__(problem, params_objective_function, **kwargs)
         self.tsp_qiskit = TSP2dQiskit(problem)
 
-    def init_model(self):
+    def init_model(self, **kwargs):
         self.quadratic_programm = self.tsp_qiskit.to_quadratic_program()
 
     def retrieve_current_solution(self, result) -> Solution:
@@ -169,10 +169,10 @@ class VQETSPSolver(SolverTSP, QiskitVQESolver):
         params_objective_function: Optional[ParamsObjectiveFunction] = None,
         **kwargs
     ):
-        super().__init__(problem, params_objective_function, kwargs)
+        super().__init__(problem, params_objective_function, **kwargs)
         self.tsp_qiskit = TSP2dQiskit(problem)
 
-    def init_model(self):
+    def init_model(self, **kwargs):
         self.quadratic_programm = self.tsp_qiskit.to_quadratic_program()
 
     def retrieve_current_solution(self, result) -> Solution:


### PR DESCRIPTION
They should all accept` **kwargs` and use it properly (`**` missing sometimes).
Generic solve functions (as used in optuna study) will try to pass kwargs to `__init__`, `init_model` and `solve` methods.