### PR TITLE
Update lexico api

### DIFF
--- a/discrete_optimization/generic_tools/do_solver.py
+++ b/discrete_optimization/generic_tools/do_solver.py
@@ -116,13 +116,13 @@ class SolverDO(Hyperparametrizable, ABC):
         else:
             return self.status_solver == StatusSolver.OPTIMAL
 
-    def get_model_objectives_available(self) -> list[str]:
+    def get_lexico_objectives_available(self) -> list[str]:
         """List objectives available for lexico optimization
 
         It corresponds to the labels accepted for obj argument for
-        - `set_model_objective()`
-        - `add_model_constraint()`
-        - `get_model_objective_value()`
+        - `set_lexico_objective()`
+        - `add_lexico_constraint()`
+        - `get_lexico_objective_value()`
 
         Default to `self.problem.get_objective_names()`.
 
@@ -131,19 +131,19 @@ class SolverDO(Hyperparametrizable, ABC):
         """
         return self.problem.get_objective_names()
 
-    def set_model_objective(self, obj: str) -> None:
+    def set_lexico_objective(self, obj: str) -> None:
         """Update internal model objective.
 
         Args:
             obj: a string representing the desired objective.
-                Should be one of `self.get_model_objectives_available()`.
+                Should be one of `self.get_lexico_objectives_available()`.
 
         Returns:
 
         """
         ...
 
-    def get_model_objective_value(self, obj: str, res: ResultStorage) -> float:
+    def get_lexico_objective_value(self, obj: str, res: ResultStorage) -> float:
         """Get best internal model objective value found by last call to `solve()`.
 
         The default implementation consists in using the fit of the last solution in result_storage.
@@ -154,7 +154,7 @@ class SolverDO(Hyperparametrizable, ABC):
 
         Args:
             obj: a string representing the desired objective.
-                Should be one of `self.get_model_objectives_available()`.
+                Should be one of `self.get_lexico_objectives_available()`.
             res: result storage returned by last call to solve().
 
         Returns:
@@ -169,12 +169,12 @@ class SolverDO(Hyperparametrizable, ABC):
         idx = objectives.index(obj)
         return float(fit.vector_fitness[idx])
 
-    def add_model_constraint(self, obj: str, value: float) -> Iterable[Any]:
+    def add_lexico_constraint(self, obj: str, value: float) -> Iterable[Any]:
         """Add a constraint on a computed sub-objective
 
         Args:
             obj: a string representing the desired objective.
-                Should be one of `self.get_model_objectives_available()`.
+                Should be one of `self.get_lexico_objectives_available()`.
             value: the limiting value.
                 If the optimization direction is maximizing, this is a lower bound,
                 else this is an upper bound.
@@ -185,11 +185,11 @@ class SolverDO(Hyperparametrizable, ABC):
         """
         ...
 
-    def remove_model_constraint(self, constraints: Iterable[Any]) -> None:
+    def remove_constraints(self, constraints: Iterable[Any]) -> None:
         """Remove the internal model constraints.
 
         Args:
-            constraints: constraints created with `add_model_constraint()`
+            constraints: constraints created for instance with `add_lexico_constraint()`
 
         Returns:
 
@@ -202,14 +202,14 @@ class SolverDO(Hyperparametrizable, ABC):
 
         Should return True only if
 
-        - `set_model_objective()`
-        - `add_model_constraint()`
-        - `get_model_objective_value()`
+        - `set_lexico_objective()`
+        - `add_lexico_constraint()`
+        - `get_lexico_objective_value()`
 
         have been really implemented, i.e.
-        - calling `set_model_objective()` and `add_model_constraint()`
+        - calling `set_lexico_objective()` and `add_lexico_constraint()`
           should actually change the next call to `solve()`,
