### PR TITLE
Implement a dashboard to sum-up results of a d-o study

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,7 +210,7 @@ jobs:
       - name: Install test dependencies
         run: |
           wheelfile=$(ls ./dist/discrete_optimization*.whl)
-          pip install "${wheelfile}[test, quantum]"
+          pip install "${wheelfile}[test, quantum, dashboard]"
           if [ "${{ startsWith(matrix.os, 'windows') || (startsWith(matrix.os, 'macos') && matrix.python-version == '3.12') }}" == false ]; then
             echo "install toulbar2"
             pip install "${wheelfile}[toulbar]"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,7 +162,12 @@ jobs:
         run: |
           python -m pip install -U pip
           wheelfile=$(ls ./dist/discrete_optimization*.whl)
-          pip install ${wheelfile}
+          python_version=${{ matrix.python-version }}
+          if [ "$python_version" = "3.9" ]; then
+            pip install ${wheelfile} "numpy<2"  # for compatibility with pytables available for python 3.9
+          else
+            pip install ${wheelfile}
+          fi
       - name: Check minizinc based solvers fails without minizinc binary
         run: |
           python -c "

--- a/discrete_optimization/generic_tools/dashboard/__init__.py
+++ b/discrete_optimization/generic_tools/dashboard/__init__.py
@@ -1,0 +1,1 @@
+from .dashboard import Dashboard

--- a/discrete_optimization/generic_tools/dashboard/config.py
+++ b/discrete_optimization/generic_tools/dashboard/config.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from collections.abc import Hashable
+from typing import Any, Optional, Union
+
+# type aliases
+DictConfig = Union[dict[str, "DictConfig"], Hashable]
+HashableConfig = Union[tuple[str, "HashableConfig"], Hashable]
+
+# config keys
+NAME = "name"
+SOLVER = "solver"
+
+
+def get_config_name(config: DictConfig) -> str:
+    if isinstance(config, dict):
+        if NAME in config:
+            return config[NAME]
+        elif SOLVER in config:
+            return f"{config[SOLVER]}-{get_config_name({k: v for k,v in config.items() if k != SOLVER})}"
+        else:
+            return "-".join(f"{k}-{get_config_name(v)}" for k, v in config.items())
+    else:
+        return str(config)
+
+
+def convert_config_dict2hashable(config: DictConfig) -> HashableConfig:
+    if isinstance(config, dict):
+        return tuple((k, convert_config_dict2hashable(v)) for k, v in config.items())
+    else:
+        return config
+
+
+def is_tupleddict(config: Any) -> bool:
+    return isinstance(config, tuple) and all(
+        isinstance(configitem, tuple)
+        and len(configitem) == 2
+        and isinstance(configitem[0], str)
+        for configitem in config
+    )
+
+
+def convert_config_hashable2dict(config: HashableConfig) -> DictConfig:
+    if is_tupleddict(config):
+        return {k: convert_config_hashable2dict(v) for k, v in config}
+    else:
+        return config
+
+
+class ConfigStore:
+    """Store experiments config and mapping to their names"""
+
+    def __init__(self):
+        self.map_name2config: dict[str, HashableConfig] = {}
+        self.map_config2name: dict[HashableConfig, str] = {}
+        self.map_config2hasusername: dict[HashableConfig, bool] = {}
+
+    def add(self, config: DictConfig) -> None:
+        """Add a config to the store.
+
+        Ensure bijection between names and configs.
+        If name already given, use it.
+        If not, construct it from solver parameters.
+        If 2 names given in different occurences raise an error.
+        If 2 different config share the same name, raise an error.
+
+        """
+        config = dict(config)  # copy dict to avoid inplace modification
+        name: Optional[str] = None
+        # name given by user?
+        if NAME in config:
+            name = config[NAME]
+            del config[NAME]
+        # hashable version of the config
+        hashable_config = convert_config_dict2hashable(config)
+
+        # get a name and check that previous similar config share the name (or had not already one defined)
+        if (
+            hashable_config in self.map_config2name
+        ):  # config already added (with potentially no name or another one)
+            if name is None:
+                name = self.map_config2name[hashable_config]
+            else:
+                if self.map_config2hasusername[
+                    hashable_config
+                ]:  # had already a name given by user
+                    assert name == self.map_config2name[hashable_config], (
+                        "Same configs should share same names. "
+                        f"The names {name} and {self.map_config2name[hashable_config]} were used."
+                    )
+                else:  # stored name was a name constructed by default => replace it with name given by user
+                    self.map_config2name[hashable_config] = name
+                    self.map_config2hasusername[hashable_config] = True
+        else:
+            if name is None:  # no name given by user: construct one from parameters
+                name = get_config_name(config)
+                self.map_config2hasusername[hashable_config] = False
+            else:  # name given by user
+                self.map_config2hasusername[hashable_config] = True
+            self.map_config2name[hashable_config] = name
+
+        # check that only one config corresponds to this name
+        if name in self.map_name2config:
+            assert hashable_config == self.map_name2config[name], (
+                f"Two configs share same name {name}: "
+                f"{convert_config_hashable2dict(self.map_name2config[name])} and {config}."
+            )
+        else:
+            self.map_name2config[name] = hashable_config
+
+    def get_name(self, config: DictConfig) -> str:
+        config = dict(config)  # copy dict to avoid inplace modification
+        if NAME in config:
+            del config[NAME]
+        hashable_config = convert_config_dict2hashable(config)
+        if hashable_config not in self.map_config2name:
+            raise RuntimeError(
+                "Be sure to add all configs to the store before extracting names. "
+                "That way, we can ensure same configs share names "
+                "and that no name is used for several different configs."
+            )
+        else:
+            return self.map_config2name[hashable_config]
+
+    def get_config(self, name: str) -> DictConfig:
+        return convert_config_hashable2dict(self.map_name2config[name])

--- a/discrete_optimization/generic_tools/dashboard/config.py
+++ b/discrete_optimization/generic_tools/dashboard/config.py
@@ -3,13 +3,11 @@ from __future__ import annotations
 from collections.abc import Hashable
 from typing import Any, Optional, Union
 
+from discrete_optimization.generic_tools.study.experiment import NAME, SOLVER
+
 # type aliases
 DictConfig = Union[dict[str, "DictConfig"], Hashable]
 HashableConfig = Union[tuple[str, "HashableConfig"], Hashable]
-
-# config keys
-NAME = "name"
-SOLVER = "solver"
 
 
 def get_config_name(config: DictConfig) -> str:

