### PR TITLE
Update explainability methods with meta constraints

### DIFF
--- a/discrete_optimization/generic_tools/lp_tools.py
+++ b/discrete_optimization/generic_tools/lp_tools.py
@@ -857,7 +857,7 @@ class GurobiMilpSolver(MilpSolver, WarmstartMixin, BoundsProviderMixin):
 
         return constraints
 
-    def explain_unsat_meta(
+    def explain_unsat_deduced_meta(
         self,
         meta_constraints: Optional[list[MetaConstraint]] = None,
     ) -> list[MetaConstraint]:
@@ -870,7 +870,7 @@ class GurobiMilpSolver(MilpSolver, WarmstartMixin, BoundsProviderMixin):
                 Default to the ones returned by `get_default_meta_constraints()`.
 
         Returns:
-            subset minimal list of meta-constraints leading to unsatisfiability.
+            subset of meta-constraints leading to unsatisfiability (corresponding fine constraints subset being minimal).
 
         """
         if meta_constraints is None:


### PR DESCRIPTION
- current methods that deduce meta constraints set from minimal fine constraints set are renamed "`***_deduced_meta`" instead of "`***_meta`".
- to find a minimal of meta constraints, we create a cpmpy constraints `all(meta.constraints)` which is the exact translation of what the meta constraint is.