### PR TITLE
Rename and change default value of use_callback in DpSolver.solve()

### DIFF
--- a/discrete_optimization/generic_tools/dyn_prog_tools.py
+++ b/discrete_optimization/generic_tools/dyn_prog_tools.py
@@ -95,7 +95,7 @@ class DpSolver(SolverDO):
         self,
         callbacks: Optional[List[Callback]] = None,
         time_limit: Optional[float] = 100.0,
-        use_callback: bool = False,
+        retrieve_intermediate_solutions: bool = True,
         **kwargs: Any,
     ) -> ResultStorage:
         self.early_stopping_exception = None
@@ -125,7 +125,7 @@ class DpSolver(SolverDO):
             kwargs_solver = kwargs
 
         solver = solver_cls(self.model, time_limit=time_limit, **kwargs_solver)
-        if use_callback:
+        if retrieve_intermediate_solutions:
             while True:
                 solution, terminated = solver.search_next()
                 logger.info(f"Objective = {solution.cost}, {solution.is_infeasible}")

--- a/examples/coloring/run_dp.py
+++ b/examples/coloring/run_dp.py
@@ -53,7 +53,7 @@ def run_dp_coloring_ws():
         solver=dp.LNBS,
         callbacks=[NbIterationStopper(nb_iteration_max=20)],
         threads=5,
-        use_callback=True,
+        retrieve_intermediate_solutions=True,
         time_limit=100,
     )
     solution, fit = result_store.get_best_solution_fit()

--- a/examples/facility/run_dp.py
+++ b/examples/facility/run_dp.py
@@ -41,7 +41,9 @@ def dp_facility_example_ws():
     solver = DpFacilitySolver(problem=problem)
     solver.init_model(modeling=DpFacilityModeling.CUSTOMER)
     solver.set_warm_start(g_sol)
-    res = solver.solve(solver=dp.LNBS, use_callback=True, time_limit=3)
+    res = solver.solve(
+        solver=dp.LNBS, retrieve_intermediate_solutions=True, time_limit=3
+    )
     sol: FacilitySolution = res[0][0]
     assert sol.facility_for_customers == g_sol.facility_for_customers
     print(problem.evaluate(sol))

--- a/examples/fjsp/run_dp.py
+++ b/examples/fjsp/run_dp.py
@@ -63,7 +63,7 @@ def run_dp_fjsp_ws():
         callbacks=[NbIterationStopper(nb_iteration_max=20)],
         solver=dp.LNBS,
         time_limit=50,
-        use_callback=True,
+        retrieve_intermediate_solutions=True,
     )
     print(g_sol.schedule)
     print(res[0][0].schedule)

--- a/examples/jsp/run_dp.py
+++ b/examples/jsp/run_dp.py
@@ -86,7 +86,7 @@ def run_dp_jsp_ws():
     solver.set_warm_start(sol_ws)
     res = solver.solve(
         callbacks=[NbIterationStopper(nb_iteration_max=1)],
-        use_callback=True,
+        retrieve_intermediate_solutions=True,
         solver=dp.LNBS,
         time_limit=100,
     )

--- a/examples/knapsack/run_dp.py
+++ b/examples/knapsack/run_dp.py
@@ -44,7 +44,7 @@ def run_ws():
     solver.set_warm_start(solution=sol)
     res = solver.solve(
         callbacks=[NbIterationStopper(nb_iteration_max=100)],
-        use_callback=True,
+        retrieve_intermediate_solutions=True,
         solver=dp.LNBS,
         time_limit=100,
     )

--- a/examples/maximum_independent_set/run_dp.py
+++ b/examples/maximum_independent_set/run_dp.py
@@ -72,7 +72,7 @@ def run_dip_solver_ws():
     res = solver.solve(
         solver=dp.LNBS,
         callbacks=[NbIterationStopper(nb_iteration_max=1)],
-        use_callback=True,
+        retrieve_intermediate_solutions=True,
         time_limit=100,
     )
     sol = res[0][0]

--- a/examples/rcpsp/run_dp.py
+++ b/examples/rcpsp/run_dp.py
@@ -34,7 +34,7 @@ def run_dp_rcpsp():
         ],
         time_limit=30,
         solver=dp.LNBS,
-        use_callback=True,
+        retrieve_intermediate_solutions=True,
         threads=10,
     )
     sol, fit = res.get_best_solution_fit()
@@ -62,7 +62,7 @@ def run_dp_rcpsp_ws():
         ],
         time_limit=30,
         solver=dp.LNBS,
-        use_callback=True,
+        retrieve_intermediate_solutions=True,
         threads=5,
     )
     sol, fit = res.get_best_solution_fit()
@@ -96,7 +96,7 @@ def run_dp_rcpsp_calendar():
         ],
         time_limit=10,
         solver=dp.CABS,
-        use_callback=False,
+        retrieve_intermediate_solutions=False,
         threads=5,
     )
     sol, fit = res.get_best_solution_fit()

--- a/examples/tsp/run_dp.py
+++ b/examples/tsp/run_dp.py
@@ -24,7 +24,9 @@ def run_dp_solver():
     params_objective_function = get_default_objective_setup(problem=model)
     solver = DpTspSolver(model, params_objective_function=params_objective_function)
     solver.init_model()
-    res = solver.solve(solver=dp.LNBS, use_callback=True, time_limit=50)
+    res = solver.solve(
+        solver=dp.LNBS, retrieve_intermediate_solutions=True, time_limit=50
+    )
     sol, fitness = res.get_best_solution_fit()
     assert model.satisfy(sol)
     fig, ax = plt.subplots(1)