--- a/discrete_optimization/generic_tools/dashboard/dashboard.py
+++ b/discrete_optimization/generic_tools/dashboard/dashboard.py
@@ -1,0 +1,726 @@
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Sequence
+from typing import Any, Optional, Union
+
+import pandas as pd
+
+from discrete_optimization.generic_tools.dashboard.config import ConfigStore
+from discrete_optimization.generic_tools.dashboard.plots import (
+    create_graph_from_series_dict,
+)
+from discrete_optimization.generic_tools.dashboard.preprocess import (
+    FIT,
+    MEAN,
+    QUANTILE,
+    aggregate_results_by_config,
+    clip_df,
+    clip_results,
+    compute_extra_metrics,
+    compute_stat_by_config,
+    drop_empty_results,
+    extract_configs,
+    extract_empty_xps_metadata,
+    extract_instances,
+    extract_metrics,
+    extract_nbsolvedinstances_by_config,
+    filter_results,
+    get_experiment_name,
+    has_multiple_runs,
+    map_stat_key2func,
+    normalize_results,
+)
+
+try:
+    import dash
+except ImportError:
+    dash_available = False
+    Dash = object
+else:
+    dash_available = True
+    from dash import Dash, Input, Output, callback, ctx, dash_table, dcc, html
+
+try:
+    import dash_bootstrap_components as dbc
+except ImportError:
+    dbc_available = False
+else:
+    dbc_available = True
+
+
+TIME_LOGSCALE_KEY = "time log-scale"
+TIME_LOGSCALE_ID = "time-log-scale"
+
+TRANSPOSE_KEY = "transpose"
+TRANSPOSE_ID = "transpose"
+
+GRAPH_METRIC_ID = "graph-metric"
+GRAPH_AGG_METRIC_ID = "graph-agg-metric"
+GRAPH_NB_SOLVED_INSTANCES_ID = "graph-nb-solved-instances"
+
+TABLE_EMPTY_XPS_ID = "table-empty-xps"
+TABLE_EMPTY_XPS_NO_DATA_ID = "table-empty-xps-no-data"
+TABLE_XP_ID = "table-metric"
+TABLE_XP_NO_DATA_ID = "table-metric-no-data"
+CONFIG_MD_ID = "config-markdown"
+
+TAB_METRIC_ID = "tab-metric"
+TAB_AGG_METRIC_ID = "tab-agg-metric"
+TAB_NB_SOLVED_INSTANCES_ID = "tab-nb-solved-instances"
+TAB_CONFIG_ID = "tab-config"
+TAB_XP_ID = "tab-experiment"
+TAB_EMPTY_XPS_ID = "tab-empty-xps"
+TABS_ID = "tabs"
+
+ALL_INSTANCES = "@all"
+
+METRIC_ID = "metric"
+INSTANCES_ID = "instances"
+STAT_ID = "stat"
+CONFIGS_ID = "configs"
+CONFIG_ID = "config"
+Q_ID = "quantile-q"
+CLIP_ID = "clip"
+CLIP_DIV_ID = "clip-div"
+METRIC_DIV_ID = "metric-div"
+INSTANCES_DIV_ID = "instances-div"
+STAT_DIV_ID = "stat-div"
+CONFIG_DIV_ID = "config-div"
+CONFIGS_DIV_ID = "configs-div"
+Q_DIV_ID = "quantile-q-div"
+TRANSPOSE_DIV_ID = "transpose-div"
+INSTANCE_ID = "instance"
+INSTANCE_DIV_ID = "instance-div"
+RUN_ID = "run-id"
+RUN_DIV_ID = "run-id-div"
+
+
+class Dashboard(Dash):
+    def __init__(
+        self,
+        results: Optional[list[pd.DataFrame]] = None,
+        title="Discrete-Optimization Experiments Dashboard",
+        external_stylesheets: Optional[Sequence[Union[str, dict[str, Any]]]] = None,
+        **kwargs,
+    ):
+        if not dash_available:
+            raise RuntimeError("You need to install 'dash' to create a dashboard.")
+        if not dbc_available:
+            raise RuntimeError(
+                "You need to install 'dash_bootstrap_components' to create a dashboard."
+            )
+
+        if external_stylesheets is None:
+            external_stylesheets = [dbc.themes.BOOTSTRAP]
+        super().__init__(
+            title=title, external_stylesheets=external_stylesheets, **kwargs
+        )
+        self.full_results = results  # all xps event empty
+        self.results = results  # without empty xps  (after preprocessing)
+        self.preprocess_data()
+        self.create_layout()
+        self.load_callbacks()
+
+    def preprocess_data(self):
+        results = self.full_results
+        assert results is not None
+        # normalization + add new metrics
+        self.config_store = ConfigStore()
+        normalize_results(results, config_store=self.config_store)
+        compute_extra_metrics(results)
+        # keep only non-empty dataframes
+        results = drop_empty_results(results)
+        self.results = results
+        # list available configs, instances, and metrics
+        self.configs = sorted(extract_configs(results))
+        self.instances = sorted(extract_instances(results))
+        self.metrics = sorted(extract_metrics(results))
+        self.full_configs = sorted(extract_configs(self.full_results))
+        self.full_instances = sorted(extract_instances(self.full_results))
+        self.full_metrics = sorted(extract_metrics(self.full_results))
+        # precompute aggregated data
+        self.results_by_config = aggregate_results_by_config(
+            results=results, configs=self.configs
+        )
+        self.nbsolvedinstances_by_config = extract_nbsolvedinstances_by_config(
+            results=results
+        )
+        self.empty_xps_metadata = extract_empty_xps_metadata(self.full_results)
+
+    def create_layout(self):
+        controls = dbc.Card(
+            [
+                dbc.CardHeader([html.H2("Filters")]),
+                dbc.CardBody(
+                    [
+                        html.Div(
+                            [
+                                dbc.Checklist(
+                                    options=[TIME_LOGSCALE_KEY],
+                                    value=[1],
+                                    id=TIME_LOGSCALE_ID,
+                                    switch=True,
+                                ),
+                            ]
+                        ),
+                        html.Div(
+                            [
+                                dbc.Label("Configs"),
+                                dcc.Dropdown(
+                                    self.configs,
+                                    self.configs,
+                                    multi=True,
+                                    id=CONFIGS_ID,
+                                ),
+                            ],
+                            id=CONFIGS_DIV_ID,
+                        ),
+                        html.Div(
+                            [
+                                dbc.Label("Instances"),
+                                dcc.Dropdown(
+                                    [ALL_INSTANCES] + self.instances,
+                                    ALL_INSTANCES,
+                                    multi=True,
+                                    id=INSTANCES_ID,
+                                ),
+                            ],
+                            id=INSTANCES_DIV_ID,
+                        ),
+                        html.Div(
+                            [
+                                dbc.Label("Metric"),
+                                dcc.Dropdown(self.metrics, FIT, id=METRIC_ID),
+                            ],
+                            id=METRIC_DIV_ID,
+                        ),
+                        html.Div(
+                            [
+                                dbc.Label("Clip at"),
+                                dbc.Input(
+                                    value=1e50, id=CLIP_ID, type="number", min=0.0
+                                ),
+                            ],
+                            id=CLIP_DIV_ID,
+                        ),
+                        html.Div(
+                            [
+                                dbc.Label("Aggregate with"),
+                                dcc.Dropdown(
+                                    sorted(map_stat_key2func.keys()), MEAN, id=STAT_ID
+                                ),
+                            ],
+                            id=STAT_DIV_ID,
+                        ),
+                        html.Div(
+                            [
+                                dbc.Label("Quantile order"),
+                                dbc.Input(
+                                    min=0,
+                                    max=1,
+                                    value=0.5,
+                                    step=0.05,
+                                    type="number",
+                                    id=Q_ID,
+                                ),
+                            ],
+                            id=Q_DIV_ID,
+                        ),
+                        html.Div(
+                            [
+                                dbc.Label("Transpose axes"),
+                                dbc.Checklist(
+                                    options=[TRANSPOSE_KEY],
+                                    value=[1],
+                                    id=TRANSPOSE_ID,
+                                    switch=True,
+                                ),
+                            ],
+                            id=TRANSPOSE_DIV_ID,
+                        ),
+                        html.Div(
+                            [
+                                dbc.Label("Config"),
+                                dcc.Dropdown(
+                                    self.full_configs,
+                                    value=self.full_configs[0],
+                                    multi=False,
+                                    id=CONFIG_ID,
+                                ),
+                            ],
+                            id=CONFIG_DIV_ID,
+                        ),
+                        html.Div(
+                            [
+                                dbc.Label("Instance"),
+                                dcc.Dropdown(
+                                    self.full_instances,
+                                    value=self.full_instances[0],
+                                    multi=False,
+                                    id=INSTANCE_ID,
+                                ),
+                            ],
+                            id=INSTANCE_DIV_ID,
+                        ),
+                        html.Div(
+                            [
+                                dbc.Label("Attempt"),
+                                dcc.Dropdown(
+                                    multi=False,
+                                    id=RUN_ID,
+                                ),
+                            ],
+                            id=RUN_DIV_ID,
+                        ),
+                    ]
+                ),
+            ]
+        )
+
+        graph_metric = dcc.Graph(id=GRAPH_METRIC_ID)
+        graph_agg_metric = dcc.Graph(id=GRAPH_AGG_METRIC_ID)
+        graph_nb_solved_instances = dcc.Graph(id=GRAPH_NB_SOLVED_INSTANCES_ID)
+
+        config_explorer = dcc.Markdown(id=CONFIG_MD_ID)
+
+        table_xp = dash_table.DataTable(page_size=20, id=TABLE_XP_ID)
+        table_xp_nodata = html.P("no data", id=TABLE_XP_NO_DATA_ID)
+
+        table_empty_xps = dash_table.DataTable(
+            data=self.empty_xps_metadata.to_dict("records"),
+            columns=[{"id": c, "name": c} for c in self.empty_xps_metadata.columns],
+            page_size=20,
+            id=TABLE_EMPTY_XPS_ID,
+            style_data={
+                "whiteSpace": "normal",
+                "height": "auto",
+            },
+        )
+        table_empty_xps_nodata = html.P("no data", id=TABLE_EMPTY_XPS_NO_DATA_ID)
+
+        graph_tabs = dbc.Card(
+            [
+                dbc.CardHeader(
+                    [
+                        html.H2("Graph"),
+                    ]
+                ),
+                dbc.CardBody(
+                    [
+                        dbc.Tabs(
+                            [
+                                dbc.Tab(
+                                    children=graph_metric,
+                                    label="Metric evolution",
+                                    tab_id=TAB_METRIC_ID,
+                                ),
+                                dbc.Tab(
+                                    children=graph_agg_metric,
+                                    label="Metric aggregation along instances",
+                                    tab_id=TAB_AGG_METRIC_ID,
+                                ),
+                                dbc.Tab(
+                                    children=graph_nb_solved_instances,
+                                    label="Nb of solved instances",
+                                    tab_id=TAB_NB_SOLVED_INSTANCES_ID,
+                                ),
+                                dbc.Tab(
+                                    children=config_explorer,
+                                    label="Config explorer",
+                                    tab_id=TAB_CONFIG_ID,
+                                ),
+                                dbc.Tab(
+                                    children=html.Div(
+                                        [table_xp, table_xp_nodata],
+                                        className="mt-3",
+                                    ),
+                                    label="Experiment data",
+                                    tab_id=TAB_XP_ID,
+                                ),
+                                dbc.Tab(
+                                    children=html.Div(
+                                        [table_empty_xps],
+                                        className="mt-3",
+                                    ),
+                                    label="Empty experiments",
+                                    tab_id=TAB_EMPTY_XPS_ID,
+                                ),
+                            ],
+                            id=TABS_ID,
+                        )
+                    ]
+                ),
+            ]
+        )
+
+        self.layout = dbc.Container(
+            [
+                html.H1(children="Discrete-Optimization Experiments Dashboard"),
+                html.Hr(),
+                dbc.Row(
+                    [
+                        dbc.Col(controls, md=4, xl=3),
+                        dbc.Col(
+                            # [
+                            #     html.H2("Graph"),
+                            #     dbc.Row(dbc.Col(dcc.Graph(id="graph-metric-evolution"))),
+                            #     dbc.Row(dbc.Col(dcc.Graph(id="graph-agg-metric-along-instances-evolution"))),
+                            #     dbc.Row(dbc.Col(dcc.Graph(id="graph-nb-solved-instances-evolution"))),
+                            # ],
+                            graph_tabs,
+                            md=8,
+                            xl=9,
+                        ),
+                    ],
+                ),
+            ],
+            fluid=False,
+            style={"$container-max-widths": "(  xl: 10820px,);"},
+        )
+
+    def load_callbacks(self):
+        # Graph graph-metric-evolution: 1 config x 1 instance => evolution of a metric
+        @self.callback(
+            Output(component_id=GRAPH_METRIC_ID, component_property="figure"),
+            inputs=dict(
+                configs=Input(component_id=CONFIGS_ID, component_property="value"),
+                instances=Input(component_id=INSTANCES_ID, component_property="value"),
+                metric=Input(component_id=METRIC_ID, component_property="value"),
+                clip_value=Input(component_id=CLIP_ID, component_property="value"),
+                time_log_scale=Input(
+                    component_id=TIME_LOGSCALE_ID, component_property="value"
+                ),
+            ),
+        )
+        def update_graph_metric(configs, instances, metric, time_log_scale, clip_value):
+            with_time_log_scale = TIME_LOGSCALE_KEY in time_log_scale
+            instances = self._replace_allinstances_alias(
+                instances
+            )  # interpret @all alias
+            results = clip_results(
+                filter_results(self.results, configs=configs, instances=instances),
+                clip_value=clip_value,
+            )
+            map_xp2metric = {
+                get_experiment_name(df, with_run_nb=has_multiple_runs(results)): df[
+                    metric
+                ]
+                for df in results
+                if metric in df
+            }
+            return create_graph_from_series_dict(
+                map_label2ser=map_xp2metric,
+                with_time_log_scale=with_time_log_scale,
+                legend_title="Experiments",
+            )
+
+        # Graph graph-agg-metric-along-instance-evolution: 1 config => aggregation of a metric along instances
+        @self.callback(
+            Output(
+                component_id=GRAPH_AGG_METRIC_ID,
+                component_property="figure",
+            ),
+            inputs=dict(
+                configs=Input(component_id=CONFIGS_ID, component_property="value"),
+                instances=Input(component_id=INSTANCES_ID, component_property="value"),
+                stat=Input(component_id=STAT_ID, component_property="value"),
+                metric=Input(component_id=METRIC_ID, component_property="value"),
+                q=Input(component_id=Q_ID, component_property="value"),
+                clip_value=Input(component_id=CLIP_ID, component_property="value"),
+                time_log_scale=Input(
+                    component_id=TIME_LOGSCALE_ID, component_property="value"
+                ),
+            ),
+        )
+        def update_graph_agg_metric(
+            configs, instances, stat, metric, q, time_log_scale, clip_value
+        ):
+            with_time_log_scale = TIME_LOGSCALE_KEY in time_log_scale
+            instances = self._replace_allinstances_alias(
+                instances
+            )  # interpret @all alias
+            # filter and clip
+            results_by_config = {
+                config: clip_df(df, clip_value=clip_value)
+                for config, df in self.results_by_config.items()
+                if config in configs
+            }
+            stat_by_config = compute_stat_by_config(
+                results_by_config=results_by_config, stat=stat, q=q, instances=instances
+            )
+            stat_metric_by_config = {
+                config: df[metric]
+                for config, df in stat_by_config.items()
+                if metric in df
+            }
+            return create_graph_from_series_dict(
+                map_label2ser=stat_metric_by_config,
+                with_time_log_scale=with_time_log_scale,
+                legend_title="Configs",
+            )
+
+        # Graph graph-nb-solved-instances-evolution: 1 config => nb of instances solved depending on time
+        @self.callback(
+            Output(
+                component_id=GRAPH_NB_SOLVED_INSTANCES_ID, component_property="figure"
+            ),
+            inputs=dict(
+                configs=Input(component_id=CONFIGS_ID, component_property="value"),
+                time_log_scale=Input(
+                    component_id=TIME_LOGSCALE_ID, component_property="value"
+                ),
+                transpose_value=Input(
+                    component_id=TRANSPOSE_ID, component_property="value"
+                ),
+            ),
+        )
+        def update_graph_nb_solved_instances(configs, time_log_scale, transpose_value):
+            transpose = TRANSPOSE_KEY in transpose_value
+            with_time_log_scale = TIME_LOGSCALE_KEY in time_log_scale
+            nbsolvedinstances_by_config = {
+                config: ser
+                for config, ser in self.nbsolvedinstances_by_config.items()
+                if config in configs
+            }
+            return create_graph_from_series_dict(
+                map_label2ser=nbsolvedinstances_by_config,
+                with_time_log_scale=with_time_log_scale,
+                legend_title="Configs",
+                transpose=transpose,
+            )
+
+        # Config explorer
+        @self.callback(
+            Output(component_id=CONFIG_MD_ID, component_property="children"),
+            inputs=dict(
+                config_name=Input(component_id=CONFIG_ID, component_property="value"),
+            ),
+        )
+        def update_config_display(config_name: str) -> str:
+            try:
+                config = self.config_store.get_config(config_name)
+            except KeyError:
+                config_str = "NOT_FOUND"
+            else:
+                config_str = json.dumps(config, indent=4)
+            return "```python\n" f"{config_str}\n" "```\n"
+
+        # Xp explorer
+        @self.callback(
+            output=dict(
+                options=Output(component_id=RUN_ID, component_property="options"),
+                value=Output(component_id=RUN_ID, component_property="value"),
+            ),
+            inputs=dict(
+                config=Input(component_id=CONFIG_ID, component_property="value"),
+                instance=Input(component_id=INSTANCE_ID, component_property="value"),
+            ),
+        )
+        def update_run_options(config: str, instance: str) -> dict[str, Any]:
+            nb_results = len(
+                filter_results(
+                    results=self.full_results, configs=[config], instances=[instance]
+                )
+            )
+            return dict(
+                options=list(range(nb_results)),
+                value=0,
+            )
+
+        @self.callback(
+            output=dict(
+                data=Output(component_id=TABLE_XP_ID, component_property="data"),
+                nodata=Output(
+                    component_id=TABLE_XP_NO_DATA_ID, component_property="className"
+                ),
+            ),
+            inputs=dict(
+                config=Input(component_id=CONFIG_ID, component_property="value"),
+                instance=Input(component_id=INSTANCE_ID, component_property="value"),
+                run=Input(component_id=RUN_ID, component_property="value"),
+            ),
+        )
+        def update_xp_data(config: str, instance: str, run: Optional[int]) -> Any:
+            if run is None:
+                return dict(data=[], nodata=_convert_bool2classname(True))
+            df = filter_results(
+                results=self.full_results, configs=[config], instances=[instance]
+            )[run]
+            df = df.reset_index()
+            return dict(
+                data=df.to_dict("records"),
+                nodata=_convert_bool2classname(len(df) == 0),
+            )
+
+        # Filters disabling
+        @self.callback(
+            output=dict(
+                metric=Output(
+                    component_id=METRIC_DIV_ID, component_property="className"
+                ),
+                configs=Output(
+                    component_id=CONFIGS_DIV_ID, component_property="className"
+                ),
+                instances=Output(
+                    component_id=INSTANCES_DIV_ID, component_property="className"
+                ),
+                stat=Output(component_id=STAT_DIV_ID, component_property="className"),
+                q=Output(component_id=Q_DIV_ID, component_property="className"),
+                transpose=Output(
+                    component_id=TRANSPOSE_DIV_ID, component_property="className"
+                ),
+                clip=Output(component_id=CLIP_DIV_ID, component_property="className"),
+                config=Output(
+                    component_id=CONFIG_DIV_ID, component_property="className"
+                ),
+                instance=Output(
+                    component_id=INSTANCE_DIV_ID, component_property="className"
+                ),
+                run=Output(component_id=RUN_DIV_ID, component_property="className"),
+                time_log_scale=Output(
+                    component_id=TIME_LOGSCALE_ID, component_property="className"
+                ),
+            ),
+            inputs=dict(
+                active_tab=Input(component_id=TABS_ID, component_property="active_tab"),
+                stat=Input(component_id=STAT_ID, component_property="value"),
+            ),
+        )
+        def update_filters(active_tab: str, stat: str):
+            if active_tab == TAB_METRIC_ID:
+                return _convert_bool2classname_dict(
+                    dict(
+                        time_log_scale=True,
+                        metric=True,
+                        configs=True,
+                        instances=True,
+                        stat=False,
+                        q=False,
+                        transpose=False,
+                        clip=True,
+                        config=False,
+                        instance=False,
+                        run=False,
+                    )
+                )
+            elif active_tab == TAB_AGG_METRIC_ID:
+                return _convert_bool2classname_dict(
+                    dict(
+                        time_log_scale=True,
+                        metric=True,
+                        configs=True,
+                        instances=True,
+                        stat=True,
+                        q=stat == QUANTILE,
+                        transpose=False,
+                        clip=True,
+                        config=False,
+                        instance=False,
+                        run=False,
+                    )
+                )
+            elif active_tab == TAB_NB_SOLVED_INSTANCES_ID:
+                return _convert_bool2classname_dict(
+                    dict(
+                        time_log_scale=True,
+                        metric=False,
+                        configs=True,
+                        instances=False,
+                        stat=False,
+                        q=False,
+                        transpose=True,
+                        clip=False,
+                        config=False,
+                        instance=False,
+                        run=False,
+                    )
+                )
+            elif active_tab == TAB_CONFIG_ID:
+                return _convert_bool2classname_dict(
+                    dict(
+                        time_log_scale=False,
+                        metric=False,
+                        configs=False,
+                        instances=False,
+                        stat=False,
+                        q=False,
+                        transpose=False,
+                        clip=False,
+                        config=True,
+                        instance=False,
+                        run=False,
+                    )
+                )
+            elif active_tab == TAB_XP_ID:
+                return _convert_bool2classname_dict(
+                    dict(
+                        time_log_scale=False,
+                        metric=False,
+                        configs=False,
+                        instances=False,
+                        stat=False,
+                        q=False,
+                        transpose=False,
+                        clip=False,
+                        config=True,
+                        instance=True,
+                        run=True,
+                    )
+                )
+            elif active_tab == TAB_EMPTY_XPS_ID:
+                return _convert_bool2classname_dict(
+                    dict(
+                        time_log_scale=False,
+                        metric=False,
+                        configs=False,
+                        instances=False,
+                        stat=False,
+                        q=False,
+                        transpose=False,
+                        clip=False,
+                        config=False,
+                        instance=False,
+                        run=False,
+                    )
+                )
+            else:
+                return _convert_bool2classname_dict(
+                    dict(
+                        time_log_scale=True,
+                        metric=True,
+                        configs=True,
+                        instances=True,
+                        stat=True,
+                        q=True,
+                        transpose=True,
+                        clip=True,
+                        config=True,
+                        instance=True,
+                        run=False,
+                    )
+                )
+
+        # store callbacks for unit testing
+        self.update_filters = update_filters
+        self.update_xp_data = update_xp_data
+        self.update_run_options = update_run_options
+        self.update_graph_agg_metric = update_graph_agg_metric
+        self.update_graph_metric = update_graph_metric
+        self.update_config_display = update_config_display
+        self.update_graph_nb_solved_instances = update_graph_nb_solved_instances
+
+    def _replace_allinstances_alias(self, instances: list[str]) -> list[str]:
+        if ALL_INSTANCES in instances:
+            return self.instances
+        else:
+            return instances
+
+
+def _convert_bool2classname_dict(d: dict[str, bool]) -> dict[str, str]:
+    return {k: _convert_bool2classname(v) for k, v in d.items()}
+
+
+def _convert_bool2classname(v: bool) -> str:
+    return "d-block" if v else "d-none"