-        - `get_model_objective_value()` should correspond to the internal model objective
+        - `get_lexico_objective_value()` should correspond to the internal model objective
 
         """
         return False

--- a/discrete_optimization/generic_tools/do_solver.py
+++ b/discrete_optimization/generic_tools/do_solver.py
@@ -95,7 +95,7 @@ class SolverDO(Hyperparametrizable, ABC):
         )
 
     def init_model(self, **kwargs: Any) -> None:
-        """Initialize intern model used to solve.
+        """Initialize internal model used to solve.
 
         Can initialize a ortools, milp, gurobi, ... model.
 
@@ -132,7 +132,7 @@ class SolverDO(Hyperparametrizable, ABC):
         return self.problem.get_objective_names()
 
     def set_model_objective(self, obj: str) -> None:
-        """Update intern model objective.
+        """Update internal model objective.
 
         Args:
             obj: a string representing the desired objective.
@@ -144,7 +144,7 @@ class SolverDO(Hyperparametrizable, ABC):
         ...
 
     def get_model_objective_value(self, obj: str, res: ResultStorage) -> float:
-        """Get best intern model objective value found by last call to `solve()`.
+        """Get best internal model objective value found by last call to `solve()`.
 
         The default implementation consists in using the fit of the last solution in result_storage.
         This assumes:
@@ -186,7 +186,7 @@ class SolverDO(Hyperparametrizable, ABC):
         ...
 
     def remove_model_constraint(self, constraints: Iterable[Any]) -> None:
-        """Remove the intern model constraints.
+        """Remove the internal model constraints.
 
         Args:
             constraints: constraints created with `add_model_constraint()`
@@ -209,7 +209,7 @@ class SolverDO(Hyperparametrizable, ABC):
         have been really implemented, i.e.
         - calling `set_model_objective()` and `add_model_constraint()`
           should actually change the next call to `solve()`,
-        - `get_model_objective_value()` should correspond to the intern model objective
+        - `get_model_objective_value()` should correspond to the internal model objective
 
         """
         return False

--- a/discrete_optimization/generic_tools/lexico_tools.py
+++ b/discrete_optimization/generic_tools/lexico_tools.py
@@ -90,7 +90,7 @@ class LexicoSolver(SolverDO):
         callbacks_list.on_solve_start(solver=self)
 
         if objectives is None:
