### PR TITLE
Adding cpsat callback in the solver attributes

### DIFF
--- a/discrete_optimization/generic_tools/ortools_cpsat_tools.py
+++ b/discrete_optimization/generic_tools/ortools_cpsat_tools.py
@@ -14,7 +14,6 @@ from ortools.sat.python.cp_model import (
     Constraint,
     CpModel,
 )
-from ortools.sat.python.cp_model import CpSolver
 from ortools.sat.python.cp_model import CpSolver as OrtoolsInternalCpSolver
 from ortools.sat.python.cp_model import CpSolverSolutionCallback
 
@@ -38,6 +37,7 @@ class OrtoolsCpSatSolver(CpSolver):
 
     cp_model: Optional[CpModel] = None
     solver: Optional[OrtoolsInternalCpSolver] = None
+    clb: Optional[CpSolverSolutionCallback] = None
     early_stopping_exception: Optional[Exception] = None
 
     @abstractmethod
@@ -102,6 +102,7 @@ class OrtoolsCpSatSolver(CpSolver):
             for k, v in ortools_cpsat_solver_kwargs.items():
                 setattr(solver.parameters, k, v)
         ortools_callback = OrtoolsCpSatCallback(do_solver=self, callback=callbacks_list)
+        self.clb = ortools_callback
         status = solver.Solve(self.cp_model, ortools_callback)
         self.status_solver = cpstatus_to_dostatus(status_from_cpsat=status)
         if self.early_stopping_exception:

--- a/tests/fjsp/solvers/test_cpsat.py
+++ b/tests/fjsp/solvers/test_cpsat.py
@@ -3,15 +3,76 @@
 #  LICENSE file in the root directory of this source tree.
 
 import logging
+import time
+from typing import Optional
 
 import discrete_optimization.fjsp.parser as fjsp_parser
 import discrete_optimization.jsp.parser as jsp_parser
 from discrete_optimization.fjsp.problem import Job
 from discrete_optimization.fjsp.solvers.cpsat import CpSatFjspSolver, FJobShopProblem
+from discrete_optimization.generic_tools.callbacks.callback import Callback
 from discrete_optimization.generic_tools.cp_tools import ParametersCp
+from discrete_optimization.generic_tools.ortools_cpsat_tools import OrtoolsCpSatSolver
+from discrete_optimization.generic_tools.result_storage.result_storage import (
+    ResultStorage,
+)
 from discrete_optimization.jsp.problem import JobShopProblem
 
 logging.basicConfig(level=logging.INFO)
+
+
+class StatsCpsatCallback(Callback):
+    def __init__(self):
+        self.starting_time: int = None
+        self.end_time: int = None
+        self.stats: list[dict] = []
+        self.final_status: str = None
+
+    def on_step_end(
+        self, step: int, res: ResultStorage, solver: OrtoolsCpSatSolver
+    ) -> Optional[bool]:
+        self.stats.append(
+            {
+                "obj": solver.clb.ObjectiveValue(),
+                "bound": solver.clb.BestObjectiveBound(),
+                "time": time.perf_counter() - self.starting_time,
+                "time-cpsat": {
+                    "user-time": solver.clb.UserTime(),
+                    "wall-time": solver.clb.WallTime(),
+                },
+            }
+        )
+        if solver.clb.ObjectiveValue() == solver.clb.BestObjectiveBound():
+            return False
+
+    def on_solve_start(self, solver: OrtoolsCpSatSolver):
+        self.starting_time = time.perf_counter()
+
+    def on_solve_end(self, res: ResultStorage, solver: OrtoolsCpSatSolver):
+        """Called at the end of solve.
+        Args:
+        res: current result storage
+        solver: solvers using the callback
+        """
+        status_name = solver.solver.status_name()
+        # status_do: StatusSolver = cpstatus_to_dostatus(status_name)
+        if len(self.stats) > 0:
+            if (
+                solver.solver.ObjectiveValue() != self.stats[-1]["obj"]
+                or solver.solver.BestObjectiveBound() != self.stats[-1]["bound"]
+            ):
+                self.stats.append(
+                    {
+                        "obj": solver.solver.ObjectiveValue(),
+                        "bound": solver.solver.BestObjectiveBound(),
+                        "time": time.perf_counter() - self.starting_time,
+                        "time-cpsat": {
+                            "user-time": solver.solver.UserTime(),
+                            "wall-time": solver.solver.WallTime(),
+                        },
+                    }
+                )
+        self.final_status = status_name
 
 
 def test_fjsp_solver_on_jsp():
@@ -50,5 +111,55 @@ def test_cpsat_fjsp():
         duplicate_temporal_var=True,
         add_cumulative_constraint=True,
     )
+    sol, _ = res.get_best_solution_fit()
+    assert problem.satisfy(sol)
+
+
+def test_cpsat_retrieve_stats():
+    files = fjsp_parser.get_data_available()
+    print(files)
+    file = [f for f in files if "Behnke60.fjs" in f][0]
+    print(file)
+    problem = fjsp_parser.parse_file(file)
+    print(problem)
+    solver = CpSatFjspSolver(problem=problem)
+    p = ParametersCp.default_cpsat()
+    p.nb_process = 10
+    res = solver.solve(
+        parameters_cp=p,
+        time_limit=5,
+        ortools_cpsat_solver_kwargs=dict(log_search_progress=True),
+        duplicate_temporal_var=True,
+        add_cumulative_constraint=True,
+        retrieve_stats=True,
+    )
+    assert res.stats is not None
+    assert res.stats[-1]["obj"] == solver.solver.ObjectiveValue()
+    # assert res.stats[-1]["bound"] == solver.solver.BestObjectiveBound()
+    sol, _ = res.get_best_solution_fit()
+    assert problem.satisfy(sol)
+
+
+def test_cpsat_retrieve_stats_via_clb():
+    files = fjsp_parser.get_data_available()
+    file = [f for f in files if "Behnke60.fjs" in f][0]
+    problem = fjsp_parser.parse_file(file)
+    solver = CpSatFjspSolver(problem=problem)
+    p = ParametersCp.default_cpsat()
+    p.nb_process = 10
+    stats_clb = StatsCpsatCallback()
+    res = solver.solve(
+        callbacks=[stats_clb],
+        parameters_cp=p,
+        time_limit=20,
+        ortools_cpsat_solver_kwargs=dict(log_search_progress=True),
+        duplicate_temporal_var=True,
+        add_cumulative_constraint=True,
+        retrieve_stats=False,
+    )
+    assert stats_clb.stats is not None
+    assert stats_clb.stats[-1]["obj"] == solver.solver.ObjectiveValue()
+    print(stats_clb.stats)
+    # assert res.stats[-1]["bound"] == solver.solver.BestObjectiveBound()
     sol, _ = res.get_best_solution_fit()
     assert problem.satisfy(sol)


### PR DESCRIPTION
we store the callback in the attrbute of the solver.
This can ease the usage of classical DO callback to retrieve advanced statistic of the solver, such as current bound of the cpsat solver. (example to come)