--- a/discrete_optimization/generic_tools/dashboard/plots.py
+++ b/discrete_optimization/generic_tools/dashboard/plots.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import pandas as pd
+
+try:
+    import plotly
+except ImportError:
+    plotly_available = False
+else:
+    plotly_available = True
+    import plotly.graph_objects as go
+
+
+logger = logging.getLogger(__name__)
+
+
+def create_graph_from_series_dict(
+    map_label2ser: dict[str, pd.Series],
+    with_time_log_scale: bool = False,
+    legend_title: str = "labels",
+    transpose: bool = False,
+) -> go.Figure:
+    fig = go.Figure()
+    x_label = ""
+    y_label = ""
+    for name, ser in map_label2ser.items():
+        ser = ser.replace([np.inf, -np.inf], np.nan).dropna()
+        if len(ser) < 2:
+            mode = "markers"
+        else:
+            mode = "lines"
+        if transpose:
+            y = ser.index
+            x = ser
+            y_label = ser.index.name
+            x_label = ser.name
+        else:
+            x = ser.index
+            y = ser
+            x_label = ser.index.name
+            y_label = ser.name
+        fig.add_trace(go.Scatter(x=x, y=y, name=name, mode=mode))
+
+    if len(map_label2ser) == 0:
+        fig.add_annotation(
+            text="NO DATA",
+            font=dict(size=20),
+            xref="paper",
+            yref="paper",
+            x=0.5,
+            y=0.5,
+            showarrow=False,
+        )
+    fig.update_layout(
+        xaxis=dict(title=dict(text=x_label)),
+        yaxis=dict(title=dict(text=y_label)),
+        legend=dict(title=dict(text=legend_title)),
+    )
+    if with_time_log_scale:
+        if transpose:
+            fig.update_yaxes(type="log")
+        else:
+            fig.update_xaxes(type="log")
+    return fig