-            objectives = self.subsolver.get_model_objectives_available()
+            objectives = self.subsolver.get_lexico_objectives_available()
 
         self._objectives = objectives
         res = ResultStorage(
@@ -105,7 +105,7 @@ class LexicoSolver(SolverDO):
             logger.debug(f"Optimizing on {obj}")
 
             # optimize next objective
-            self.subsolver.set_model_objective(obj)
+            self.subsolver.set_lexico_objective(obj)
             res.extend(
                 self.subsolver.solve(callbacks=kwargs["subsolver_callbacks"], **kwargs)
             )
@@ -115,9 +115,9 @@ class LexicoSolver(SolverDO):
                 break
 
             # add constraint on current objective for next one
-            fit = self.subsolver.get_model_objective_value(obj, res)
+            fit = self.subsolver.get_lexico_objective_value(obj, res)
             logger.debug(f"Found {fit} when optimizing {obj}")
-            self.subsolver.add_model_constraint(obj, fit)
+            self.subsolver.add_lexico_constraint(obj, fit)
 
         # end of solve callback
         callbacks_list.on_solve_end(res=res, solver=self)

--- a/discrete_optimization/generic_tools/ortools_cpsat_tools.py
+++ b/discrete_optimization/generic_tools/ortools_cpsat_tools.py
@@ -112,11 +112,11 @@ class OrtoolsCPSatSolver(CPSolver):
         callbacks_list.on_solve_end(res=res, solver=self)
         return res
 
-    def remove_model_constraint(self, constraints: Iterable[Any]) -> None:
+    def remove_constraints(self, constraints: Iterable[Any]) -> None:
         """Remove the internal model constraints.
 
         Args:
-            constraints: constraints created with `add_model_constraint()`
+            constraints: constraints created for instance with `add_lexico_constraint()`
 
         Returns:
 

--- a/discrete_optimization/generic_tools/ortools_cpsat_tools.py
+++ b/discrete_optimization/generic_tools/ortools_cpsat_tools.py
@@ -113,7 +113,7 @@ class OrtoolsCPSatSolver(CPSolver):
         return res
 
     def remove_model_constraint(self, constraints: Iterable[Any]) -> None:
-        """Remove the intern model constraints.
+        """Remove the internal model constraints.
 
         Args:
             constraints: constraints created with `add_model_constraint()`

--- a/discrete_optimization/knapsack/solvers/knapsack_cpsat_solver.py
+++ b/discrete_optimization/knapsack/solvers/knapsack_cpsat_solver.py
@@ -50,7 +50,7 @@ class CPSatKnapsackSolver(OrtoolsCPSatSolver, SolverKnapsack, WarmstartMixin):
         self.variables["taken"] = variables
         self.cp_model = model
 
-        model.Add(-self._intern_weight() <= self.problem.max_capacity)
+        model.Add(-self._internal_weight() <= self.problem.max_capacity)
 
         self.set_model_objective("value")
 
@@ -60,7 +60,7 @@ class CPSatKnapsackSolver(OrtoolsCPSatSolver, SolverKnapsack, WarmstartMixin):
         for i in range(len(solution.list_taken)):
             self.cp_model.AddHint(self.variables["taken"][i], solution.list_taken[i])
 
-    def _intern_value(self) -> LinearExpr:
+    def _internal_value(self) -> LinearExpr:
         return sum(
             [
                 self.variables["taken"][i] * self.problem.list_items[i].value
@@ -68,7 +68,7 @@ class CPSatKnapsackSolver(OrtoolsCPSatSolver, SolverKnapsack, WarmstartMixin):
             ]
         )
 
-    def _intern_weight(self) -> LinearExpr:
+    def _internal_weight(self) -> LinearExpr:
         return sum(
             [
                 -self.variables["taken"][i] * self.problem.list_items[i].weight
@@ -76,7 +76,7 @@ class CPSatKnapsackSolver(OrtoolsCPSatSolver, SolverKnapsack, WarmstartMixin):
             ]
         )
 
-    def _intern_heaviest_item(self) -> IntVar:
+    def _internal_heaviest_item(self) -> IntVar:
         if "heaviest_item" not in self.variables:
             heaviest_item_var = self.cp_model.new_int_var(
                 name="heaviest_item",
@@ -102,14 +102,14 @@ class CPSatKnapsackSolver(OrtoolsCPSatSolver, SolverKnapsack, WarmstartMixin):
             heaviest_item_var = self.variables["heaviest_item"][0]
         return heaviest_item_var
 
-    def _intern_objective(self, obj: str) -> ObjLinearExprT:
-        intern_objective_mapping = {
-            "value": self._intern_value,
-            "weight": self._intern_weight,
-            "heaviest_item": self._intern_heaviest_item,
+    def _internal_objective(self, obj: str) -> ObjLinearExprT:
+        internal_objective_mapping = {
+            "value": self._internal_value,
+            "weight": self._internal_weight,
+            "heaviest_item": self._internal_heaviest_item,
         }
-        if obj in intern_objective_mapping:
-            return intern_objective_mapping[obj]()
+        if obj in internal_objective_mapping:
+            return internal_objective_mapping[obj]()
         else:
             if obj == "weight_violation":
                 raise ValueError(
@@ -120,7 +120,7 @@ class CPSatKnapsackSolver(OrtoolsCPSatSolver, SolverKnapsack, WarmstartMixin):
                 raise ValueError(f"Unknown objective '{obj}'.")
 
     def set_model_objective(self, obj: str) -> None:
-        self.cp_model.Maximize(self._intern_objective(obj))
+        self.cp_model.Maximize(self._internal_objective(obj))
 
     def add_model_constraint(self, obj: str, value: float) -> Iterable[Constraint]:
         """
@@ -136,7 +136,7 @@ class CPSatKnapsackSolver(OrtoolsCPSatSolver, SolverKnapsack, WarmstartMixin):
             the created constraints.
 
         """
-        return [self.cp_model.Add(self._intern_objective(obj) >= int(value))]
+        return [self.cp_model.Add(self._internal_objective(obj) >= int(value))]
 
     @staticmethod
     def implements_lexico_api() -> bool:

--- a/discrete_optimization/knapsack/solvers/knapsack_cpsat_solver.py
+++ b/discrete_optimization/knapsack/solvers/knapsack_cpsat_solver.py
@@ -52,7 +52,7 @@ class CPSatKnapsackSolver(OrtoolsCPSatSolver, SolverKnapsack, WarmstartMixin):
 
         model.Add(-self._internal_weight() <= self.problem.max_capacity)
 
-        self.set_model_objective("value")
+        self.set_lexico_objective("value")
 
     def set_warm_start(self, solution: KnapsackSolution) -> None:
         """Make the solver warm start from the given solution."""
@@ -119,10 +119,10 @@ class CPSatKnapsackSolver(OrtoolsCPSatSolver, SolverKnapsack, WarmstartMixin):
             else:
                 raise ValueError(f"Unknown objective '{obj}'.")
 
-    def set_model_objective(self, obj: str) -> None:
+    def set_lexico_objective(self, obj: str) -> None:
         self.cp_model.Maximize(self._internal_objective(obj))
 
-    def add_model_constraint(self, obj: str, value: float) -> Iterable[Constraint]:
+    def add_lexico_constraint(self, obj: str, value: float) -> Iterable[Constraint]:
         """
 
         Args:
@@ -142,7 +142,7 @@ class CPSatKnapsackSolver(OrtoolsCPSatSolver, SolverKnapsack, WarmstartMixin):
     def implements_lexico_api() -> bool:
         return True
 
-    def get_model_objectives_available(self) -> list[str]:
+    def get_lexico_objectives_available(self) -> list[str]:
         return ["value", "weight", "heaviest_item"]
 
     def retrieve_solution(

--- a/discrete_optimization/rcpsp/solver/cpsat_solver.py
+++ b/discrete_optimization/rcpsp/solver/cpsat_solver.py
@@ -476,7 +476,7 @@ class CPSatRCPSPSolverResource(CPSatRCPSPSolver):
         else:
             raise ValueError(f"Unknown objective '{obj}'.")
 
-    def set_model_objective(self, obj: str) -> None:
+    def set_lexico_objective(self, obj: str) -> None:
         """Update internal model objective.
 
         Args:
@@ -488,7 +488,7 @@ class CPSatRCPSPSolverResource(CPSatRCPSPSolver):
         """
         self.cp_model.Minimize(self._internal_objective(obj))
 
-    def add_model_constraint(self, obj: str, value: float) -> Iterable[Constraint]:
+    def add_lexico_constraint(self, obj: str, value: float) -> Iterable[Constraint]:
         """
 
         Args:
@@ -512,14 +512,14 @@ class CPSatRCPSPSolverResource(CPSatRCPSPSolver):
         sol = super().retrieve_solution(cpsolvercb)
         sol._internal_objectives = {
             obj: cpsolvercb.value(self._internal_objective(obj))
-            for obj in self.get_model_objectives_available()
+            for obj in self.get_lexico_objectives_available()
         }
         return sol
 
-    def get_model_objectives_available(self) -> list[str]:
+    def get_lexico_objectives_available(self) -> list[str]:
         return ["makespan", "used_resource"]
 
-    def get_model_objective_value(self, obj: str, res: ResultStorage) -> float:
+    def get_lexico_objective_value(self, obj: str, res: ResultStorage) -> float:
         values = [sol._internal_objectives[obj] for sol, fit in res.list_solution_fits]
         return min(values)
 
@@ -704,7 +704,7 @@ class CPSatRCPSPSolverCumulativeResource(CPSatRCPSPSolver):
         else:
             raise ValueError(f"Unknown objective '{obj}'.")
 
-    def set_model_objective(self, obj: str) -> None:
+    def set_lexico_objective(self, obj: str) -> None:
         """Update internal model objective.
 
         Args:
@@ -716,7 +716,7 @@ class CPSatRCPSPSolverCumulativeResource(CPSatRCPSPSolver):
         """
         self.cp_model.Minimize(self._internal_objective(obj))
 
-    def add_model_constraint(self, obj: str, value: float) -> Iterable[Constraint]:
+    def add_lexico_constraint(self, obj: str, value: float) -> Iterable[Constraint]:
         """
 
         Args:
@@ -740,13 +740,13 @@ class CPSatRCPSPSolverCumulativeResource(CPSatRCPSPSolver):
         sol = super().retrieve_solution(cpsolvercb)
         sol._internal_objectives = {
             obj: cpsolvercb.value(self._internal_objective(obj))
-            for obj in self.get_model_objectives_available()
+            for obj in self.get_lexico_objectives_available()
         }
         return sol
 
-    def get_model_objectives_available(self) -> list[str]:
+    def get_lexico_objectives_available(self) -> list[str]:
         return ["makespan", "used_resource"]
 
-    def get_model_objective_value(self, obj: str, res: ResultStorage) -> float:
+    def get_lexico_objective_value(self, obj: str, res: ResultStorage) -> float:
         values = [sol._internal_objectives[obj] for sol, fit in res.list_solution_fits]
         return min(values)

--- a/discrete_optimization/rcpsp/solver/cpsat_solver.py
+++ b/discrete_optimization/rcpsp/solver/cpsat_solver.py
@@ -460,24 +460,24 @@ class CPSatRCPSPSolverResource(CPSatRCPSPSolver):
             "is_used_resource": is_used_resource,
         }
 
-    def _intern_makespan(self) -> IntVar:
+    def _internal_makespan(self) -> IntVar:
         return self.variables["start"][self.problem.sink_task]
 
-    def _intern_used_resource(self) -> LinearExpr:
+    def _internal_used_resource(self) -> LinearExpr:
         return sum(self.variables["is_used_resource"].values())
 
-    def _intern_objective(self, obj: str) -> ObjLinearExprT:
-        intern_objective_mapping = {
-            "makespan": self._intern_makespan,
-            "used_resource": self._intern_used_resource,
+    def _internal_objective(self, obj: str) -> ObjLinearExprT:
+        internal_objective_mapping = {
+            "makespan": self._internal_makespan,
+            "used_resource": self._internal_used_resource,
         }
-        if obj in intern_objective_mapping:
-            return intern_objective_mapping[obj]()
+        if obj in internal_objective_mapping:
+            return internal_objective_mapping[obj]()
         else:
             raise ValueError(f"Unknown objective '{obj}'.")
 
     def set_model_objective(self, obj: str) -> None:
-        """Update intern model objective.
+        """Update internal model objective.
 
         Args:
             obj: a string representing the desired objective.
@@ -486,7 +486,7 @@ class CPSatRCPSPSolverResource(CPSatRCPSPSolver):
         Returns:
 
         """
-        self.cp_model.Minimize(self._intern_objective(obj))
+        self.cp_model.Minimize(self._internal_objective(obj))
 
     def add_model_constraint(self, obj: str, value: float) -> Iterable[Constraint]:
         """
@@ -502,7 +502,7 @@ class CPSatRCPSPSolverResource(CPSatRCPSPSolver):
             the created constraints.
 
         """
-        return [self.cp_model.Add(self._intern_objective(obj) <= int(value))]
+        return [self.cp_model.Add(self._internal_objective(obj) <= int(value))]
 
     @staticmethod
     def implements_lexico_api() -> bool:
@@ -510,8 +510,8 @@ class CPSatRCPSPSolverResource(CPSatRCPSPSolver):
 
     def retrieve_solution(self, cpsolvercb: CpSolverSolutionCallback) -> RCPSPSolution:
         sol = super().retrieve_solution(cpsolvercb)
-        sol._intern_objectives = {
-            obj: cpsolvercb.value(self._intern_objective(obj))
+        sol._internal_objectives = {
+            obj: cpsolvercb.value(self._internal_objective(obj))
             for obj in self.get_model_objectives_available()
         }
         return sol
@@ -520,7 +520,7 @@ class CPSatRCPSPSolverResource(CPSatRCPSPSolver):
         return ["makespan", "used_resource"]
 
     def get_model_objective_value(self, obj: str, res: ResultStorage) -> float:
-        values = [sol._intern_objectives[obj] for sol, fit in res.list_solution_fits]
+        values = [sol._internal_objectives[obj] for sol, fit in res.list_solution_fits]
         return min(values)
 
 
@@ -688,24 +688,24 @@ class CPSatRCPSPSolverCumulativeResource(CPSatRCPSPSolver):
             "resource_capacity": resource_capacity_var,
         }
 
-    def _intern_makespan(self) -> IntVar:
+    def _internal_makespan(self) -> IntVar:
         return self.variables["start"][self.problem.sink_task]
 
-    def _intern_used_resource(self) -> LinearExpr:
+    def _internal_used_resource(self) -> LinearExpr:
         return sum(self.variables["resource_capacity"].values())
 
-    def _intern_objective(self, obj: str) -> ObjLinearExprT:
-        intern_objective_mapping = {
-            "makespan": self._intern_makespan,
-            "used_resource": self._intern_used_resource,
+    def _internal_objective(self, obj: str) -> ObjLinearExprT:
+        internal_objective_mapping = {
+            "makespan": self._internal_makespan,
+            "used_resource": self._internal_used_resource,
         }
-        if obj in intern_objective_mapping:
-            return intern_objective_mapping[obj]()
+        if obj in internal_objective_mapping:
+            return internal_objective_mapping[obj]()
         else:
             raise ValueError(f"Unknown objective '{obj}'.")
 
     def set_model_objective(self, obj: str) -> None:
-        """Update intern model objective.
+        """Update internal model objective.
 
         Args:
             obj: a string representing the desired objective.
@@ -714,7 +714,7 @@ class CPSatRCPSPSolverCumulativeResource(CPSatRCPSPSolver):
         Returns:
 
         """
-        self.cp_model.Minimize(self._intern_objective(obj))
+        self.cp_model.Minimize(self._internal_objective(obj))
 
     def add_model_constraint(self, obj: str, value: float) -> Iterable[Constraint]:
         """
@@ -730,7 +730,7 @@ class CPSatRCPSPSolverCumulativeResource(CPSatRCPSPSolver):
             the created constraints.
 
         """
-        return [self.cp_model.Add(self._intern_objective(obj) <= int(value))]
+        return [self.cp_model.Add(self._internal_objective(obj) <= int(value))]
 
     @staticmethod
     def implements_lexico_api() -> bool:
@@ -738,8 +738,8 @@ class CPSatRCPSPSolverCumulativeResource(CPSatRCPSPSolver):
 
     def retrieve_solution(self, cpsolvercb: CpSolverSolutionCallback) -> RCPSPSolution:
         sol = super().retrieve_solution(cpsolvercb)
-        sol._intern_objectives = {
-            obj: cpsolvercb.value(self._intern_objective(obj))
+        sol._internal_objectives = {
+            obj: cpsolvercb.value(self._internal_objective(obj))
             for obj in self.get_model_objectives_available()
         }
         return sol
@@ -748,5 +748,5 @@ class CPSatRCPSPSolverCumulativeResource(CPSatRCPSPSolver):
         return ["makespan", "used_resource"]
 
     def get_model_objective_value(self, obj: str, res: ResultStorage) -> float:
-        values = [sol._intern_objectives[obj] for sol, fit in res.list_solution_fits]
+        values = [sol._internal_objectives[obj] for sol, fit in res.list_solution_fits]
         return min(values)

--- a/discrete_optimization/rcpsp_multiskill/solvers/cpsat_msrcpsp_solver.py
+++ b/discrete_optimization/rcpsp_multiskill/solvers/cpsat_msrcpsp_solver.py
@@ -49,21 +49,21 @@ class CPSatMSRCPSPSolver(OrtoolsCPSatSolver):
         super().__init__(problem, **kwargs)
         self.variables = {}
 
-    def set_model_objective(self, obj: str) -> None:
+    def set_lexico_objective(self, obj: str) -> None:
         self.cp_model.Minimize(self.variables[obj])
 
-    def add_model_constraint(self, obj: str, value: float) -> Iterable[Constraint]:
+    def add_lexico_constraint(self, obj: str, value: float) -> Iterable[Constraint]:
         return [self.cp_model.Add(self.variables[obj] <= int(value))]
 
     @staticmethod
     def implements_lexico_api() -> bool:
         return True
 
-    def get_model_objectives_available(self) -> List[str]:
+    def get_lexico_objectives_available(self) -> List[str]:
         return ["makespan"]
         # return ["makespan", "cost"]
 
-    def get_model_objective_value(self, obj: str, res: ResultStorage) -> float:
+    def get_lexico_objective_value(self, obj: str, res: ResultStorage) -> float:
         return min(s._internal_obj[obj] for s, _ in res.list_solution_fits)
 
     def init_model(self, **args: Any) -> None:
@@ -808,6 +808,6 @@ class CPSatMSRCPSPSolver(OrtoolsCPSatSolver):
             employee_usage=employee_usage,
         )
         sol._internal_obj = {}
-        for k in self.get_model_objectives_available():
+        for k in self.get_lexico_objectives_available():
             sol._internal_obj[k] = cpsolvercb.Value(self.variables[k])
         return sol

--- a/discrete_optimization/rcpsp_multiskill/solvers/cpsat_msrcpsp_solver.py
+++ b/discrete_optimization/rcpsp_multiskill/solvers/cpsat_msrcpsp_solver.py
@@ -64,7 +64,7 @@ class CPSatMSRCPSPSolver(OrtoolsCPSatSolver):
         # return ["makespan", "cost"]
 
     def get_model_objective_value(self, obj: str, res: ResultStorage) -> float:
-        return min(s._intern_obj[obj] for s, _ in res.list_solution_fits)
+        return min(s._internal_obj[obj] for s, _ in res.list_solution_fits)
 
     def init_model(self, **args: Any) -> None:
         args = self.complete_with_default_hyperparameters(args)
@@ -807,7 +807,7 @@ class CPSatMSRCPSPSolver(OrtoolsCPSatSolver):
             modes=modes_dict,
             employee_usage=employee_usage,
         )
-        sol._intern_obj = {}
+        sol._internal_obj = {}
         for k in self.get_model_objectives_available():
-            sol._intern_obj[k] = cpsolvercb.Value(self.variables[k])
+            sol._internal_obj[k] = cpsolvercb.Value(self.variables[k])
         return sol

--- a/examples/rcpsp/rcpsp_ortools_lexico.py
+++ b/examples/rcpsp/rcpsp_ortools_lexico.py
@@ -43,7 +43,7 @@ def run_ortools_resource_optim(objectives):
         time_limit=5,
         objectives=objectives,
     )
