### PR TITLE
Stop using deprecated/removed arguments from qiskit-ibm-runtime

### DIFF
--- a/discrete_optimization/generic_tools/qiskit_tools.py
+++ b/discrete_optimization/generic_tools/qiskit_tools.py
@@ -161,15 +161,16 @@ def execute_ansatz_with_Hamiltonian(
     if use_session:
         max_time = kwargs.get("session_time", "2h")
         session = Session(backend=backend, max_time=max_time)
+        mode = session
     else:
-        session = None
+        mode = backend
 
     # Configure estimator
-    estimator = Estimator(backend=backend, session=session)
+    estimator = Estimator(mode=mode)
     estimator.options.default_shots = nb_shots
 
     # Configure sampler
-    sampler = SamplerV2(backend=backend, session=session)
+    sampler = SamplerV2(mode=mode)
     sampler.options.default_shots = nb_shots
 
     callback_dict = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ quantum = [
     "qiskit-algorithms>=0.3.0",
     "qiskit-optimization>=0.6.1",
     "qiskit-aer>=0.14.1",
-    "qiskit-ibm-runtime>=0.23.0"
+    "qiskit-ibm-runtime>=0.24"
 ]
 
 [project.urls]


### PR DESCRIPTION
The args backend/session for EstimatorV2 have been deprecated in 0.24 (released on 2024/06/11) then removed in 0.30 (released 2024/09/23), in favor of mode (which will be equal to backend or session depending on the situation.