--- a/discrete_optimization/generic_tools/dashboard/preprocess.py
+++ b/discrete_optimization/generic_tools/dashboard/preprocess.py
@@ -1,0 +1,315 @@
+from collections import defaultdict
+from collections.abc import Container, Iterable
+from copy import copy
+from typing import Any, Optional, Union
+
+import pandas as pd
+
+from discrete_optimization.generic_tools.dashboard.config import ConfigStore
+from discrete_optimization.generic_tools.do_solver import StatusSolver
+
+# metadata keys
+STATUS = "status"
+INSTANCE = "instance"
+CONFIG = "config"
+REASON = "reason"
+
+# data columns
+BOUND = "bound"
+OBJ = "obj"
+GAP = "gap"
+GAP_REL_OBJ = "gap_rel_obj"
+GAP_REL_BOUND = "gap_rel_bound"
+GAP_REL_MAX_OBJ_BOUND = "gap_rel_max_obj_bound"
+FIT = "fit"
+
+# available stats
+MEAN = "mean"
+MAX = "max"
+MIN = "min"
+MEDIAN = "median"
+QUANTILE = "quantile"
+map_stat_key2func = {
+    MEAN: pd.DataFrame.mean,
+    MAX: pd.DataFrame.max,
+    MIN: pd.DataFrame.min,
+    MEDIAN: pd.DataFrame.median,
+    QUANTILE: pd.DataFrame.quantile,
+}
+
+# new metadata keys for empty xps
+I_RUN_LABEL = "attempt"
+
+TIMEOUT_REASON = "Probably due to a timeout."
+
+
+def drop_empty_results(results: list[pd.DataFrame]) -> list[pd.DataFrame]:
+    return [df for df in results if len(df) > 0]
+
+
+def extract_empty_xps_metadata(results: list[pd.DataFrame]) -> pd.DataFrame:
+    empty_xps_attrs = [df.attrs for df in results if len(df) == 0]
+    metadata_df = pd.DataFrame(
+        empty_xps_attrs, columns=[CONFIG, INSTANCE, I_RUN_LABEL, STATUS, REASON]
+    )
+    metadata_df.loc[metadata_df.loc[:, REASON] == "", REASON] = TIMEOUT_REASON
+    metadata_df.loc[:, STATUS] = metadata_df.loc[:, STATUS].map(lambda st: st.value)
+    return metadata_df
+
+
+def normalize_results(results: list[pd.DataFrame], config_store: ConfigStore) -> None:
+    # add all configs beforehand to ensure name<->config bijection
+    for df in results:
+        config = df.attrs[CONFIG]
+        if isinstance(config, dict):
+            config_store.add(config)
+        elif not isinstance(config, str):
+            raise ValueError(
+                "For each result df, df.attrs['config'] must be either a dictionary "
+                "or a string representing its name."
+            )
+
+    # normalize each result one by one
+    for df in results:
+        normalize_df(df=df, config_store=config_store)
+
+    # compute an attempt number
+    n_runs_by_config_instance = defaultdict(lambda: 0)
+    for df in results:
+        attrs = df.attrs
+        key = attrs[CONFIG], attrs[INSTANCE]
+        attrs[I_RUN_LABEL] = n_runs_by_config_instance[key]
+        n_runs_by_config_instance[key] += 1
+
+
+def normalize_df(
+    df: pd.DataFrame, config_store: ConfigStore, timedelta_unit="s"
+) -> None:
+    normalize_metadata(df.attrs, config_store=config_store)
+    df.sort_index(inplace=True)
+    # -> timedeltaindex
+    if isinstance(df.index, pd.DatetimeIndex):
+        df.index = df.index - df.index[0]
+    elif not isinstance(df.index, pd.TimedeltaIndex):
+        df.index = pd.to_timedelta(df.index, unit=timedelta_unit)
+    # -> total_seconds
+    df.index = [t.total_seconds() for t in df.index.to_pytimedelta()]
+    df.index.name = "time (s)"
+    # drop columns full of NaNs
+    df.dropna(axis=1, how="all", inplace=True)
+    # no more columns => on vide la dataframe
+    if len(df.columns) == 0:
+        df.drop(df.index, inplace=True)
+
+
+def normalize_metadata(metadata: dict[str, Any], config_store: ConfigStore) -> None:
+    # status
+    if STATUS not in metadata:
+        metadata[STATUS] = StatusSolver.UNKNOWN
+    else:
+        if not isinstance(metadata[STATUS], StatusSolver):
+            metadata[STATUS] = StatusSolver(metadata[STATUS].upper())
+    # config -> config name
+    config = metadata[CONFIG]
+    if isinstance(config, dict):
+        config_name = config_store.get_name(config)
+    elif isinstance(config, str):
+        config_name = config
+    else:
+        raise ValueError(
+            "For each result df, df.attrs['config'] must be either a dictionary "
+            "or a string representing its name."
+        )
+    metadata[CONFIG] = config_name
+
+
+def compute_extra_metrics(results: list[pd.DataFrame]) -> None:
+    for df in results:
+        compute_extra_metrics_df(df)
+
+
+def compute_extra_metrics_df(df: pd.DataFrame) -> None:
+    # gap
+    if GAP not in df.columns:
+        if OBJ in df.columns and BOUND in df.columns:
+            df[GAP] = (df[OBJ] - df[BOUND]).abs()
+
+    # gap relative
+    if GAP in df.columns:
+        if GAP_REL_OBJ not in df.columns:
+            if OBJ in df.columns:
+                df[GAP_REL_OBJ] = df[GAP] / df[OBJ].abs()
+
+        if GAP_REL_BOUND not in df.columns:
+            if BOUND in df.columns:
+                df[GAP_REL_BOUND] = df[GAP] / df[BOUND].abs()
+
+        if GAP_REL_OBJ not in df.columns:
+            if OBJ in df.columns and BOUND in df.columns:
+                df[GAP_REL_MAX_OBJ_BOUND] = df[GAP] / df.loc[:, [OBJ, BOUND]].abs().max(
+                    axis=1
+                )
+
+
+def extract_instances(results) -> set[str]:
+    return {df.attrs[INSTANCE] for df in results}
+
+
+def extract_configs(results) -> set[str]:
+    return {df.attrs[CONFIG] for df in results}
+
+
+def extract_metrics(results) -> set[str]:
+    metrics = set()
+    for df in results:
+        metrics.update(df.columns)
+    return metrics
+
+
+def filter_results(
+    results: list[pd.DataFrame], configs: Container[str], instances: Container[str]
+) -> list[pd.DataFrame]:
+    return [
+        df
+        for df in results
+        if df.attrs[INSTANCE] in instances and df.attrs[CONFIG] in configs
+    ]
+
+
+def clip_df(df: pd.DataFrame, clip_value: float) -> pd.DataFrame:
+    # copy
+    df = copy(df)
+    df[df > clip_value] = pd.NA
+    df[df < -clip_value] = pd.NA
+    return df
+
+
+def clip_results(results: list[pd.DataFrame], clip_value: float) -> list[pd.DataFrame]:
+    return [clip_df(df, clip_value=clip_value) for df in results]
+
+
+def get_experiment_name(df: Union[pd.DataFrame, pd.Series], with_run_nb=True) -> str:
+    if with_run_nb:
+        return f"{df.attrs[CONFIG]} x {df.attrs[INSTANCE]} #{df.attrs[I_RUN_LABEL]}"
+    else:
+        return f"{df.attrs[CONFIG]} x {df.attrs[INSTANCE]}"
+
+
+def has_multiple_runs(results: list[pd.DataFrame]) -> bool:
+    return max(df.attrs[I_RUN_LABEL] for df in results) > 0
+
+
+def get_stat_name(stat: str, q: float) -> str:
+    if stat == QUANTILE:
+        return f"{stat}({q})"
+    else:
+        return stat
+
+
+def aggregate_results_config(results: list[pd.DataFrame], config: str) -> pd.DataFrame:
+    results_config = [df for df in results if df.attrs[CONFIG] == config]
+    instances_config = [
+        (df.attrs[INSTANCE], run) for run, df in enumerate(results_config)
+    ]
+    return (
+        pd.concat(
+            results_config,
+            axis=1,
+            join="outer",
+            keys=instances_config,
+            names=["instance", "run"],
+        )
+        .sort_index()  # increasing time
+        .ffill()  # replace nan by previous value (as instances do not share same timescale)
+        .stack(level=-1, future_stack=True)  # pre-stack to speed-up stat computation
+    )
+
+
+def aggregate_results_by_config(
+    results: list[pd.DataFrame], configs: Iterable[str]
+) -> dict[str, pd.DataFrame]:
+    return {
+        config: aggregate_results_config(results=results, config=config)
+        for config in configs
+    }
+
+
+def compute_stat_by_config(
+    results_by_config: dict[str, pd.DataFrame],
+    stat: str = MEAN,
+    q: float = 0.5,
+    instances: Optional[list[str]] = None,
+) -> dict[str, pd.DataFrame]:
+    return {
+        config: compute_stat_from_df_config(
+            df_config, stat=stat, q=q, instances=instances
+        )
+        for config, df_config in results_by_config.items()
+        if len(df_config) > 0
+    }
+
+
+def compute_stat_from_df_config(
+    df_config: pd.DataFrame,
+    stat: str = MEAN,
+    q: float = 0.5,
+    instances: Optional[list[str]] = None,
+) -> pd.DataFrame:
+    # filter instances to aggregate
+    if instances is not None:
+        # intersection with instances present in df_config (some could be missing for a given config)
+        df_config_instances = set(df_config.columns.get_level_values("instance"))
+        instances = [i for i in instances if i in df_config_instances]
+        # filter data according to instances
+        df_config = df_config.loc[:, instances]
+        # no remaining instances? => empty result
+        if len(df_config.columns) == 0:
+            empty_df = pd.DataFrame([])
+            empty_df.index.name = df_config.index.names[0]
+            empty_df.columns.name = df_config.index.names[1]
+            return empty_df
+    # function used to aggregate
+    stat_func = map_stat_key2func[stat]
+    if stat_func is pd.DataFrame.quantile:
+        kwargs = dict(q=q)
+    else:
+        kwargs = dict()
+    # aggregate
+    df_stat = stat_func(df_config.dropna(), axis=1, **kwargs).unstack()
+    return df_stat
+
+
+def extract_solvetimes_by_config(results: list[pd.DataFrame]) -> dict[str, list[float]]:
+    solvetimes_by_config = defaultdict(list)
+    for df in results:
+        if df.attrs[STATUS] == StatusSolver.OPTIMAL:
+            solvetime = df.index[-1]
+            config = df.attrs[CONFIG]
+            solvetimes_by_config[config].append(solvetime)
+    return solvetimes_by_config
+
+
+def convert_solvetimes2nbsolvedinstances(
+    solvetimes: list[float],
+    time_label: str = "time",
+    name: str = "nb of solved instances",
+) -> pd.Series:
+    ser = pd.Series(
+        {t: n for t, n in zip(sorted(solvetimes), range(1, len(solvetimes) + 1))},
+        name=name,
+    )
+    ser.index.name = time_label
+    return ser
+
+
+def extract_nbsolvedinstances_by_config(
+    results: list[pd.DataFrame],
+) -> dict[str, pd.Series]:
+    if len(results) == 0:
+        time_label = "time"
+    else:
+        time_label = results[0].index.name
+    return {
+        config: convert_solvetimes2nbsolvedinstances(solvetimes, time_label=time_label)
+        for config, solvetimes in extract_solvetimes_by_config(results=results).items()
+    }