@@ -54,7 +56,7 @@ def run_dp_solver_ws():
     res = solver.solve(
         solver=dp.LNBS,
         callbacks=[NbIterationStopper(nb_iteration_max=500)],
-        use_callback=True,
+        retrieve_intermediate_solutions=True,
         threads=5,
         time_limit=40,
     )

--- a/examples/vrp/run_dp.py
+++ b/examples/vrp/run_dp.py
@@ -56,7 +56,7 @@ def run_dp_vrp_ws():
     res = solver.solve(
         solver=dp.LNBS,
         callbacks=[NbIterationStopper(nb_iteration_max=1)],
-        use_callback=True,
+        retrieve_intermediate_solutions=True,
         threads=6,
         time_limit=20,
     )

--- a/tests/coloring/solvers/test_dp.py
+++ b/tests/coloring/solvers/test_dp.py
@@ -53,7 +53,7 @@ def test_dp_coloring_ws(modeling):
         solver=dp.DDLNS,
         callbacks=[NbIterationStopper(nb_iteration_max=1)],
         threads=1,
-        use_callback=True,
+        retrieve_intermediate_solutions=True,
         time_limit=100,
     )
     solution, fit = result_store.get_best_solution_fit()
@@ -83,7 +83,7 @@ def test_coloring_dp_callback_stop():
     problem: ColoringProblem = parse_file(small_example)
     solver = DpColoringSolver(problem=problem)
 
-    kwargs = dict(solver=dp.CABS, time_limit=5, use_callback=True)
+    kwargs = dict(solver=dp.CABS, time_limit=5)
     result_store = solver.solve(**kwargs)
     assert len(result_store) > 1
 

--- a/tests/facility/solvers/test_dp.py
+++ b/tests/facility/solvers/test_dp.py
@@ -42,7 +42,7 @@ def test_facility_example_ws(modeling):
     res = solver.solve(
         callbacks=[NbIterationStopper(nb_iteration_max=1)],
         solver=dp.LNBS,
-        use_callback=True,
+        retrieve_intermediate_solutions=True,
         time_limit=3,
     )
     sol = res[0][0]

--- a/tests/fjsp/solvers/test_dp.py
+++ b/tests/fjsp/solvers/test_dp.py
@@ -60,6 +60,6 @@ def test_dp_fjsp_ws():
         callbacks=[NbIterationStopper(nb_iteration_max=1)],
         solver=dp.LNBS,
         time_limit=3,
-        use_callback=True,
+        retrieve_intermediate_solutions=True,
     )
     assert problem.satisfy(res[0][0])

--- a/tests/jsp/solvers/test_dp.py
+++ b/tests/jsp/solvers/test_dp.py
@@ -29,7 +29,7 @@ def test_dp_jsp_ws():
     solver.set_warm_start(sol_ws)
     res = solver.solve(
         callbacks=[NbIterationStopper(nb_iteration_max=1)],
-        use_callback=True,
+        retrieve_intermediate_solutions=True,
         solver=dp.LNBS,
         time_limit=100,
     )

--- a/tests/knapsack/solvers/test_dp.py
+++ b/tests/knapsack/solvers/test_dp.py
@@ -30,7 +30,7 @@ def test_dp_ws():
     solver.set_warm_start(solution=sol)
     res = solver.solve(
         callbacks=[NbIterationStopper(nb_iteration_max=1)],
-        use_callback=True,
+        retrieve_intermediate_solutions=True,
         solver=dp.LNBS,
         time_limit=100,
     )

--- a/tests/maximum_independent_set/solvers/test_dp.py
+++ b/tests/maximum_independent_set/solvers/test_dp.py
@@ -41,7 +41,7 @@ def test_dip_solver_ws(modeling):
     res = solver.solve(
         solver=dp.LNBS,
         callbacks=[NbIterationStopper(nb_iteration_max=1)],
-        use_callback=True,
+        retrieve_intermediate_solutions=True,
         time_limit=100,
     )
     sol = res[0][0]

--- a/tests/rcpsp/solvers/test_dp.py
+++ b/tests/rcpsp/solvers/test_dp.py
@@ -76,7 +76,7 @@ def test_dp_rcpsp_ws(modeling):
         callbacks=[NbIterationStopper(nb_iteration_max=1)],
         time_limit=30,
         solver=dp.LNBS,
-        use_callback=True,
+        retrieve_intermediate_solutions=True,
         threads=5,
     )
     sol, fit = res.get_best_solution_fit()

--- a/tests/tsp/solvers/test_dp.py
+++ b/tests/tsp/solvers/test_dp.py
@@ -44,7 +44,7 @@ def test_dp_solver_ws():
     res = solver.solve(
         solver=dp.LNBS,
         callbacks=[NbIterationStopper(nb_iteration_max=1)],
-        use_callback=True,
+        retrieve_intermediate_solutions=True,
         threads=5,
         time_limit=40,
     )

--- a/tests/vrp/solvers/test_dp.py
+++ b/tests/vrp/solvers/test_dp.py
@@ -36,7 +36,7 @@ def test_dp_vrp_ws():
     res = solver.solve(
         solver=dp.LNBS,
         callbacks=[NbIterationStopper(nb_iteration_max=1)],
-        use_callback=True,
+        retrieve_intermediate_solutions=True,
         threads=6,
         time_limit=20,
     )


### PR DESCRIPTION
- rename it into retrieve_intermediate_solutions (more explicit)
- set it by default to True (in order to mirror what is done by other solvers)

Note: if retrieve_intermediate_solutions is False, the user callbacks will be called only once, for the last (and only) solution found.