-    print([sol._intern_objectives for sol, fit in result_storage.list_solution_fits])
+    print([sol._internal_objectives for sol, fit in result_storage.list_solution_fits])
     import matplotlib.pyplot as plt
 
     fig, ax1 = plt.subplots(figsize=(10, 6))
@@ -52,13 +52,13 @@ def run_ortools_resource_optim(objectives):
     ax1.set_ylabel("KPI 1", color=color1)
     obj_array_0 = np.array(
         [
-            sol._intern_objectives[objectives[0]]
+            sol._internal_objectives[objectives[0]]
             for sol, fit in result_storage.list_solution_fits
         ]
     )
     obj_array_1 = np.array(
         [
-            sol._intern_objectives[objectives[1]]
+            sol._internal_objectives[objectives[1]]
             for sol, fit in result_storage.list_solution_fits
         ]
     )

--- a/notebooks/z_Advanced/lexico.ipynb
+++ b/notebooks/z_Advanced/lexico.ipynb
@@ -28,13 +28,13 @@
    "source": [
     "To be used as a subsolver of `LexicoSolver` a solver needs to implement some methods. Its method `implements_lexico_api` should return `True` which means that it implements:\n",
     "- `get_model_objectives_available()`: list of labels available\n",
-    "  corresponding to the intern objectives the solver can optimize.\n",
+    "  corresponding to the internal objectives the solver can optimize.\n",
     "  Defaults to`problem.get_objective_names()`.\n",
-    "- `set_model_objective()`: update the intern objective the subsolver\n",
+    "- `set_model_objective()`: update the internal objective the subsolver\n",
     "  will optimize\n",
     "- `get_model_objective_value()`: retrieve the value of the intern\n",
     "  objective currently optimized\n",
-    "- `add_model_constraint()`: add a constraint to the intern model\n",
+    "- `add_model_constraint()`: add a constraint to the internal model\n",
     "  on the given objective to avoid worsening it."
    ]
   },
