### PR TITLE
Implement `explain_unsat_meta()` for gurobi

### DIFF
--- a/tests/knapsack/solvers/test_gurobi_unsat.py
+++ b/tests/knapsack/solvers/test_gurobi_unsat.py
@@ -34,5 +34,5 @@ def test_knapsack_gurobi_unsat():
     assert solver.status_solver == StatusSolver.UNSATISFIABLE
 
     # explain it
-    constraints = solver.explain_unsat()
+    constraints = solver.explain_unsat_fine()
     assert len(constraints) > 0


### PR DESCRIPTION
We implement a version of explainability using meta constraints (gathering several constraints).
We rename `explain_unsat()` into `explain_unsat_fine()` to mimic cpmpy wrapper. 
We implement the metaconstraints for the coloring solver as it was done for cpmpy.