### PR TITLE
Adapt pickup-vrp lp iterative solver with ortools/mathopt

### DIFF
--- a/discrete_optimization/generic_tools/lns_mip.py
+++ b/discrete_optimization/generic_tools/lns_mip.py
@@ -37,8 +37,7 @@ class GurobiConstraintHandler(ConstraintHandler):
         previous_constraints: Iterable[Any],
         **kwargs: Any,
     ) -> None:
-        solver.model.remove(list(previous_constraints))
-        solver.model.update()
+        solver.remove_constraints(previous_constraints)
 
 
 class OrtoolsMathOptConstraintHandler(ConstraintHandler):
@@ -48,8 +47,7 @@ class OrtoolsMathOptConstraintHandler(ConstraintHandler):
         previous_constraints: Iterable[Any],
         **kwargs: Any,
     ) -> None:
-        for cstr in previous_constraints:
-            solver.model.delete_linear_constraint(cstr)
+        solver.remove_constraints(previous_constraints)
 
 
 class LNS_MILP(BaseLNS):

--- a/discrete_optimization/maximum_independent_set/solvers/mis_mathopt.py
+++ b/discrete_optimization/maximum_independent_set/solvers/mis_mathopt.py
@@ -34,6 +34,8 @@ class MisMathOptQuadraticSolver(OrtoolsMathOptMilpSolver, BaseQuadMisSolver):
 
     """
 
+    has_quadratic_objective = True
+
     def convert_to_variable_values(
         self, solution: MisSolution
     ) -> dict[mathopt.Variable, float]:

--- a/tests/pickup_vrp/builders/test_linear_flow_solver.py
+++ b/tests/pickup_vrp/builders/test_linear_flow_solver.py
@@ -56,14 +56,39 @@ def solver_class(request):
     return solver_class
 
 
-def test_tsp_new_api(solver_class):
+@pytest.mark.parametrize(
+    "subtour_do_order, subtour_use_indicator, include_subtour",
+    [
+        (False, False, False),
+        (True, False, False),
+        (True, True, False),
+        (False, False, True),
+    ],
+)
+@pytest.mark.parametrize(
+    "subtour_consider_only_first_component",
+    [True, False],
+)
+def test_tsp_new_api(
+    solver_class,
+    subtour_do_order,
+    subtour_use_indicator,
+    subtour_consider_only_first_component,
+    include_subtour,
+):
     files_available = tsp_parser.get_data_available()
     file_path = [f for f in files_available if "tsp_5_1" in f][0]
     tsp_model = tsp_parser.parse_file(file_path)
     gpdp = ProxyClass.from_tsp_model_gpdp(tsp_model=tsp_model, compute_graph=True)
     linear_flow_solver = solver_class(problem=gpdp)
     linear_flow_solver.init_model(
-        one_visit_per_node=True, include_capacity=False, include_time_evolution=False
+        one_visit_per_node=True,
+        include_capacity=False,
+        include_time_evolution=False,
+        subtour_do_order=subtour_do_order,
+        subtour_use_indicator=subtour_use_indicator,
+        subtour_consider_only_first_component=subtour_consider_only_first_component,
+        include_subtour=include_subtour,
     )
     res = linear_flow_solver.solve(
         time_limit_subsolver=100,
@@ -225,7 +250,21 @@ def test_vrp_simplified(solver_class):
     plot_gpdp_solution(sol, gpdp)
 
 
-def test_selective_tsp(random_seed, solver_class):
+@pytest.mark.parametrize(
+    "subtour_do_order, subtour_use_indicator",
+    [(False, False), (True, False), (True, True)],
+)
+@pytest.mark.parametrize(
+    "subtour_consider_only_first_component",
+    [True, False],
+)
+def test_selective_tsp(
+    random_seed,
+    solver_class,
+    subtour_do_order,
+    subtour_use_indicator,
+    subtour_consider_only_first_component,
+):
     gpdp = create_selective_tsp(nb_nodes=20, nb_vehicles=1, nb_clusters=4)
     linear_flow_solver = solver_class(problem=gpdp)
     kwargs_init_model = dict(
@@ -233,6 +272,9 @@ def test_selective_tsp(random_seed, solver_class):
         one_visit_per_cluster=True,
         include_capacity=False,
         include_time_evolution=False,
+        subtour_do_order=subtour_do_order,
+        subtour_use_indicator=subtour_use_indicator,
+        subtour_consider_only_first_component=subtour_consider_only_first_component,
     )
     linear_flow_solver.init_model(**kwargs_init_model)
     linear_flow_solver.set_random_seed(random_seed)

--- a/tests/pickup_vrp/builders/test_linear_flow_solver.py
+++ b/tests/pickup_vrp/builders/test_linear_flow_solver.py
@@ -27,6 +27,7 @@ from discrete_optimization.pickup_vrp.gpdp import (
 from discrete_optimization.pickup_vrp.plots.gpdp_plot_utils import plot_gpdp_solution
 from discrete_optimization.pickup_vrp.solver.lp_solver import (
     LinearFlowSolver,
+    LinearFlowSolverLazyConstraint,
     LinearFlowSolverMathOpt,
 )
 
@@ -48,7 +49,9 @@ def random_seed():
     return seed
 
 
-@pytest.fixture(params=[LinearFlowSolver, LinearFlowSolverMathOpt])
+@pytest.fixture(
+    params=[LinearFlowSolver, LinearFlowSolverMathOpt, LinearFlowSolverLazyConstraint]
+)
 def solver_class(request):
     solver_class = request.param
     if issubclass(solver_class, GurobiMilpSolver) and not gurobi_available:


### PR DESCRIPTION
- We put as much code in common as possible
   - between gurobi and mathopt version
   - between normal/lazy/cluster versions
- We catch on the fly solutions as TemporaryResult during solve_one_iteration() thanks to a dedicated callback
- We put much part of solve() for base classes GurobiMilpSolver and OrtoolsMathOptMilpSolver into optimize_model() in order to make a good use of it (in particular callback stuff) in solve_one_iteration()
- We add some methods to base classes GurobiMilpSolver and OrtoolsMathOptMilpSolver:
  - set_random_seed()
  - add_linear_constraint_with_indicator() which mimics gurobipy.Model.addGenConstrIndicator()
- We add access to objective during MathOptCallback (by evaluating registered objective): Be careful, by default we use `as_linear_expression`. One has to override `has_quadratic_objective` to make it use `as_quadratic_expression` instead.
- We remove dead code (if do_order in update_model(), init_warm_start())