### PR TITLE
Unify lp solvers `init_model()` methods 

### DIFF
--- a/discrete_optimization/maximum_independent_set/solvers/mis_lp.py
+++ b/discrete_optimization/maximum_independent_set/solvers/mis_lp.py
@@ -1,13 +1,45 @@
 from collections.abc import Callable
 from typing import Any
 
+import networkx as nx
+import numpy as np
+
+from discrete_optimization.generic_tools.graph_api import get_node_attributes
 from discrete_optimization.generic_tools.lp_tools import MilpSolver
 from discrete_optimization.maximum_independent_set.mis_model import MisSolution
 from discrete_optimization.maximum_independent_set.solvers.mis_solver import MisSolver
 
 
 class BaseLPMisSolver(MisSolver, MilpSolver):
-    vars_node: dict[int, Any]
+    vars_node: list[Any]
+
+    def init_model(self, **kwargs: Any) -> None:
+
+        # Create a new model
+        self.model = self.create_empty_model()
+
+        # Create variables
+        self.vars_node = [
+            self.add_binary_variable(name=f"N{i}")
+            for i in range(self.problem.number_nodes)
+        ]
+
+        # Set objective
+        value = get_node_attributes(self.problem.graph_nx, "value", default=1)
+        obj_exp = 0.0
+        obj_exp += self.construct_linear_sum(
+            value[self.problem.index_to_nodes[i]] * self.vars_node[i]
+            for i in range(0, self.problem.number_nodes)
+        )
+        self.set_model_objective(obj_exp, minimize=False)
+
+        # for each edge it's impossible to choose the two nodes of this edges in our solution
+
+        for edge in self.problem.graph_nx.edges():
+            self.add_linear_constraint(
+                self.vars_node[self.problem.nodes_to_index[edge[0]]]
+                <= 1 - self.vars_node[self.problem.nodes_to_index[edge[1]]]
+            )
 
     def retrieve_current_solution(
         self,
@@ -33,3 +65,41 @@ class BaseLPMisSolver(MisSolver, MilpSolver):
             self.vars_node[i]: solution.chosen[i]
             for i in range(0, self.problem.number_nodes)
         }
+
+
+class BaseQuadMisSolver(BaseLPMisSolver):
+    """Base class for quadratic solvers with gurobi or mathopt.
+
+    Work only for graph without weight on nodes.
+    If there are weights, it's going to ignore them.
+
+    """
+
+    vars_node_matrix: np.array
+
+    @property
+    def vars_node(self) -> list[Any]:
+        return self.vars_node_matrix.tolist()
+
+    def create_vars_node_matrix(self) -> np.array:
+        return np.array(
+            [
+                self.add_binary_variable(name=f"N{i}")
+                for i in range(self.problem.number_nodes)
+            ]
+        )
+
+    def init_model(self, **kwargs: Any) -> None:
+        # Create a new model
+        self.model = self.create_empty_model()
+
+        # Create variables
+        self.vars_node_matrix = self.create_vars_node_matrix()
+
+        # Set objective
+        adj = nx.to_numpy_array(self.problem.graph_nx)
+        J = np.identity(self.problem.number_nodes)
+        A = J - adj
+        self.set_model_objective(
+            self.vars_node_matrix @ A @ self.vars_node_matrix, minimize=False
+        )

--- a/discrete_optimization/maximum_independent_set/solvers/mis_mathopt.py
+++ b/discrete_optimization/maximum_independent_set/solvers/mis_mathopt.py
@@ -1,15 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import Any
-
-import networkx as nx
-import numpy as np
-
-from discrete_optimization.generic_tools.do_problem import Solution
-from discrete_optimization.generic_tools.do_solver import WarmstartMixin
-from discrete_optimization.generic_tools.graph_api import get_node_attributes
-from discrete_optimization.maximum_independent_set.solvers.mis_lp import BaseLPMisSolver
+from discrete_optimization.maximum_independent_set.solvers.mis_lp import (
+    BaseLPMisSolver,
+    BaseQuadMisSolver,
+)
 
 try:
     import gurobipy
@@ -21,78 +15,26 @@ else:
 
 from ortools.math_opt.python import mathopt
 
-from discrete_optimization.generic_tools.lp_tools import (
-    GurobiMilpSolver,
-    OrtoolsMathOptMilpSolver,
-)
+from discrete_optimization.generic_tools.lp_tools import OrtoolsMathOptMilpSolver
 from discrete_optimization.maximum_independent_set.mis_model import MisSolution
 
 
 class MisMathOptMilpSolver(OrtoolsMathOptMilpSolver, BaseLPMisSolver):