@@ -267,7 +267,7 @@
    "id": "461905b1-1a75-47f1-8022-256b812ea892",
    "metadata": {},
    "source": [
-    "Le us take a look at available intern objectives:"
+    "Le us take a look at available internal objectives:"
    ]
   },
   {
@@ -317,7 +317,7 @@
     "    ) -> Optional[bool]:\n",
     "        # restrict the result storage to last found solution\n",
     "        res_last = ResultStorage(mode_optim=res.mode_optim, list_solution_fits=res[-1:])\n",
-    "        # get corresponding intern objective value\n",
+    "        # get corresponding internal objective value\n",
     "        for obj in self.objectives:\n",
     "            self.objectives_values[obj].append(\n",
     "                solver.get_model_objective_value(obj=obj, res=res)\n",
@@ -380,14 +380,14 @@
     "time_limit = 4  # timeout for each single-objective optimization\n",
     "ortools_cpsat_solver_kwargs = dict(random_seed=seed, num_search_workers=1)\n",
     "\n",
-    "# callback to store intern objectives (for future visualization)\n",
-    "intern_obj_cb = InternalObjectivesCallback(objectives)\n",
+    "# callback to store internal objectives (for future visualization)\n",
+    "internal_obj_cb = InternalObjectivesCallback(objectives)\n",
     "# callback to store objective changing steps (for future visualization)\n",
     "obj_end_step_cb = ObjectiveEndStepCallback(objectives)\n",
     "\n",
     "# lexicographic optimization\n",
     "result_storage = solver.solve(\n",
-    "    subsolver_callbacks=[ObjectiveLogger(), intern_obj_cb],\n",
+    "    subsolver_callbacks=[ObjectiveLogger(), internal_obj_cb],\n",
     "    callbacks=[obj_end_step_cb],\n",
     "    parameters_cp=parameters_cp,\n",
     "    time_limit=time_limit,\n",
@@ -423,7 +423,7 @@
     "i_obj = 0\n",
     "color = colors[i_obj]\n",
     "obj = objectives[i_obj]\n",
-    "obj_values = intern_obj_cb.objectives_values[obj]\n",
+    "obj_values = internal_obj_cb.objectives_values[obj]\n",
     "x_steps = list(range(1, len(obj_values) + 1))\n",
     "ax.set_ylabel(obj, color=color)\n",
     "ax.plot(x_steps, obj_values, color=color)\n",
@@ -437,7 +437,7 @@
     "i_obj = 1\n",
     "color = colors[i_obj]\n",
     "obj = objectives[i_obj]\n",
-    "obj_values = intern_obj_cb.objectives_values[obj]\n",
+    "obj_values = internal_obj_cb.objectives_values[obj]\n",
     "x_steps = list(range(1, len(obj_values) + 1))\n",
     "ax.set_ylabel(obj, color=color)\n",
     "ax.plot(x_steps, obj_values, color=color)\n",

--- a/notebooks/z_Advanced/lexico.ipynb
+++ b/notebooks/z_Advanced/lexico.ipynb
@@ -27,14 +27,14 @@
    "metadata": {},
    "source": [
     "To be used as a subsolver of `LexicoSolver` a solver needs to implement some methods. Its method `implements_lexico_api` should return `True` which means that it implements:\n",
-    "- `get_model_objectives_available()`: list of labels available\n",
+    "- `get_lexico_objectives_available()`: list of labels available\n",
     "  corresponding to the internal objectives the solver can optimize.\n",
     "  Defaults to`problem.get_objective_names()`.\n",
-    "- `set_model_objective()`: update the internal objective the subsolver\n",
+    "- `set_lexico_objective()`: update the internal objective the subsolver\n",
     "  will optimize\n",
-    "- `get_model_objective_value()`: retrieve the value of the intern\n",
+    "- `get_lexico_objective_value()`: retrieve the value of the intern\n",
     "  objective currently optimized\n",
-    "- `add_model_constraint()`: add a constraint to the internal model\n",
+    "- `add_lexico_constraint()`: add a constraint to the internal model\n",
     "  on the given objective to avoid worsening it."
    ]
   },
