### PR TITLE
Add functionalities to d-o dashboard

### DIFF
--- a/discrete_optimization/generic_tools/dashboard/dashboard.py
+++ b/discrete_optimization/generic_tools/dashboard/dashboard.py
@@ -29,6 +29,7 @@ from discrete_optimization.generic_tools.dashboard.preprocess import (
     extract_instances,
     extract_metrics,
     extract_nb_xps_by_config,
+    extract_nb_xps_w_n_wo_sol_by_config,
     extract_nbsolvedinstances_by_config,
     filter_results,
     get_experiment_name,
@@ -496,8 +497,17 @@ class Dashboard(Dash):
                 for config, df in stat_by_config.items()
                 if metric in df
             }
+            (
+                nb_xps_by_config,
+                nb_xps_wo_sol_by_config,
+            ) = extract_nb_xps_w_n_wo_sol_by_config(
+                results=self.full_results, configs=configs, instances=instances
+            )
             df_summary = construct_summary_metric_agg(
-                stat_by_config=stat_by_config, configs=configs
+                stat_by_config=stat_by_config,
+                configs=configs,
+                nb_xps_by_config=nb_xps_by_config,
+                nb_xps_wo_sol_by_config=nb_xps_wo_sol_by_config,
             )
             return dict(
                 plot=create_graph_from_series_dict(

--- a/discrete_optimization/generic_tools/dashboard/dashboard.py
+++ b/discrete_optimization/generic_tools/dashboard/dashboard.py
@@ -570,13 +570,17 @@ class Dashboard(Dash):
             ),
         )
         def update_config_display(config_name: str) -> str:
