### PR TITLE
Add status to lp solvers (and default one to all solvers)

### DIFF
--- a/discrete_optimization/generic_tools/cp_tools.py
+++ b/discrete_optimization/generic_tools/cp_tools.py
@@ -23,7 +23,7 @@ from discrete_optimization.generic_tools.callbacks.callback import (
     CallbackList,
 )
 from discrete_optimization.generic_tools.do_problem import Solution
-from discrete_optimization.generic_tools.do_solver import SolverDO
+from discrete_optimization.generic_tools.do_solver import SolverDO, StatusSolver
 from discrete_optimization.generic_tools.exceptions import SolveEarlyStop
 from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
     EnumHyperparameter,
@@ -160,13 +160,6 @@ class SignEnum(Enum):
     UP = ">"
 
 
-class StatusSolver(Enum):
-    SATISFIED = "SATISFIED"
-    UNSATISFIABLE = "UNSATISFIABLE"
-    OPTIMAL = "OPTIMAL"
-    UNKNOWN = "UNKNOWN"
-
-
 map_mzn_status_to_do_status: dict[Status, StatusSolver] = {
     Status.SATISFIED: StatusSolver.SATISFIED,
     Status.UNSATISFIABLE: StatusSolver.UNSATISFIABLE,
@@ -179,22 +172,6 @@ class CPSolver(SolverDO):
     """
     Additional function to be implemented by a CP Solver.
     """
-
-    status_solver: Optional[StatusSolver] = None
-
-    def is_optimal(self) -> Optional[bool]:
-        """Tell if found solution is supposed to be optimal.
-
-        To be called after a solve.
-
-        Returns:
-            optimality of the solution. If information missing, returns None instead.
-
-        """
-        if self.status_solver is None or self.status_solver == StatusSolver.UNKNOWN:
-            return None
-        else:
-            return self.status_solver == StatusSolver.OPTIMAL
 
     @abstractmethod
     def init_model(self, **args: Any) -> None:
@@ -214,9 +191,6 @@ class CPSolver(SolverDO):
         **args: Any,
     ) -> ResultStorage:
         ...
-
-    def get_status_solver(self) -> Union[StatusSolver, None]:
-        return self.status_solver
 
 
 class MinizincCPSolver(CPSolver):

--- a/discrete_optimization/generic_tools/do_solver.py
+++ b/discrete_optimization/generic_tools/do_solver.py
@@ -7,6 +7,7 @@ from __future__ import annotations  # see annotations as str
 
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
+from enum import Enum
 from typing import Any, Optional
 
 from discrete_optimization.generic_tools.callbacks.callback import Callback
@@ -28,10 +29,18 @@ from discrete_optimization.generic_tools.result_storage.result_storage import (
 )
 
 
+class StatusSolver(Enum):
+    SATISFIED = "SATISFIED"
+    UNSATISFIABLE = "UNSATISFIABLE"
+    OPTIMAL = "OPTIMAL"
+    UNKNOWN = "UNKNOWN"
+
+
 class SolverDO(Hyperparametrizable, ABC):
     """Base class for a discrete-optimization solver."""
 
     problem: Problem
+    status_solver: StatusSolver = StatusSolver.UNKNOWN
 
     def __init__(
         self,
@@ -102,7 +111,10 @@ class SolverDO(Hyperparametrizable, ABC):
             optimality of the solution. If information missing, returns None instead.
 
         """
-        return None
+        if self.status_solver == StatusSolver.UNKNOWN:
+            return None
+        else:
+            return self.status_solver == StatusSolver.OPTIMAL
 
     def get_model_objectives_available(self) -> list[str]:
         """List objectives available for lexico optimization

--- a/discrete_optimization/generic_tools/ortools_cpsat_tools.py
+++ b/discrete_optimization/generic_tools/ortools_cpsat_tools.py
@@ -21,12 +21,9 @@ from discrete_optimization.generic_tools.callbacks.callback import (
     Callback,
     CallbackList,
 )
-from discrete_optimization.generic_tools.cp_tools import (
-    CPSolver,
-    ParametersCP,
-    StatusSolver,
-)
+from discrete_optimization.generic_tools.cp_tools import CPSolver, ParametersCP
 from discrete_optimization.generic_tools.do_problem import Solution
+from discrete_optimization.generic_tools.do_solver import StatusSolver
 from discrete_optimization.generic_tools.exceptions import SolveEarlyStop
 from discrete_optimization.generic_tools.result_storage.result_storage import (
     ResultStorage,

--- a/discrete_optimization/rcpsp/solver/cpsat_solver.py
+++ b/discrete_optimization/rcpsp/solver/cpsat_solver.py
@@ -19,9 +19,8 @@ from ortools.sat.python.cp_model import (
     ObjLinearExprT,
 )
 
-from discrete_optimization.generic_tools.cp_tools import StatusSolver
 from discrete_optimization.generic_tools.do_problem import ParamsObjectiveFunction
-from discrete_optimization.generic_tools.do_solver import WarmstartMixin
+from discrete_optimization.generic_tools.do_solver import StatusSolver, WarmstartMixin
 from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
     CategoricalHyperparameter,
 )

--- a/examples/coloring/coloring_cpspat_solver_example.py
+++ b/examples/coloring/coloring_cpspat_solver_example.py
@@ -47,7 +47,7 @@ def run_cpsat_coloring():
         callbacks=[NbIterationTracker(step_verbosity_level=logging.INFO)],
         parameters_cp=p,
     )