--- a/discrete_optimization/generic_tools/dashboard/preprocess.py
+++ b/discrete_optimization/generic_tools/dashboard/preprocess.py
@@ -7,12 +7,12 @@ import pandas as pd
 
 from discrete_optimization.generic_tools.dashboard.config import ConfigStore
 from discrete_optimization.generic_tools.do_solver import StatusSolver
-
-# metadata keys
-STATUS = "status"
-INSTANCE = "instance"
-CONFIG = "config"
-REASON = "reason"
+from discrete_optimization.generic_tools.study.experiment import (
+    CONFIG,
+    INSTANCE,
+    REASON,
+    STATUS,
+)
 
 # data columns
 BOUND = "bound"

--- a/discrete_optimization/generic_tools/dashboard/preprocess.py
+++ b/discrete_optimization/generic_tools/dashboard/preprocess.py
@@ -151,15 +151,22 @@ def compute_extra_metrics_df(df: pd.DataFrame) -> None:
                 )
 
 
-def extract_instances(results) -> set[str]:
+def extract_instances(results: list[pd.DataFrame]) -> set[str]:
     return {df.attrs[INSTANCE] for df in results}
 
 
-def extract_configs(results) -> set[str]:
+def extract_configs(results: list[pd.DataFrame]) -> set[str]:
     return {df.attrs[CONFIG] for df in results}
 
 
-def extract_metrics(results) -> set[str]:
+def extract_nb_xps_by_config(results: list[pd.DataFrame]) -> dict[str, int]:
+    nb_xps_by_config = defaultdict(lambda: 0)
+    for df in results:
+        nb_xps_by_config[df.attrs[CONFIG]] += 1
+    return nb_xps_by_config
+
+
+def extract_metrics(results: list[pd.DataFrame]) -> set[str]:
     metrics = set()
     for df in results:
         metrics.update(df.columns)
