### PR TITLE
Fix interactive example on unsatisfiability with fine constraints

### DIFF
--- a/examples/coloring/run_unsat_interactive_fine.py
+++ b/examples/coloring/run_unsat_interactive_fine.py
@@ -21,12 +21,16 @@ solver.init_model(**kwargs_init_model)
 
 done = False
 removed_constraints = []
+soft_constraints = solver.get_soft_constraints()
+hard_constraints = solver.get_hard_constraints()
 while not done:
     print("Solving...")
     result_store = solver.solve()
 
     if solver.status_solver == StatusSolver.UNSATISFIABLE:
-        mus = solver.explain_unsat_fine(**kwargs_mus)
+        mus = solver.explain_unsat_fine(
+            soft=soft_constraints, hard=hard_constraints, **kwargs_mus
+        )
         print("The problem is unsatisfiable.")
         str_list_cstr = "\n".join(
             f"{i_cstr}: {cstr}" for i_cstr, cstr in enumerate(mus)
@@ -38,11 +42,12 @@ while not done:
                 + "\n> "
             )
         )
-        # remove constraint from model
+        # remove constraint from model and soft constraints
         cstr = mus[i_cstr]
         solver.model.constraints = [
             c for c in solver.model.constraints if c is not cstr
         ]
+        soft_constraints = [c for c in soft_constraints if c is not cstr]
         removed_constraints.append(cstr)
     elif len(result_store) > 0:
         print(f"The problem was solved with status {solver.status_solver.value}.")


### PR DESCRIPTION
Because of the overriding of `solver.get_soft_constraints()`, removing constraints from the model was not sufficient to be taken into account by `solver.get_soft_constraints()`. So we explicitely track the soft constraints passed to `solver.explain_unsat_fine()` to avoid looping infinitely on the same choice of constraints.