-    print("Status solver : ", solver.get_status_solver())
+    print("Status solver : ", solver.status_solver)
     solution, fit = result_store.get_best_solution_fit()
     plot_coloring_solution(solution)
     plt.show()
@@ -70,7 +70,7 @@ def run_cpsat_coloring_with_constraints():
     p = ParametersCP.default()
     result_store = solver.solve(parameters_cp=p, time_limit=20)
     solution, fit = result_store.get_best_solution_fit()
-    print("Status solver : ", solver.get_status_solver())
+    print("Status solver : ", solver.status_solver)
     plot_coloring_solution(solution)
     plt.show()
     print(solution, fit)

--- a/examples/jsp/jsp_cpsat_example.py
+++ b/examples/jsp/jsp_cpsat_example.py
@@ -31,7 +31,7 @@ def run_cpsat_jsp():
     p.nb_process = 10
     res = solver.solve(parameters_cp=p, time_limit=10)
     sol = res.get_best_solution_fit()[0]
-    print(solver.get_status_solver())
+    print(solver.status_solver)
     assert problem.satisfy(sol)
     print(problem.evaluate(sol))
 

--- a/examples/knapsack/knapsack_cpsat_solver.py
+++ b/examples/knapsack/knapsack_cpsat_solver.py
@@ -20,7 +20,7 @@ def run_cpsat_knapsack():
     params_cp = ParametersCP.default()
     result_storage = cp_model.solve(parameters_cp=params_cp, time_limit=10)
     sol, fit = result_storage.get_best_solution_fit()
-    print("Status solver :", cp_model.get_status_solver())
+    print("Status solver :", cp_model.status_solver)
     assert knapsack_model.satisfy(sol)
 
 

--- a/examples/maximum_independent_set/lns_cpsat_mis.py
+++ b/examples/maximum_independent_set/lns_cpsat_mis.py
@@ -50,7 +50,7 @@ def run_lns():
     )
     sol, fit = res.get_best_solution_fit()
     print("Found by cpsat :", fit)
-    print("Status : ", solver.get_status_solver())
+    print("Status : ", solver.status_solver)
 
     initial_solution_provider = TrivialInitialSolution(
         solver.create_result_storage(
@@ -106,7 +106,7 @@ def run_lns_mix():
     )
     sol, fit = res.get_best_solution_fit()
     print("Found by cpsat :", fit)
-    print("Status : ", solver.get_status_solver())
+    print("Status : ", solver.status_solver)
 
     initial_solution_provider = TrivialInitialSolution(
         solver.create_result_storage(

--- a/examples/rcpsp_multiskill/mslib/mslib_parse_and_solve.py
+++ b/examples/rcpsp_multiskill/mslib/mslib_parse_and_solve.py
@@ -60,7 +60,7 @@ def example_mslib_cpsat():
         ],
         ortools_cpsat_solver_kwargs={"log_search_progress": True},
     )
-    print(solver.get_status_solver())
+    print(solver.status_solver)
     from discrete_optimization.rcpsp_multiskill.plots.plot_solution import (
         plot_resource_individual_gantt,
     )

--- a/examples/vrp/vrp_cpsat_example.py
+++ b/examples/vrp/vrp_cpsat_example.py
@@ -26,7 +26,7 @@ def run_cpsat_vrp():
     p = ParametersCP.default_cpsat()
     p.nb_process = 10
     res = solver.solve(parameters_cp=p, time_limit=20)
-    print(solver.get_status_solver())
+    print(solver.status_solver)
     sol, fit = res.get_best_solution_fit()
     sol: VrpSolution
     print(problem.evaluate(sol))
@@ -111,7 +111,7 @@ def warm_starting():
             fix_variables_to_their_hinted_value=False, log_search_progress=True
         ),
     )
-    print(solver.get_status_solver())
+    print(solver.status_solver)
     # assert res[0][0].list_paths == start_solution.list_paths
 
 

--- a/tests/coloring/test_coloring_lns_cpsat.py
+++ b/tests/coloring/test_coloring_lns_cpsat.py
@@ -76,7 +76,7 @@ def test_lns_cpsat_coloring():
         parameters_cp=p,
         time_limit_subsolver=20,
     )
-    print("Status solver : ", solver.get_status_solver())
+    print("Status solver : ", solver.status_solver)
     solution, fit = result_store.get_best_solution_fit()
     # plot_coloring_solution(solution)
     # plt.show()
@@ -128,7 +128,7 @@ def test_lns_cpsat_coloring_with_constraints():
         ],
         parameters_cp=p,
     )
-    print("Status solver : ", solver.get_status_solver())
+    print("Status solver : ", solver.status_solver)
     solution, fit = result_store.get_best_solution_fit()
     # plot_coloring_solution(solution)
     # plt.show()


### PR DESCRIPTION
Gurobi and mathopt give information about solver status. As for minizinc and cpsat, we make it available on the wrapper level.

As we use the same enumeration `StatusSolver`, we move it to `solver_do` module. And thus add for all solvers a `status_solver` attribute, by default equal to unknown and which is used by `is_optimal()` method.

We remove `get_status_solver()` method which was only returning `self.status_solver`.