### PR TITLE
Fix current best objective value and bound for gurobi and mathopt solvers

### DIFF
--- a/discrete_optimization/generic_tools/lp_tools.py
+++ b/discrete_optimization/generic_tools/lp_tools.py
@@ -1070,7 +1070,7 @@ class GurobiCallback:
                 self.nb_solutions += 1
                 # store mip stats
                 self.do_solver._current_internal_objective_best_value = model.cbGet(
-                    gurobipy.GRB.Callback.MIPSOL_OBJBST
+                    gurobipy.GRB.Callback.MIPSOL_OBJ
                 )
                 self.do_solver._current_internal_objective_best_bound = model.cbGet(
                     gurobipy.GRB.Callback.MIPSOL_OBJBND

--- a/discrete_optimization/generic_tools/lp_tools.py
+++ b/discrete_optimization/generic_tools/lp_tools.py
@@ -480,6 +480,10 @@ class OrtoolsMathOptMilpSolver(MilpSolver, WarmstartMixin, BoundsProviderMixin):
                 mathopt_solver_type == mathopt.SolverType.HIGHS
             )
 
+        # reset best bound and obj
+        self._current_internal_objective_best_value = None
+        self._current_internal_objective_best_bound = None
+
         self.early_stopping_exception = None
         callbacks_list = CallbackList(callbacks=callbacks)
 
@@ -506,6 +510,10 @@ class OrtoolsMathOptMilpSolver(MilpSolver, WarmstartMixin, BoundsProviderMixin):
         )
         if store_mathopt_res:
             self.mathopt_res = mathopt_res
+
+        # update best bound and obj
+        self._current_internal_objective_best_value = mathopt_res.primal_bound()
+        self._current_internal_objective_best_bound = mathopt_res.dual_bound()
 
         # get result storage
         if extract_solutions_from_mathopt_res:
@@ -774,6 +782,10 @@ class GurobiMilpSolver(MilpSolver, WarmstartMixin, BoundsProviderMixin):
         **kwargs: Any,
     ) -> ResultStorage:
         self.early_stopping_exception = None
+        # reset best bound and obj
+        self._current_internal_objective_best_value = None
+        self._current_internal_objective_best_bound = None
+
         callbacks_list = CallbackList(callbacks=callbacks)
 
         # callback: solve start
@@ -788,6 +800,12 @@ class GurobiMilpSolver(MilpSolver, WarmstartMixin, BoundsProviderMixin):
             gurobi_callback=gurobi_callback,
             **kwargs,
         )
+
+        # update best bound and obj
+        if hasattr(self.model, "ObjVal"):
+            self._current_internal_objective_best_value = self.model.ObjVal
+        if hasattr(self.model, "ObjBound"):
+            self._current_internal_objective_best_bound = self.model.ObjBound
 
         # get result storage
         res = gurobi_callback.res

--- a/tests/coloring/solvers/test_solvers.py
+++ b/tests/coloring/solvers/test_solvers.py
@@ -552,7 +552,7 @@ def test_color_lp_gurobi_cb_stop():
 
 
 @pytest.mark.skipif(not gurobi_available, reason="You need Gurobi to test this solver.")
-def test_color_lp_gurobi_current_obj():
+def test_color_lp_gurobi_current_obj_not_inf():
     file = [f for f in get_data_available() if "gc_70_1" in f][0]
     color_problem = parse_file(file)
     solver = GurobiColoringSolver(
@@ -566,6 +566,55 @@ def test_color_lp_gurobi_current_obj():
     # check stop after 1st iteration
     assert len(result_store) == 1
     assert solver.get_current_best_internal_objective_value() < gurobipy.GRB.INFINITY
+
+
+@pytest.mark.skipif(not gurobi_available, reason="You need Gurobi to test this solver.")
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="On windows guthub runner, it finds a solution despite the time limit.",
+)
+def test_color_lp_gurobi_current_obj_timeout():
+    file = [f for f in get_data_available() if "gc_70_1" in f][0]
+    color_problem = parse_file(file)
+    solver = GurobiColoringSolver(
+        color_problem,
+    )
+    result_store = solver.solve(time_limit=1e-5)
+    assert solver.get_current_best_internal_objective_value() == float("inf")
+    assert solver.get_current_best_internal_objective_bound() == -float("inf")
+
+
+@pytest.mark.skipif(not gurobi_available, reason="You need Gurobi to test this solver.")
+def test_color_lp_gurobi_current_obj_infeasible():
+    file = [f for f in get_data_available() if "gc_70_1" in f][0]
+    color_problem = parse_file(file)
+    solver = GurobiColoringSolver(
+        color_problem,
+    )
+    solver.init_model()
+    obj = solver.model.getObjective()
+    solver.add_linear_constraint(obj <= 1)
+    solver.model.update()
+    solver.solve()
+    assert solver.status_solver == StatusSolver.UNSATISFIABLE
+    assert solver.get_current_best_internal_objective_value() is None
+    assert solver.get_current_best_internal_objective_bound() == float("inf")
+
+
+@pytest.mark.skipif(not gurobi_available, reason="You need Gurobi to test this solver.")
+def test_color_lp_gurobi_current_bnd_optimal():
+    file = [f for f in get_data_available() if "gc_50_1" in f][0]
+    color_problem = parse_file(file)
+    solver = GurobiColoringSolver(
+        color_problem,
+    )
+    result_store = solver.solve()
+    # check stop after 1st iteration
+    assert solver.status_solver == StatusSolver.OPTIMAL
+    assert (
+        solver.get_current_best_internal_objective_value()
+        == solver.get_current_best_internal_objective_bound()
+    )
 
 
 @pytest.mark.skipif(not gurobi_available, reason="You need Gurobi to test this solver.")
