### PR TITLE
Handle failed introspection on the dp solvers

### DIFF
--- a/discrete_optimization/generic_tools/dyn_prog_tools.py
+++ b/discrete_optimization/generic_tools/dyn_prog_tools.py
@@ -110,8 +110,20 @@ class DpSolver(SolverDO):
         if "quiet" not in kwargs:
             kwargs["quiet"] = False
         solver_cls = kwargs["solver"]
-        solver_allowed_params = inspect.signature(solver_cls).parameters
-        kwargs_solver = {k: v for k, v in kwargs.items() if k in solver_allowed_params}
+        try:
+            solver_allowed_params = inspect.signature(solver_cls).parameters
+            kwargs_solver = {
+                k: v for k, v in kwargs.items() if k in solver_allowed_params
+            }
+        except:
+            # Previous mode, for python<=3.9
+            for k in list(kwargs.keys()):
+                if k not in {"threads", "initial_solution"}:
+                    kwargs.pop(k)
+                if k == "threads" and solver_cls in {dp.DDLNS, dp.DFBB}:
+                    kwargs.pop(k)
+            kwargs_solver = kwargs
+
         solver = solver_cls(self.model, time_limit=time_limit, **kwargs_solver)
         if use_callback:
             while True:


### PR DESCRIPTION
The introspection capabilities of python3.9 doesn't cover our needs so we include a try except case and do a temporary fix of kwargs parameters (not as robust as introspection) but that should allow 3.9 user to use DP solvers still