### PR TITLE
Update rcpsp + lns tutorial

### DIFF
--- a/notebooks/RCPSP tutorials/RCPSP-6 Large Neighbourhood Search .ipynb
+++ b/notebooks/RCPSP tutorials/RCPSP-6 Large Neighbourhood Search .ipynb
@@ -85,7 +85,6 @@
     "    mix_lot,\n",
     ")\n",
     "from discrete_optimization.generic_tools.cp_tools import CpSolverName, ParametersCp\n",
-    "from discrete_optimization.generic_tools.lns_cp import LnsCpMzn\n",
     "from discrete_optimization.generic_tools.lns_tools import TrivialInitialSolution\n",
     "from discrete_optimization.generic_tools.result_storage.result_storage import (\n",
     "    from_solutions_to_result_storage,\n",
@@ -192,51 +191,7 @@
    "id": "454048f3",
    "metadata": {},
    "source": [
-    "## LNS"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9ebfdc3b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "constraint_handler = ConstraintHandlerStartTimeInterval_CP(\n",
-    "    problem=rcpsp_problem,\n",
-    "    fraction_to_fix=0.8,\n",
-    "    # here i want to apply bounds constraint on all the tasks\n",
-    "    minus_delta=10,\n",
-    "    plus_delta=10,\n",
-    ")\n",
-    "\n",
-    "some_solution = rcpsp_problem.get_dummy_solution()  # starting solution\n",
-    "initial_solution_provider = TrivialInitialSolution(\n",
-    "    solution=from_solutions_to_result_storage([some_solution], problem=rcpsp_problem)\n",
-    ")\n",
-    "parameters_cp = ParametersCp.default()\n",
-    "time_limit_subsolver_iter0 = 5  # timeout for first call to subsolver\n",
-    "time_limit_subsolver = 2  # timeout for further calls to subsolver\n",
-    "lns_solver = LnsCpMzn(\n",
-    "    problem=rcpsp_problem,\n",
-    "    subsolver=solver,\n",
-    "    initial_solution_provider=initial_solution_provider,\n",
-    "    constraint_handler=constraint_handler,\n",
-    ")\n",
-    "result_store = lns_solver.solve(\n",
-    "    parameters_cp=parameters_cp,\n",
-    "    time_limit_subsolver_iter0=time_limit_subsolver_iter0,\n",
-    "    time_limit_subsolver=time_limit_subsolver,\n",
-    "    nb_iteration_lns=100,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4f8ff1bf",
-   "metadata": {},
-   "source": [
-    "## Easier LNS for scheduling"
+    "## LNS for scheduling"
    ]
   },
   {
@@ -244,7 +199,7 @@
    "id": "ca743106",
    "metadata": {},
    "source": [
-    "Ease the use of LNS solver, with by default initial solution provider, constraint handler etc. By default parameters may work less good than customized ones."
+    "For scheduling, there is a class wrapping the base LNS solver of discrete-optimization which provides default initial solution provider, constraint handler etc. Note that default parameters may work less good than customized ones. You can see the base LNS solver in action in the [advanced tutorial on callbacks](../z_Advanced/callbacks.ipynb)."
    ]
   },
   {
@@ -264,15 +219,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "time_limit_subsolver_iter0 = 5\n",
-    "time_limit_subsolver = 2\n",
     "results = lns_solver.solve(\n",
-    "    nb_iteration_lns=1000,\n",
-    "    skip_first_iteration=False,\n",
-    "    stop_first_iteration_if_optimal=False,\n",
-    "    time_limit_subsolver_iter0=time_limit_subsolver_iter0,\n",
-    "    time_limit_subsolver=time_limit_subsolver,\n",
-    "    nb_iteration_no_improvement=200,\n",
+    "    nb_iteration_lns=1000,  # nb max of iterations\n",
+    "    nb_iteration_no_improvement=200,  # stops if no improvement occurs during such number of consecutive iterations\n",
+    "    time_limit_subsolver=3,  # time limit by subsolver.solve call,\n",
     ")"
    ]
   },
@@ -355,16 +305,11 @@
    "source": [
     "parameters_cp = ParametersCp.default()\n",
     "parameters_cp.free_search = True\n",
-    "time_limit_subsolver_iter0 = 5\n",
-    "time_limit_subsolver = 3\n",
     "results = lns_solver.solve(\n",
-    "    nb_iteration_lns=1000,\n",
-    "    skip_first_iteration=False,\n",
-    "    stop_first_iteration_if_optimal=False,\n",
+    "    nb_iteration_lns=1000,  # nb max of iterations\n",
+    "    nb_iteration_no_improvement=200,  # stops if no improvement occurs during such number of consecutive iterations\n",
+    "    time_limit_subsolver=3,  # time limit by subsolver.solve call,\n",
     "    parameters_cp=parameters_cp,\n",
-    "    nb_iteration_no_improvement=200,\n",
-    "    time_limit_subsolver_iter0=time_limit_subsolver_iter0,\n",
-    "    time_limit_subsolver=time_limit_subsolver,\n",
     ")"
    ]
   },


### PR DESCRIPTION
- the constraint-handler specific to rcpsp does not exist anymore
- => we skip the part using the base lns solver
- we adapt the arguments used by LnsCpMznGenericRcpspSolver
  - remove or rename not relevant parameters