@@ -647,6 +696,49 @@ def test_color_lp_ortools_mathopt_stop():
     )
     # check stop after 1st iteration
     assert len(result_store) == 1
+
+
+def test_color_lp_ortools_mathopt_optimal_bnd():
+    file = [f for f in get_data_available() if "gc_50_1" in f][0]
+    color_problem = parse_file(file)
+    solver = MathOptColoringSolver(
+        color_problem,
+    )
+    result_store = solver.solve()
+    # check obj and bound
+    assert solver.status_solver == StatusSolver.OPTIMAL
+    assert solver.get_current_best_internal_objective_value() is not None
+    assert solver.get_current_best_internal_objective_bound() is not None
+    assert (
+        solver.get_current_best_internal_objective_value()
+        == solver.get_current_best_internal_objective_bound()
+    )
+
+
+def test_color_lp_ortools_mathopt_current_obj_timeout():
+    file = [f for f in get_data_available() if "gc_70_1" in f][0]
+    color_problem = parse_file(file)
+    solver = MathOptColoringSolver(
+        color_problem,
+    )
+    solver.solve(time_limit=1e-5)
+    assert solver.get_current_best_internal_objective_value() == float("inf")
+    assert solver.get_current_best_internal_objective_bound() == -float("inf")
+
+
+def test_color_lp_ortools_mathopt_current_obj_infeasible():
+    file = [f for f in get_data_available() if "gc_70_1" in f][0]
+    color_problem = parse_file(file)
+    solver = MathOptColoringSolver(
+        color_problem,
+    )
+    solver.init_model()
+    obj = solver.model.objective.as_linear_expression()
+    solver.add_linear_constraint(obj <= 1)
+    solver.solve()
+    assert solver.status_solver == StatusSolver.UNSATISFIABLE
+    assert solver.get_current_best_internal_objective_value() == float("inf")
+    assert solver.get_current_best_internal_objective_bound() == float("inf")
 
 
 def test_color_lp_ortools_mathopt_cb_exception():

--- a/tests/coloring/solvers/test_solvers.py
+++ b/tests/coloring/solvers/test_solvers.py
@@ -552,6 +552,23 @@ def test_color_lp_gurobi_cb_stop():
 
 
 @pytest.mark.skipif(not gurobi_available, reason="You need Gurobi to test this solver.")
+def test_color_lp_gurobi_current_obj():
+    file = [f for f in get_data_available() if "gc_70_1" in f][0]
+    color_problem = parse_file(file)
+    solver = GurobiColoringSolver(
+        color_problem,
+    )
+    stopper = NbIterationStopper(nb_iteration_max=1)
+    callbacks = [stopper]
+    result_store = solver.solve(
+        parameters_milp=ParametersMilp.default(), callbacks=callbacks
+    )
+    # check stop after 1st iteration
+    assert len(result_store) == 1
+    assert solver.get_current_best_internal_objective_value() < gurobipy.GRB.INFINITY
+
+
+@pytest.mark.skipif(not gurobi_available, reason="You need Gurobi to test this solver.")
 def test_color_lp_gurobi_cb_exception():
     file = [f for f in get_data_available() if "gc_70_1" in f][0]
     color_problem = parse_file(file)


### PR DESCRIPTION
- Use `gurobipy.GRB.Callback.MIPSOL_OBJ` to track current best objective value instead of
`gurobipy.GRB.Callback.MIPSOL_OBJBST` which seems not to take into account last sol (and thus provides a "infinite" one when called on the first solution found)
- Update obj and bnd at the end of the solve process (intermediate results can be not tight)