@@ -277,7 +277,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "subsolver.get_model_objectives_available()"
+    "subsolver.get_lexico_objectives_available()"
    ]
   },
   {
@@ -320,7 +320,7 @@
     "        # get corresponding internal objective value\n",
     "        for obj in self.objectives:\n",
     "            self.objectives_values[obj].append(\n",
-    "                solver.get_model_objective_value(obj=obj, res=res)\n",
+    "                solver.get_lexico_objective_value(obj=obj, res=res)\n",
     "            )"
    ]
   },

--- a/tests/rcpsp/solver/test_rcpsp_ortools_lexico.py
+++ b/tests/rcpsp/solver/test_rcpsp_ortools_lexico.py
@@ -49,7 +49,7 @@ def check_lexico_order_on_result_storage(
         # print("len ", len(callback_subres.sol_per_step))
         obj_array = np.array(
             [
-                [sol._intern_objectives[obj] for obj in objectives]
+                [sol._internal_objectives[obj] for obj in objectives]
                 for sol in callback_subres.sol_per_step[i]
             ]
         )
@@ -84,7 +84,7 @@ def test_ortools_cumulativeresource_optim(objectives):
     clb = RetrieveSubRes()
     result_storage = solver.solve(time_limit=10, objectives=objectives, callbacks=[clb])
 
-    print([sol._intern_objectives for sol, fit in result_storage.list_solution_fits])
+    print([sol._internal_objectives for sol, fit in result_storage.list_solution_fits])
     check_lexico_order_on_result_storage(callback_subres=clb, solver=solver)
 
 
@@ -113,5 +113,5 @@ def test_ortools_resource_optim(objectives):
         time_limit=10,
         objectives=objectives,
     )
-    print([sol._intern_objectives for sol, fit in result_storage.list_solution_fits])
+    print([sol._internal_objectives for sol, fit in result_storage.list_solution_fits])
     check_lexico_order_on_result_storage(callback_subres=clb, solver=solver)


### PR DESCRIPTION
- we want to make it clear that it deals with lexico optimization (e.g. `add_model_constraint` was not very clear)
- we want to avoid confusion with utility methods to be added to share most `init_model()` code for lp or cp solvers (in particular `set_model_objective` and `add_model_constraint`)

- we also replace "intern" by "internal" as a more appropriate english word. This was in particular used in docstring of lexico methods.