-    def init_model(self, **kwargs: Any) -> None:
-
-        # Create a new model
-        self.model = mathopt.Model()
-
-        # Create variables
-        self.vars_node = {
-            i: self.model.add_binary_variable(name=f"N{i}")
-            for i in range(self.problem.number_nodes)
-        }
-
-        # Set objective
-        value = get_node_attributes(self.problem.graph_nx, "value", default=1)
-        obj_exp = 0.0
-        obj_exp += mathopt.LinearSum(
-            value[self.problem.index_to_nodes[i]] * self.vars_node[i]
-            for i in range(0, self.problem.number_nodes)
-        )
-        self.model.maximize(obj_exp)
-
-        # for each edge it's impossible to choose the two nodes of this edges in our solution
-
-        for edge in self.problem.graph_nx.edges():
-            self.model.add_linear_constraint(
-                self.vars_node[self.problem.nodes_to_index[edge[0]]]
-                <= 1 - self.vars_node[self.problem.nodes_to_index[edge[1]]]
-            )
-
     def convert_to_variable_values(
         self, solution: MisSolution
     ) -> dict[mathopt.Variable, float]:
         return BaseLPMisSolver.convert_to_variable_values(self, solution)
 
 
-class MisMathOptQuadraticSolver(OrtoolsMathOptMilpSolver, BaseLPMisSolver):
+class MisMathOptQuadraticSolver(OrtoolsMathOptMilpSolver, BaseQuadMisSolver):
+    """Quadratic solver mathopt.
+
+    Work only for graph without weight on nodes.
+    If there are weights, it's going to ignore them.
+
     """
-    The quadratic gurobi solver work only for graph without weight on nodes,
-    if there is weight, it's going to ignore them
-    """
-
-    @property
-    def vars_node(self) -> dict[int, Var]:
-        return dict(enumerate(self.vars_node_matrix.tolist()))
-
-    def init_model(self, **kwargs: Any) -> None:
-
-        # Create a new model
-        self.model = mathopt.Model()
-
-        # Create variables
-        self.vars_node_matrix = np.array(
-            [
-                self.model.add_binary_variable(name=f"N{i}")
-                for i in range(self.problem.number_nodes)
-            ]
-        )
-
-        # Set objective
-        adj = nx.to_numpy_array(self.problem.graph_nx)
-        J = np.identity(self.problem.number_nodes)
-        A = J - adj
-        self.model.maximize(self.vars_node_matrix @ A @ self.vars_node_matrix)
 
     def convert_to_variable_values(
         self, solution: MisSolution
     ) -> dict[mathopt.Variable, float]:
-        return BaseLPMisSolver.convert_to_variable_values(self, solution)
+        return BaseQuadMisSolver.convert_to_variable_values(self, solution)

--- a/tests/facility/test_facility_lp.py
+++ b/tests/facility/test_facility_lp.py
@@ -33,13 +33,14 @@ else:
 
 
 @pytest.mark.skipif(not gurobi_available, reason="You need Gurobi to test this solver.")
-def test_facility_lp_gurobi():
+@pytest.mark.parametrize("use_matrix_indicator_heuristic", [True, False])
+def test_facility_lp_gurobi(use_matrix_indicator_heuristic):
     file = [f for f in get_data_available() if os.path.basename(f) == "fl_3_1"][0]
     color_problem = parse_file(file)
     solver = LP_Facility_Solver(color_problem)
     kwargs = dict(
         time_limit=20,
-        use_matrix_indicator_heuristic=False,
+        use_matrix_indicator_heuristic=use_matrix_indicator_heuristic,
     )
     result_storage = solver.solve(**kwargs)
     solution, fit = result_storage.get_best_solution_fit()
@@ -65,13 +66,14 @@ def test_facility_lp_gurobi():
     )
 
 
-def test_facility_lp_ortools_mathopt():
+@pytest.mark.parametrize("use_matrix_indicator_heuristic", [True, False])
+def test_facility_lp_ortools_mathopt(use_matrix_indicator_heuristic):
     file = [f for f in get_data_available() if os.path.basename(f) == "fl_3_1"][0]
     color_problem = parse_file(file)
     solver = LP_Facility_Solver_MathOpt(color_problem)
     kwargs = dict(
         time_limit=20,
-        use_matrix_indicator_heuristic=False,
+        use_matrix_indicator_heuristic=use_matrix_indicator_heuristic,
     )
     result_storage = solver.solve(**kwargs)
     solution, fit = result_storage.get_best_solution_fit()


### PR DESCRIPTION
Share as much as possible init_model() between gurobi and mathopt solvers, by using new methods helping creating model, variables and constraints for each framework.

We also added tests for init_model options that were not tested (like `use_cliques` and `greedy_start`).