### PR TITLE
Wrap (time, node) in CPM so that heapq works with mixed node types

### DIFF
--- a/discrete_optimization/rcpsp/solvers/cpm.py
+++ b/discrete_optimization/rcpsp/solvers/cpm.py
@@ -3,6 +3,8 @@
 #  LICENSE file in the root directory of this source tree.
 
 import logging
+from collections.abc import Hashable
+from dataclasses import dataclass
 from heapq import heappop, heappush
 from typing import Any
 
@@ -42,6 +44,15 @@ class CpmObject:
 
     def __str__(self):
         return str({k: getattr(self, k) for k in self.__dict__.keys()})
+
+
+@dataclass
+class TimedNode:
+    time: int
+    node: Hashable
+
+    def __lt__(self, other: "TimedNode"):
+        return self.time < other.time
 
 
 class CpmRcpspSolver(RcpspSolver):
@@ -101,10 +112,11 @@ class CpmRcpspSolver(RcpspSolver):
             for n in current_pred
             if n not in done_forward and current_pred[n]["nb"] == 0
         }
-        queue = [(0, n) for n in available_activities]
+        queue = [TimedNode(time=0, node=n) for n in available_activities]
         forward = True
         while queue:
-            time, node = heappop(queue)
+            timednode = heappop(queue)
+            time, node = timednode.time, timednode.node
             if forward and node in done_forward:
                 continue
             elif not forward and node in done_backward:
@@ -138,14 +150,14 @@ class CpmRcpspSolver(RcpspSolver):
                 if forward:
                     if all(self.map_node[n]._ESD is not None for n in pred):
                         max_esd = max([self.map_node[n]._EFD for n in pred])
-                        heappush(queue, (max_esd, next_node))
+                        heappush(queue, TimedNode(time=max_esd, node=next_node))
                 else:
                     if all(self.map_node[n]._LSD is not None for n in pred):
                         max_esd = min([self.map_node[n]._LSD for n in pred])
-                        heappush(queue, (-max_esd, next_node))
+                        heappush(queue, TimedNode(time=-max_esd, node=next_node))
             if node == self.sink:
                 forward = False
-                heappush(queue, (-self.map_node[node]._EFD, node))
+                heappush(queue, TimedNode(time=-self.map_node[node]._EFD, node=node))
 
         critical_path = [self.sink]
         cur_node = self.sink

--- a/examples/jsp/run_dp.py
+++ b/examples/jsp/run_dp.py
@@ -10,9 +10,7 @@ from didppy import BeamParallelizationMethod
 from discrete_optimization.generic_tools.callbacks.early_stoppers import (
     NbIterationStopper,
 )
-from discrete_optimization.generic_tools.cp_tools import ParametersCp
 from discrete_optimization.jsp.parser import get_data_available, parse_file
-from discrete_optimization.jsp.problem import JobShopProblem
 from discrete_optimization.jsp.solvers.cpsat import CpSatJspSolver
 from discrete_optimization.jsp.solvers.dp import DpJspSolver
 from discrete_optimization.jsp.utils import transform_jsp_to_rcpsp
@@ -118,4 +116,4 @@ def run_dp_of_rcpsp():
 
 
 if __name__ == "__main__":
-    run_dp_jsp_ws()
+    run_dp_of_rcpsp()


### PR DESCRIPTION
We wrap it in a class that compares only on time so that heapq do not care if several node types occur.
(Was an issue in examples.jsp.run_dp.run_dp_of_rcpsp)