@@ -296,8 +303,8 @@ def extract_solvetimes_by_config(results: list[pd.DataFrame]) -> dict[str, list[
 def convert_solvetimes2nbsolvedinstances(
     solvetimes: list[float],
     time_label: str = "time",
-    name: str = "nb of solved instances",
 ) -> pd.Series:
+    name = "nb of solved instances"
     ser = pd.Series(
         {t: n for t, n in zip(sorted(solvetimes), range(1, len(solvetimes) + 1))},
         name=name,
@@ -317,3 +324,68 @@ def extract_nbsolvedinstances_by_config(
         config: convert_solvetimes2nbsolvedinstances(solvetimes, time_label=time_label)
         for config, solvetimes in extract_solvetimes_by_config(results=results).items()
     }
+
+
+def convert_nb2percentage_solvedinstances(
+    ser: pd.Series,
+    n_xps: int,
+) -> pd.Series:
+    ser = ser * 100 / n_xps
+    ser.name = "% of solved instances"
+    return ser
+
+
+def convert_nb2percentage_solvedinstances_by_config(
+    nbsolvedinstances_by_config: dict[str, pd.Series],
+    n_xps_by_config: dict[str, int],
+) -> dict[str, pd.Series]:
+    return {
+        config: convert_nb2percentage_solvedinstances(
+            ser, n_xps=n_xps_by_config[config]
+        )
+        for config, ser in nbsolvedinstances_by_config.items()
+    }
+
+
+def construct_summary_nbsolved_instances(
+    nbsolvedinstances_by_config: dict[str, pd.Series],
+    nb_xps_by_config: dict[str, int],
+    configs: Optional[Container[str]] = None,
+) -> pd.DataFrame:
+    if configs is None:
+        configs = set(nb_xps_by_config)
+    data = []
+    for config in configs:
+        if config in nbsolvedinstances_by_config:
+            nbsolvedinstances = nbsolvedinstances_by_config[config].iloc[-1]
+        else:
+            nbsolvedinstances = 0
+        data.append((config, nbsolvedinstances, nb_xps_by_config[config]))
+
+    return pd.DataFrame(
+        data=data,
+        columns=[
+            "config",
+            "# solved xps",
+            "# xps",
+        ],
+    )
+
+
+def construct_summary_metric_agg(
+    stat_by_config: dict[str, pd.DataFrame],
+    configs: Optional[list[str]] = None,
+) -> pd.DataFrame:
+    if configs is None:
+        configs = list(stat_by_config)
+    index_config = pd.Index(configs, name="config")
+    df_stat = next(iter(stat_by_config.values()))
+    metrics = list(df_stat.columns)
+    data = (
+        stat_by_config[config].iloc[-1, :]
+        if config in stat_by_config and len(stat_by_config[config]) > 0
+        else pd.Series(index=metrics)
+        for config in configs
+    )
+    df_summary = pd.DataFrame(data, index=index_config, columns=metrics).reset_index()
+    return df_summary

--- a/discrete_optimization/generic_tools/dashboard/preprocess.py
+++ b/discrete_optimization/generic_tools/dashboard/preprocess.py
@@ -195,6 +195,10 @@ def get_experiment_name(df: Union[pd.DataFrame, pd.Series], with_run_nb=True) ->
         return f"{df.attrs[CONFIG]} x {df.attrs[INSTANCE]}"
 
 
+def get_status_str(df: pd.DataFrame) -> str:
+    return df.attrs[STATUS].value
+
+
 def has_multiple_runs(results: list[pd.DataFrame]) -> bool:
     return max(df.attrs[I_RUN_LABEL] for df in results) > 0
 

--- a/discrete_optimization/generic_tools/do_solver.py
+++ b/discrete_optimization/generic_tools/do_solver.py
@@ -34,6 +34,7 @@ class StatusSolver(Enum):
     UNSATISFIABLE = "UNSATISFIABLE"
     OPTIMAL = "OPTIMAL"
     UNKNOWN = "UNKNOWN"
+    ERROR = "FAILED"
 
 
 class SolverDO(Hyperparametrizable, ABC):

--- a/discrete_optimization/generic_tools/lp_tools.py
+++ b/discrete_optimization/generic_tools/lp_tools.py
@@ -699,8 +699,8 @@ map_mathopt_status_to_do_status: dict[mathopt.TerminationReason, StatusSolver] =
     mathopt.TerminationReason.FEASIBLE: StatusSolver.SATISFIED,
     mathopt.TerminationReason.NO_SOLUTION_FOUND: StatusSolver.UNSATISFIABLE,
     mathopt.TerminationReason.IMPRECISE: StatusSolver.UNKNOWN,
-    mathopt.TerminationReason.NUMERICAL_ERROR: StatusSolver.UNKNOWN,
-    mathopt.TerminationReason.OTHER_ERROR: StatusSolver.UNKNOWN,
+    mathopt.TerminationReason.NUMERICAL_ERROR: StatusSolver.ERROR,
+    mathopt.TerminationReason.OTHER_ERROR: StatusSolver.ERROR,
 }
 
 

--- a/discrete_optimization/generic_tools/study/__init__.py
+++ b/discrete_optimization/generic_tools/study/__init__.py
@@ -1,0 +1,2 @@
+from .database import Hdf5Database
+from .experiment import Experiment, SolverConfig

--- a/discrete_optimization/generic_tools/study/database.py
+++ b/discrete_optimization/generic_tools/study/database.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from types import TracebackType
+from typing import TYPE_CHECKING, Optional
+
+import pandas as pd
+
+from discrete_optimization.generic_tools.do_solver import StatusSolver
+from discrete_optimization.generic_tools.study.experiment import (
+    CONFIG_PREFIX,
+    ID,
+    INSTANCE,
+    METRICS,
+    NAME,
+    PARAMETERS,
+    REASON,
+    SOLVER,
+    STATUS,
+    Experiment,
+    SolverJsonableConfig,
+)
+
+if TYPE_CHECKING:
+    from pandas._typing import Self
+
+logger = logging.getLogger(__name__)
+
+
+class Database(ABC):
+    """Base class for database storing experiments.
+
+    By default, we assume a database is associated with a given study.
+    But it could be implemented so that it can store several studies at once.
+
+    d-o experiments:
+    - instance => string representing problem used
+    - config:
+       - name: can be empty, but useful to have a simple name for the config
+       - solver: e.g. class name
+       - params: hyperparameters used (nested dict whose leaves should be hashable, and preferably jsonable)
+    - status: status of tge solver at then of the solve process
+    - metrics: timeseries of objective, bound, ...
+
+
+    """
+
+    @abstractmethod
+    def get_new_experiment_id(self) -> int:
+        ...
+
+    @abstractmethod
+    def store(self, xp: Experiment) -> None:
+        """Store the experiment in the database.
+
+        Could store a complete experiment.
+        Depending on implementations, could also support storing a partial experiment,
+        and then overwriting with a complete experiment by re-calling `store` on an experiment
+        with same id and more data.
+        """
+        ...
+
+    @abstractmethod
+    def load(self) -> list[Experiment]:
+        """Load all experiments of the study."""
+        ...
+
+    def load_results(self) -> list[pd.DataFrame]:
+        """Load all experiments as time-indexes dataframes with metadata in `attrs` attribute."""
+        return [xp.to_df() for xp in self.load()]
+
+    def close(self) -> None:
+        """Close the database."""
+        ...
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.close()
+
+
+# database keys
+METADATA = "metadata"
+
+
+COL_STR_MAXSIZE = {
+    REASON: 512,
+    INSTANCE: 32,
+    STATUS: max(len(s.value) for s in StatusSolver),
+    CONFIG_PREFIX + SOLVER: 52,
+    CONFIG_PREFIX + NAME: 32,
+    CONFIG_PREFIX + PARAMETERS: 1024,
+}
+
+PARAMETERS_STR_MAX_SIZE = 1024
+REASON_MAX_SIZE = 512
+
+
+def _get_metrics_key(xp_id: int) -> str:
+    return f"{METRICS}/{xp_id}"
+
+
+class Hdf5Database(Database):
+    """Database based on hdf5 format."""
+
+    def __init__(self, filepath: str):
+        self.hdfstore = pd.HDFStore(filepath)
+        if ID not in self.hdfstore:
+            self.hdfstore[ID] = pd.Series([-1])
+
+    def close(self) -> None:
+        self.hdfstore.close()
+
+    def get_new_experiment_id(self) -> int:
+        current_id = int(self.hdfstore[ID].iloc[-1])
+        new_id = current_id + 1
+        self.hdfstore[ID] = pd.Series([new_id])
+        return new_id
+
+    def store(self, xp: Experiment) -> None:
+        self.store_metadata(xp)
+        self.store_metrics(xp)
+
+    def store_metadata(self, xp: Experiment) -> None:
+        self.hdfstore.append(
+            METADATA,
+            pd.DataFrame.from_records([xp.get_metadata_as_a_record()]),
+            min_itemsize=COL_STR_MAXSIZE,
+        )
+
+    def store_metrics(self, xp: Experiment) -> None:
+        self.hdfstore.put(_get_metrics_key(xp.xp_id), xp.metrics)
+
+    def load(self) -> list[Experiment]:
+        df_metadata: pd.DataFrame = self.hdfstore[METADATA]
+        xps: list[Experiment] = []
+        for row in df_metadata.itertuples(index=False):
+            record = row._asdict()
+            xp_id = record[ID]
+            config = SolverJsonableConfig.from_xp_metadata_record(record)
+            try:
+                metrics = self.hdfstore[_get_metrics_key(xp_id)]
+            except KeyError:
+                metrics = pd.DataFrame()
+                logger.warning(
+                    f"Missing metrics for xp {xp_id}: config {config.name}, instance {record[INSTANCE]}"
+                )
+            xps.append(
+                Experiment(
+                    xp_id=xp_id,
+                    instance=record[INSTANCE],
+                    status=record[STATUS],
+                    metrics=metrics,
+                    config=config,
+                    reason=record[REASON],
+                )
+            )
+        return xps

--- a/discrete_optimization/generic_tools/study/experiment.py
+++ b/discrete_optimization/generic_tools/study/experiment.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Hashable
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Optional, Union
+
+import pandas as pd
+
+from discrete_optimization.generic_tools.do_solver import SolverDO, StatusSolver
+
+# keys
+ID = "id"
+SOLVER = "solver"
+PARAMETERS = "parameters"
+NAME = "name"
+STATUS = "status"
+INSTANCE = "instance"
+METRICS = "metrics"
+CONFIG_PREFIX = "config_"
+REASON = "reason"
+CONFIG = "config"
+
+# Type alias
+ConfigDict = dict[str, Union["ConfigDict", Hashable]]
+
+
+@dataclass
+class SolverConfig:
+    cls: type[SolverDO]
+    kwargs: dict[str, Any]
+
+
+@dataclass
+class SolverJsonableConfig:
+    """Config representing solver used with its tuning."""
+
+    solver: str
+    parameters: ConfigDict
+    name: Optional[str] = None
+
+    def get_json_parameters(self) -> str:
+        """Jsonify the config parameters attribute."""
+        return json.dumps(self.parameters, cls=DoJSONEncoder)
+
+    def get_record(self) -> dict[str, Optional[str]]:
+        return {
+            SOLVER: self.solver,
+            PARAMETERS: self.get_json_parameters(),
+            NAME: self.name,
+        }
+
+    def as_nested_dict(self) -> ConfigDict:
+        return {
+            SOLVER: self.solver,
+            PARAMETERS: self.parameters,
+            NAME: self.name,
+        }
+
+    @classmethod
+    def from_xp_metadata_record(cls, record):
+        return cls(
+            solver=record[CONFIG_PREFIX + SOLVER],
+            parameters=json.loads(record[CONFIG_PREFIX + PARAMETERS]),
+            name=record[CONFIG_PREFIX + NAME],
+        )
+
+    @classmethod
+    def from_record(cls, record):
+        return cls(
+            solver=record[SOLVER],
+            parameters=json.loads(record[PARAMETERS]),
+            name=record[NAME],
+        )
+
+    @classmethod
+    def from_solver_config(cls, config: SolverConfig, name: Optional[str] = None):
+        return cls(name=name, solver=config.cls.__name__, parameters=config.kwargs)
+
+
+@dataclass
+class Experiment:
+    """Experiment of a d-o study."""
+
+    xp_id: int
+    instance: str
+    status: str
+    config: SolverJsonableConfig
+    metrics: pd.DataFrame  # time-indexed dataframe, each column being a tracked metric
+    reason: str = ""
+
+    def get_metadata_as_a_record(self) -> dict[str, Any]:
+        return {
+            ID: self.xp_id,
+            INSTANCE: self.instance,
+            **{CONFIG_PREFIX + k: v for k, v in self.config.get_record().items()},
+            STATUS: self.status,
+            REASON: self.reason,
+        }
+
+    def get_metadata_as_nested_dict(self) -> ConfigDict:
+        return {
+            ID: self.xp_id,
+            INSTANCE: self.instance,
+            CONFIG: self.config.as_nested_dict(),
+            STATUS: self.status,
+            REASON: self.reason,
+        }
+
+    def to_df(self):
+        """Convert to a dataframe (metrics) with metadata store in `attrs` attribute."""
+        metadata = self.get_metadata_as_nested_dict()
+        df = pd.DataFrame(self.metrics)
+        df.attrs = metadata
+        return df
+
+    @classmethod
+    def from_solver_config(
+        cls,
+        xp_id: int,
+        instance: str,
+        status: Union[str, StatusSolver],
+        solver_config: SolverConfig,
+        metrics: pd.DataFrame,
+        config_name: Optional[str] = None,
+        reason: str = "",
+    ):
+        if isinstance(status, StatusSolver):
+            status_str = status.value
+        else:
+            status_str = status
+        return cls(
+            xp_id=xp_id,
+            instance=instance,
+            status=status_str,
+            config=SolverJsonableConfig.from_solver_config(
+                solver_config, name=config_name
+            ),
+            metrics=metrics,
+            reason=reason,
+        )
+
+
+@dataclass
+class Study:
+    name: str
+    instances: list[str]
+    solver_configs: list[SolverConfig]
+
+
+class DoJSONEncoder(json.JSONEncoder):
+    def default(self, o):
+        if hasattr(o, "to_json"):
+            return o.to_json()
+        elif isinstance(o, Enum):
+            return o.value
+        elif hasattr(o, "__dict__"):
+            return o.__dict__
+        return super().default(o)

--- a/examples/dashboard/retrieve_fake_data.py
+++ b/examples/dashboard/retrieve_fake_data.py
@@ -1,0 +1,82 @@
+import pandas as pd
+
+
+def load_results() -> list[pd.DataFrame]:
+    results = []
+
+    # In[39]:
+
+    metadata = dict(
+        instance="p01",
+        config=dict(
+            solver="CpSat",
+            params=dict(timeout=1000, parallel=True, free_search=False),
+            name="cpsat-0",
+        ),
+        status="optimal",
+    )
+    timestamps = pd.DatetimeIndex(
+        [
+            "2018-01-01 00:00:00",
+            "2018-01-01 00:00:02",
+            "2018-01-01 00:00:01",
+            "2018-01-01 00:00:03",
+            "2018-01-01 00:00:04",
+        ]
+    )
+    data = dict(obj=[10, 7, 8, 6.5, 6.2], bound=[0, 4, 2, 6, 6.1])
+    df = pd.DataFrame(data, index=timestamps)
+    df.attrs = metadata  # spectial attribute to store metadata
+    results.append(df)
+
+    # In[42]:
+
+    metadata = dict(
+        instance="p01",
+        config=dict(
+            solver="gurobi",
+            params=dict(timeout=1000, parallel=True, free_search=True),
+            name="gurobi-0",
+        ),
+        status="optimal",
+    )
+    timestamps = pd.to_timedelta(range(4), unit="s")
+    data = dict(obj=[9.5, 8.8, 7.5, 6.5], bound=[0, 2, 4, 6])
+    df = pd.DataFrame(data, index=timestamps)
+    df.attrs = metadata  # spectial attribute to store metadata
+    results.append(df)
+
+    # In[43]:
+
+    metadata = dict(
+        instance="p01",
+        config=dict(
+            solver="CpSat",
+            params=dict(timeout=1000, parallel=True, free_search=True),
+            name="cpsat-1",
+        ),
+        status="unknown",
+    )
+    timestamps = pd.to_timedelta(range(0, 4, 2), unit="s")
+    data = dict(obj=[10, 7.5], bound=[0, 3])
+    df = pd.DataFrame(data, index=timestamps)
+    df.attrs = metadata  # spectial attribute to store metadata
+    results.append(df)
+
+    # In[44]:
+
+    metadata = dict(
+        instance="p02",
+        config=dict(
+            solver="gurobi",
+            params=dict(timeout=1000, parallel=True, free_search=True),
+        ),
+        status="optimal",
+    )
+    timestamps = pd.to_timedelta(range(0, 4, 2), unit="s")
+    data = dict(obj=[12, 5], bound=[0, 3])
+    df = pd.DataFrame(data, index=timestamps)
+    df.attrs = metadata  # spectial attribute to store metadata
+    results.append(df)
+
+    return results

--- a/examples/dashboard/run_coloring_study.py
+++ b/examples/dashboard/run_coloring_study.py
@@ -1,0 +1,113 @@
+import logging
+import os
+
+import pandas as pd
+
+from discrete_optimization.coloring.parser import get_data_available, parse_file
+from discrete_optimization.coloring.solvers.cpsat import (
+    CpSatColoringSolver,
+    ModelingCpSat,
+)
+from discrete_optimization.coloring.solvers.lp import (
+    GurobiColoringSolver,
+    MathOptColoringSolver,
+)
+from discrete_optimization.generic_tools.callbacks.loggers import NbIterationTracker
+from discrete_optimization.generic_tools.callbacks.stats_retrievers import (
+    StatsWithBoundsCallback,
+)
+from discrete_optimization.generic_tools.cp_tools import ParametersCp
+from discrete_optimization.generic_tools.do_solver import StatusSolver
+from discrete_optimization.generic_tools.study import (
+    Experiment,
+    Hdf5Database,
+    SolverConfig,
+)
+
+logging.basicConfig(level=logging.INFO)
+
+study_name = "Coloring-Study-0"
+overwrite = True  # do we overwrite previous study with same name or not? if False, we possibly add duplicates
+instances = ["gc_50_3", "gc_50_1"]
+solver_configs = {
+    "cpsat-integer": SolverConfig(
+        cls=CpSatColoringSolver,
+        kwargs=dict(
+            parameters_cp=ParametersCp.default_cpsat(),
+            modeling=ModelingCpSat.INTEGER,
+            do_warmstart=False,
+            value_sequence_chain=False,
+            used_variable=True,
+            symmetry_on_used=True,
+        ),
+    ),
+    "cpsat-binary": SolverConfig(
+        cls=CpSatColoringSolver,
+        kwargs=dict(
+            parameters_cp=ParametersCp.default_cpsat(),
+            modeling=ModelingCpSat.BINARY,
+            do_warmstart=False,
+            value_sequence_chain=False,
+            used_variable=True,
+            symmetry_on_used=True,
+        ),
+    ),
+    "gurobi": SolverConfig(cls=GurobiColoringSolver, kwargs=dict()),
+    "mathopt": SolverConfig(cls=MathOptColoringSolver, kwargs=dict()),
+}
+
+database_filepath = f"{study_name}.h5"
+if overwrite:
+    try:
+        os.remove(database_filepath)
+    except FileNotFoundError:
+        pass
+with Hdf5Database(
+    database_filepath
+) as database:  # ensure closing the database at the end of computation (even if error)
+
+    # loop over instances x configs
+    for instance in instances:
+        for config_name, solver_config in solver_configs.items():
+
+            logging.info(f"###### Instance {instance}, config {config_name} ######\n\n")
+
+            try:
+                # init problem
+                file = [f for f in get_data_available() if instance in f][0]
+                color_problem = parse_file(file)
+                # init solver
+                stats_cb = StatsWithBoundsCallback()
+                solver = solver_config.cls(color_problem, **solver_config.kwargs)
+                solver.init_model(**solver_config.kwargs)
+                # solve
+                result_store = solver.solve(
+                    callbacks=[
+                        stats_cb,
+                        NbIterationTracker(step_verbosity_level=logging.INFO),
+                    ],
+                    **solver_config.kwargs,
+                )
+            except Exception as e:
+                # failed experiment
+                metrics = pd.DataFrame([])
+                status = StatusSolver.ERROR
+                reason = f"{type(e).__name__}: {str(e)}"
+            else:
+                # get metrics and solver status
+                status = solver.status_solver
+                metrics = stats_cb.get_df_metrics()
+                reason = ""
+
+            # store corresponding experiment
+            xp_id = database.get_new_experiment_id()
+            xp = Experiment.from_solver_config(
+                xp_id=xp_id,
+                instance=instance,
+                config_name=config_name,
+                solver_config=solver_config,
+                metrics=metrics,
+                status=status,
+                reason=reason,
+            )
+            database.store(xp)

--- a/examples/dashboard/run_dashboard_coloring_study.py
+++ b/examples/dashboard/run_dashboard_coloring_study.py
@@ -1,0 +1,13 @@
+from discrete_optimization.generic_tools.dashboard import Dashboard
+from discrete_optimization.generic_tools.study import Hdf5Database
+
+study_name = "Coloring-Study-0"
+
+# retrieve data
+with Hdf5Database(f"{study_name}.h5") as database:
+    results = database.load_results()
+
+
+# launch dashboard with this data
+app = Dashboard(results=results)
+app.run()

--- a/examples/dashboard/run_dashboard_fake_data.py
+++ b/examples/dashboard/run_dashboard_fake_data.py
@@ -1,0 +1,10 @@
+from retrieve_fake_data import load_results
+
+from discrete_optimization.generic_tools.dashboard.dashboard import Dashboard
+
+# retrieve data
+results = load_results()
+
+# launch dashboard with this data
+app = Dashboard(results=results)
+app.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,8 @@ dependencies = [
     "numpy>=1.21",
     "clingo>=5.6",
     "didppy>=0.8.0",
-    "setuptools"
+    "setuptools",
+    "pandas>=2"
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ quantum = [
     "qiskit-ibm-runtime>=0.24"
 ]
 toulbar = ["pytoulbar2>=0.0.0.4"]
-dashboard = ["dash", "plotly", "dash_bootstrap_components"]
+dashboard = ["dash", "plotly", "dash_bootstrap_components", "pandas[hdf5]"]
 
 [project.urls]
 documentation = "https://airbus.github.io/discrete-optimization"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ quantum = [
     "qiskit-ibm-runtime>=0.24"
 ]
 toulbar = ["pytoulbar2>=0.0.0.4"]
+dashboard = ["dash", "plotly", "dash_bootstrap_components"]
 
 [project.urls]
 documentation = "https://airbus.github.io/discrete-optimization"

--- a/tests/generic_tools/dashboard/test_dashboard.py
+++ b/tests/generic_tools/dashboard/test_dashboard.py
@@ -1,0 +1,355 @@
+import logging
+import os
+from typing import Any, Optional
+
+import pandas as pd
+import pytest
+from pytest import fixture
+
+from discrete_optimization.coloring.parser import get_data_available, parse_file
+from discrete_optimization.coloring.solvers import ColoringSolver
+from discrete_optimization.coloring.solvers.cpsat import (
+    CpSatColoringSolver,
+    ModelingCpSat,
+)
+from discrete_optimization.coloring.solvers.lp import MathOptColoringSolver
+from discrete_optimization.generic_tools.callbacks.callback import (
+    Callback,
+    CallbackList,
+)
+from discrete_optimization.generic_tools.callbacks.loggers import NbIterationTracker
+from discrete_optimization.generic_tools.callbacks.stats_retrievers import (
+    StatsWithBoundsCallback,
+)
+from discrete_optimization.generic_tools.cp_tools import ParametersCp
+from discrete_optimization.generic_tools.dashboard import Dashboard
+from discrete_optimization.generic_tools.dashboard.dashboard import (
+    TIME_LOGSCALE_KEY,
+    TRANSPOSE_KEY,
+)
+from discrete_optimization.generic_tools.do_solver import (
+    BoundsProviderMixin,
+    StatusSolver,
+)
+from discrete_optimization.generic_tools.result_storage.result_storage import (
+    ResultStorage,
+)
+from discrete_optimization.generic_tools.study import (
+    Experiment,
+    Hdf5Database,
+    SolverConfig,
+)
+
+
+class FakeFailingSolver(ColoringSolver):
+    def solve(
+        self, callbacks: Optional[list[Callback]] = None, **kwargs: Any
+    ) -> ResultStorage:
+        raise RuntimeError("This fake solver is failing!")
+
+
+class FakeTimeoutSolver(BoundsProviderMixin, ColoringSolver):
+    def solve(
+        self, callbacks: Optional[list[Callback]] = None, **kwargs: Any
+    ) -> ResultStorage:
+        callbacks_list = CallbackList(callbacks=callbacks)
+        callbacks_list.on_solve_start(solver=self)
+
+        res = self.create_result_storage()  # empty sols
+        ...  # timeout
+
+        callbacks_list.on_solve_end(solver=self, res=res)
+        return res
+
+    def get_current_best_internal_objective_bound(self) -> Optional[float]:
+        return None
+
+    def get_current_best_internal_objective_value(self) -> Optional[float]:
+        return None
+
+
+def run_study(study_name):
+    instances = ["gc_50_3", "gc_50_1", "gc_50_3"]  # test duplicates
+    solver_configs = {
+        "cpsat-integer": SolverConfig(
+            cls=CpSatColoringSolver,
+            kwargs=dict(
+                parameters_cp=ParametersCp.default_cpsat(),
+                modeling=ModelingCpSat.INTEGER,
+                do_warmstart=False,
+                value_sequence_chain=False,
+                used_variable=True,
+                symmetry_on_used=True,
+            ),
+        ),
+        "cpsat-binary": SolverConfig(
+            cls=CpSatColoringSolver,
+            kwargs=dict(
+                parameters_cp=ParametersCp.default_cpsat(),
+                modeling=ModelingCpSat.BINARY,
+                do_warmstart=False,
+                value_sequence_chain=False,
+                used_variable=True,
+                symmetry_on_used=True,
+            ),
+        ),
+        "fake": SolverConfig(cls=FakeFailingSolver, kwargs=dict()),
+        "mathopt": SolverConfig(cls=MathOptColoringSolver, kwargs=dict()),
+        "timeout": SolverConfig(cls=FakeTimeoutSolver, kwargs=dict()),
+    }
+    database_filepath = f"{study_name}.h5"
+    try:
+        os.remove(database_filepath)
+    except FileNotFoundError:
+        pass
+    with Hdf5Database(
+        database_filepath
+    ) as database:  # ensure closing the database at the end of computation (even if error)
+
+        # loop over instances x configs
+        for instance in instances:
+            for config_name, solver_config in solver_configs.items():
+
+                logging.info(
+                    f"###### Instance {instance}, config {config_name} ######\n\n"
+                )
+
+                try:
+                    # init problem
+                    file = [f for f in get_data_available() if instance in f][0]
+                    color_problem = parse_file(file)
+                    # init solver
+                    stats_cb = StatsWithBoundsCallback()
+                    solver = solver_config.cls(color_problem, **solver_config.kwargs)
+                    solver.init_model(**solver_config.kwargs)
+                    # solve
+                    result_store = solver.solve(
+                        callbacks=[
+                            stats_cb,
+                            NbIterationTracker(step_verbosity_level=logging.INFO),
+                        ],
+                        **solver_config.kwargs,
+                    )
+                except Exception as e:
+                    # failed experiment
+                    metrics = pd.DataFrame([])
+                    status = StatusSolver.ERROR
+                    reason = f"{type(e).__name__}: {str(e)}"
+                else:
+                    # get metrics and solver status
+                    status = solver.status_solver
+                    metrics = stats_cb.get_df_metrics()
+                    reason = ""
+
+                # store corresponding experiment
+                xp_id = database.get_new_experiment_id()
+                xp = Experiment.from_solver_config(
+                    xp_id=xp_id,
+                    instance=instance,
+                    config_name=config_name,
+                    solver_config=solver_config,
+                    metrics=metrics,
+                    status=status,
+                    reason=reason,
+                )
+                database.store(xp)
+
+
+@fixture(scope="module")
+def study_name():
+    # create and run experiments, and fill a database with it
+    study_name = "Coloring-Test-Study"
+    run_study(study_name=study_name)
+    return study_name
+
+
+@fixture
+def study_results(study_name):
+    # retrieve data
+    with Hdf5Database(f"{study_name}.h5") as database:
+        results = database.load_results()
+
+    return results
+
+
+@fixture
+def app(study_results):
+    return Dashboard(results=study_results)
+
+
+def test_init_app(app):
+    assert len(app.results) == 9
+    assert len(app.full_results) == 15
+
+
+def test_update_config_display_ok(app):
+    string = app.update_config_display(config_name="cpsat-binary")
+    assert '"solver": "CpSatColoringSolver"' in string
+    assert '"parameters_cp": {' in string
+    assert '"multiprocess": true,' in string
+
+
+def test_update_config_display_nok(app):
+    string = app.update_config_display(config_name="toto-binary")
+    assert "NOT_FOUND" in string
+
+
+@pytest.mark.parametrize(
+    "configs, instances, metric, time_log_scale, expected_n_traces, attempt_in_legend",
+    [
+        (
+            ["cpsat-binary", "cpsat-integer", "fake", "mathopt", "timeout"],
+            ["@all"],
+            "fit",
+            [],
+            9,
+            True,
+        ),
+        (["cpsat-binary"], ["gc_50_1"], "gap", [], 1, False),
+    ],
+)
+def test_update_graph_metric(
+    app,
+    configs,
+    instances,
+    metric,
+    time_log_scale,
+    expected_n_traces,
+    attempt_in_legend,
+):
+    plot = app.update_graph_metric(
+        configs=configs,
+        instances=instances,
+        metric=metric,
+        time_log_scale=time_log_scale,
+        clip_value=1e50,
+    )
+    assert len(plot.data) == expected_n_traces
+    assert ("#" in plot.data[0].name) is attempt_in_legend
+
+
+@pytest.mark.parametrize(
+    "configs, instances, metric, stat, time_log_scale, expected_n_traces, nodata",
+    [
+        (
+            ["cpsat-binary", "cpsat-integer", "fake", "mathopt", "timeout"],
+            ["@all"],
+            "fit",
+            "mean",
+            [],
+            3,
+            False,
+        ),
+        (["cpsat-binary"], ["gc_50_3"], "gap", "quantile", [], 1, False),
+        (["cpsat-binary"], [], "gap", "quantile", [], 0, True),
+    ],
+)
+def test_update_graph_agg_metric(
+    app, configs, instances, metric, stat, time_log_scale, expected_n_traces, nodata
+):
+    plot = app.update_graph_agg_metric(
+        configs=configs,
+        instances=instances,
+        metric=metric,
+        stat=stat,
+        q=0.5,
+        time_log_scale=time_log_scale,
+        clip_value=1e50,
+    )
+    assert len(plot.data) == expected_n_traces
+    if nodata:
+        assert len(plot.layout.annotations) == 1
+        assert plot.layout.annotations[0].text == "NO DATA"
+    else:
+        assert len(plot.layout.annotations) == 0
+
+
+@pytest.mark.parametrize(
+    "time_log_scale",
+    [[TIME_LOGSCALE_KEY], []],
+)
+@pytest.mark.parametrize(
+    "transpose_value",
+    [[TRANSPOSE_KEY], []],
+)
+def test_update_graph_nb_solved_instances(app, time_log_scale, transpose_value):
+    configs = ["mathopt", "cpsat-integer", "timeout"]
+    expected_n_traces = 2
+    plot = app.update_graph_nb_solved_instances(
+        configs=configs, time_log_scale=time_log_scale, transpose_value=transpose_value
+    )
+    assert len(plot.data) == expected_n_traces
+    if TRANSPOSE_KEY in transpose_value:
+        assert plot.layout.xaxis.title.text == "nb of solved instances"
+        assert plot.layout.yaxis.title.text == "time (s)"
+        time_axes = next(plot.select_yaxes())
+    else:
+        assert plot.layout.yaxis.title.text == "nb of solved instances"
+        assert plot.layout.xaxis.title.text == "time (s)"
+        time_axes = next(plot.select_xaxes())
+
+    if TIME_LOGSCALE_KEY in time_log_scale:
+        assert time_axes.type == "log"
+    else:
+        assert time_axes.type is None
+
+
+@pytest.mark.parametrize(
+    "instance, nb_runs",
+    [
+        (
+            "gc_50_1",
+            1,
+        ),
+        (
+            "gc_50_3",
+            2,
+        ),
+    ],
+)
+def test_update_run_options(app, instance, nb_runs):
+    config = "cpsat-binary"
+    output = app.update_run_options(
+        config=config,
+        instance=instance,
+    )
+    assert len(output["options"]) == nb_runs
+
+
+@pytest.mark.parametrize(
+    "config, instance, i_run, nodata",
+    [
+        ("cpsat-binary", "gc_50_1", 0, False),
+        ("cpsat-binary", "gc_50_3", 1, False),
+        (
+            "fake",
+            "gc_50_1",
+            0,
+            True,
+        ),
+        (
+            "timeout",
+            "gc_50_1",
+            0,
+            True,
+        ),
+    ],
+)
+def test_update_xp_data(app, config, instance, i_run, nodata):
+    output = app.update_xp_data(config=config, instance=instance, run=i_run)
+    if nodata:
+        assert len(output["data"]) == 0
+        assert output["nodata"] == "d-block"
+    else:
+        assert len(output["data"]) > 0
+        assert output["nodata"] == "d-none"
+
+
+def test_empty_xps(app):
+    df = app.empty_xps_metadata
+    assert len(df) == 6
+    assert sum(df["status"] == "FAILED") == 3
+    assert sum(df["status"] == "UNKNOWN") == 3
+    assert "timeout" in df.loc[df["status"] == "UNKNOWN", "reason"].iloc[0]
+    assert "fake solver" in df.loc[df["status"] == "FAILED", "reason"].iloc[0]
+    assert "RuntimeError" in df.loc[df["status"] == "FAILED", "reason"].iloc[0]

--- a/tests/generic_tools/dashboard/test_dashboard.py
+++ b/tests/generic_tools/dashboard/test_dashboard.py
@@ -317,25 +317,15 @@ def test_update_run_options(app, instance, nb_runs):
 
 
 @pytest.mark.parametrize(
-    "config, instance, i_run, nodata",
+    "config, instance, i_run, nodata, status",
     [
-        ("cpsat-binary", "gc_50_1", 0, False),
-        ("cpsat-binary", "gc_50_3", 1, False),
-        (
-            "fake",
-            "gc_50_1",
-            0,
-            True,
-        ),
-        (
-            "timeout",
-            "gc_50_1",
-            0,
-            True,
-        ),
+        ("cpsat-binary", "gc_50_1", 0, False, StatusSolver.OPTIMAL),
+        ("cpsat-binary", "gc_50_3", 1, False, StatusSolver.OPTIMAL),
+        ("fake", "gc_50_1", 0, True, StatusSolver.ERROR),
+        ("timeout", "gc_50_1", 0, True, StatusSolver.UNKNOWN),
     ],
 )
-def test_update_xp_data(app, config, instance, i_run, nodata):
+def test_update_xp_data(app, config, instance, i_run, nodata, status):
     output = app.update_xp_data(config=config, instance=instance, run=i_run)
     if nodata:
         assert len(output["data"]) == 0
@@ -343,6 +333,7 @@ def test_update_xp_data(app, config, instance, i_run, nodata):
     else:
         assert len(output["data"]) > 0
         assert output["nodata"] == "d-none"
+    assert status.value in output["status"]
 
 
 def test_empty_xps(app):


### PR DESCRIPTION
- Database (hdf5 store) to store 
     - metrics timeseries (fitness, obj, bound, gap) 
     - metadata (pb instance, solver config, solver status)
     - experiment class to wrap all that

- Use StatsCallback to populate the database

- Data preprocessing
    - normalize index, metadata
    - map config to config name  (ensure a bijection, create a name if not
      given)
    - add metrics (gap absolute and relative)
    - aggregate data by config
    - extract stats
    
- Plots
    - time evolution of a metric for a config x instance
    - time evolution of aggregated metric along instances for a given config
    - time evolution of number of instances solved (solver status=="optimal")
    
- Dashboard
    - we use dash library to present the 3 plots with filters on solver configs and instances

- Example: examples/dashboard/run_coloring_study.py + examples/dashboard/run_dashboard_coloring_study.py

- Unit tests: tests/generic_tools/dashboard/test_dashboard.py
   - including failed/timed-out solvers, solvers w/o some metrics