-            try:
-                config = self.config_store.get_config(config_name)
-            except KeyError:
-                config_str = "NOT_FOUND"
-            else:
-                config_str = json.dumps(config, indent=4)
-            return "```python\n" f"{config_str}\n" "```\n"
+            configs = self.config_store.get_configs(config_name)
+            config_str = "\n\n".join(json.dumps(config, indent=4) for config in configs)
+            md_str = "```python\n" f"{config_str}\n" "```\n"
+            if len(configs) > 1:
+                md_str = (
+                    f"> WARNING: {len(configs)} configs with same name found!\n\n"
+                    + md_str
+                )
+            elif len(configs) == 0:
+                md_str = f"> WARNING: no config found with given name!\n"
+            return md_str
 
         # Xp explorer
         @self.callback(

--- a/discrete_optimization/generic_tools/dashboard/preprocess.py
+++ b/discrete_optimization/generic_tools/dashboard/preprocess.py
@@ -378,7 +378,7 @@ def construct_summary_metric_agg(
 ) -> pd.DataFrame:
     if configs is None:
         configs = list(stat_by_config)
-    index_config = pd.Index(configs, name="config")
+    index_config = pd.Index(configs, name=CONFIG)
     df_stat = next(iter(stat_by_config.values()))
     metrics = list(df_stat.columns)
     data = (

--- a/discrete_optimization/generic_tools/dashboard/preprocess.py
+++ b/discrete_optimization/generic_tools/dashboard/preprocess.py
@@ -168,6 +168,16 @@ def extract_configs(results: list[pd.DataFrame]) -> set[str]:
     return {df.attrs[CONFIG] for df in results}
 
 
+def extract_instances_with_sol_by_config(
+    results: list[pd.DataFrame],
+) -> dict[str, set[str]]:
+    instances_with_sol_by_config = defaultdict(set)
+    for df in results:
+        if len(df) > 0:
+            instances_with_sol_by_config[df.attrs[CONFIG]].add(df.attrs[INSTANCE])
+    return instances_with_sol_by_config
+
+
 def extract_nb_xps_by_config(results: list[pd.DataFrame]) -> dict[str, int]:
     nb_xps_by_config = defaultdict(lambda: 0)
     for df in results:

--- a/docs/source/dashboard.md
+++ b/docs/source/dashboard.md
@@ -166,12 +166,15 @@ By default, the dashboard will then be available at http://127.0.0.1:8050/.
 
 You will find on a left panel the different filters:
 - solver configs
-- instances ("@all" alias selecting all the instances)
+- instances, with some aliases:
+  - @all: select all the instances
+  - @withsol: select all instances for which each selected config has found at least one solution
 - metric to show
 - clip at: to avoid outliers, the data whose absolute value is above it are removed
 - on-off buttons for
   - time in log-scale
   - transposing the graph (solved instances graph only)
+  - spectifying if the metric is supposed to be minimized or maximized the metric (aggregated ranks table only)
 
 On the main panel, you have several tabs corresponding to graph type, or tables:
 - "Metric evolution": the curve for each experiment of the chosen metric
@@ -179,9 +182,11 @@ On the main panel, you have several tabs corresponding to graph type, or tables:
   A point is drawn for a given time on the curve of a given config,
   only if at least a point occurred before for each filtered instances.
   The table below gives the last point of each curve (so the aggregated metric at solve end of each experiment)
+  + number of experiments by config + number of experiments without solution (usually because of timeout)
 - "Nb of solved instances": the graph shows the time evolution of the number of solved instances (i.e. whose solver status is "optimal")
   On the graph the % is relative to the total number of experiments done for the solver config. On the table below, you get
   this total number of experiments versus the number of experiments finishing with solver status "optimal".
+- "Solvers competition": aggregated config rank along instances and aggregated distance to best metric
 - "Config explorer": displays the solver class and hyperparameters corresponding to each solver config name.
 - "Experiment data": displays the raw timeseries for each experiment
 - "Empty experiments": list the experiments with no data and the potential reason (timeout or raised error)

--- a/tests/generic_tools/dashboard/test_dashboard.py
+++ b/tests/generic_tools/dashboard/test_dashboard.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from copy import copy
 from typing import Any, Optional
 
 import pandas as pd
@@ -155,6 +156,10 @@ def run_study(study_name):
                     status=status,
                     reason=reason,
                 )
+                # modify fake config to create a duplicate
+                if config_name == "fake" and instance == "gc_50_1":
+                    xp.config.parameters = copy(xp.config.parameters)
+                    xp.config.parameters["toto"] = 0.5
                 database.store(xp)
 
 
@@ -192,9 +197,14 @@ def test_update_config_display_ok(app):
     assert '"multiprocess": true,' in string
 
 
-def test_update_config_display_nok(app):
+def test_update_config_display_no_config(app):
     string = app.update_config_display(config_name="toto-binary")
-    assert "NOT_FOUND" in string
+    assert "WARNING: no config" in string
+
+
+def test_update_config_display_several_configs(app):
+    string = app.update_config_display(config_name="fake")
+    assert "WARNING: 2 configs" in string
 
 
 @pytest.mark.parametrize(

--- a/tests/generic_tools/dashboard/test_dashboard.py
+++ b/tests/generic_tools/dashboard/test_dashboard.py
@@ -113,6 +113,9 @@ def run_study(study_name):
                 logging.info(
                     f"###### Instance {instance}, config {config_name} ######\n\n"
                 )
+                # remove one xp to have solvers with less instances
+                if config_name == "mathopt" and instance == "gc_50_1":
+                    continue
 
                 try:
                     # init problem
@@ -178,8 +181,8 @@ def app(study_results):
 
 
 def test_init_app(app):
-    assert len(app.results) == 9
-    assert len(app.full_results) == 15
+    assert len(app.results) == 8
+    assert len(app.full_results) == 14
 
 
 def test_update_config_display_ok(app):
@@ -202,7 +205,7 @@ def test_update_config_display_nok(app):
             ["@all"],
             "fit",
             [],
-            9,
+            8,
             True,
         ),
         (["cpsat-binary"], ["gc_50_1"], "gap", [], 1, False),

--- a/tests/generic_tools/dashboard/test_dashboard.py
+++ b/tests/generic_tools/dashboard/test_dashboard.py
@@ -70,7 +70,11 @@ class FakeTimeoutSolver(BoundsProviderMixin, ColoringSolver):
 
 
 def run_study(study_name):
-    instances = ["gc_50_3", "gc_50_1", "gc_50_3"]  # test duplicates
+    instances = [
+        "gc_50_3",
+        "gc_50_1",
+        "gc_50_3",
+    ]  # test duplicates
     cpsat_integer_timeout = False
     solver_configs = {
         "cpsat-integer": SolverConfig(
@@ -220,6 +224,36 @@ def test_update_config_display_several_configs(app):
     assert "WARNING: 2 configs" in string
 
 
+def test_replace_instances_aliases(app):
+    configs = app.full_configs
+    instances = ["@all"]
+    assert app._replace_instances_aliases(instances, configs) == ["gc_50_1", "gc_50_3"]
+    instances = ["@withsol"]
+    assert app._replace_instances_aliases(instances, configs) == []
+    instances = ["@withsol", "gc_50_3", "gc_50_1"]
+    assert app._replace_instances_aliases(instances, configs) == ["gc_50_3", "gc_50_1"]
+
+    configs = app.configs
+    instances = ["@all"]
+    assert app._replace_instances_aliases(instances, configs) == ["gc_50_1", "gc_50_3"]
+    instances = ["@withsol"]
+    assert app._replace_instances_aliases(instances, configs) == ["gc_50_3"]
+    instances = ["@withsol", "gc_50_1", "gc_50_3"]
+    assert app._replace_instances_aliases(instances, configs) == ["gc_50_1", "gc_50_3"]
+    instances = ["gc_50_1", "@withsol"]
+    assert app._replace_instances_aliases(instances, configs) == ["gc_50_1", "gc_50_3"]
+    instances = ["@withsol", "gc_50_3"]
+    assert app._replace_instances_aliases(instances, configs) == ["gc_50_3"]
+
+    configs = ["cpsat-binary"]
+    instances = ["@all"]
+    assert app._replace_instances_aliases(instances, configs) == ["gc_50_1", "gc_50_3"]
+    instances = ["@withsol"]
+    assert app._replace_instances_aliases(instances, configs) == ["gc_50_1", "gc_50_3"]
+    instances = ["@withsol", "gc_50_3", "gc_50_1"]
+    assert app._replace_instances_aliases(instances, configs) == ["gc_50_3", "gc_50_1"]
+
+
 @pytest.mark.parametrize(
     "configs, instances, metric, time_log_scale, expected_n_traces, attempt_in_legend",
     [
@@ -232,6 +266,14 @@ def test_update_config_display_several_configs(app):
             True,
         ),
         (["cpsat-binary"], ["gc_50_1"], "gap", [], 1, False),
+        (
+            ["cpsat-binary", "cpsat-integer", "mathopt"],
+            ["@withsol"],
+            "fit",
+            [],
+            5,
+            True,
+        ),
     ],
 )
 def test_update_graph_metric(


### PR DESCRIPTION
- Add new alias "@withsol": select all instances for which each selected config has found at least one solution
- Limit number of significative digits in tables
- Allow several configs to share the same config name
  - raise a warning instead of an error
  - show all configs under a name in config explorer tab
  - aggregate them in aggregating tabs 
-  Add number of xps and number of xps w/o sol in summary for aggregated metrics
-  Add a tab for aggregated ranks and aggregageted distance to best metric
- Update accordingly the doc