### PR TITLE
Fix dimacs parsers

### DIFF
--- a/tests/maximum_independent_set/myciel3.col
+++ b/tests/maximum_independent_set/myciel3.col
@@ -1,0 +1,26 @@
+c FILE: myciel3.col
+c SOURCE: Michael Trick (trick@cmu.edu)
+c DESCRIPTION: Graph based on Mycielski transformation.
+c Triangle free (clique number 2) but increasing
+c coloring number
+p edge 11 20
+e 1 2
+e 1 4
+e 1 7
+e 1 9
+e 2 3
+e 2 6
+e 2 8
+e 3 5
+e 3 7
+e 3 10
+e 4 5
+e 4 6
+e 4 10
+e 5 8
+e 5 9
+e 6 11
+e 7 11
+e 8 11
+e 9 11
+e 10 11

--- a/tests/maximum_independent_set/myciel3.mod.col
+++ b/tests/maximum_independent_set/myciel3.mod.col
@@ -1,0 +1,23 @@
+c modfied from myciel3.col to test isolated node
+p edge 12 20
+
+e 1 2
+e 1 4
+e 1 7
+e 1 9
+e 2 3
+e 2 6
+e 2 8
+e 3 5
+e 3 7
+e 3 10
+e 4 5
+e 4 6
+e 4 10
+e 5 8
+e 5 9
+e 6 11
+e 7 11
+e 8 11
+e 9 11
+e 10 11

--- a/tests/maximum_independent_set/test_parser.py
+++ b/tests/maximum_independent_set/test_parser.py
@@ -1,0 +1,21 @@
+import os
+
+from discrete_optimization.maximum_independent_set.parser import dimacs_parser
+
+test_dir = os.path.dirname(__file__)
+
+
+def test_dimacs_parser():
+    filename = f"{test_dir}/myciel3.col"
+    mis_problem = dimacs_parser(filename)
+    assert 11 in mis_problem.graph_nx
+    assert 0 not in mis_problem.graph_nx
+
+
+def test_dimacs_parser_isolated_node():
+    filename = f"{test_dir}/myciel3.mod.col"
+    mis_problem = dimacs_parser(filename)
+    assert 12 in mis_problem.graph_nx
+    assert 0 not in mis_problem.graph_nx
+    assert len(mis_problem.graph_nx[11]) > 0
+    assert len(mis_problem.graph_nx[12]) == 0


### PR DESCRIPTION
The `dimacs_parser()` and `dimacs_parser_nx()` were not following exactly the dimacs specifications (see
http://prolland.free.fr/works/research/dsat/dimacs.html)

In particular
- both were assuming no comment lines
- `dimacs_parser()` was adding node 0 (because trying to number nodes from 0 to n-1) and potentially forgetting node n if not part of an edge
- `dimacs_parser_nx()` was ignoring the number of nodes defined in problem line and only adding nodes enumerated in the edges

We now have `dimacs_parser_nx()` be an alias for `dimacs_parser()` and follow the exact specifications.

Fixes #361.