### PR TITLE
Add doc for RcpspSolution and RcpspProblem

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -251,6 +251,9 @@ jobs:
             --cov-report term \
             -v --durations=0 --durations-min=10 \
             tests
+      - name: Test examples in docstrings
+        run: |
+          pytest --doctest-modules src -v
       - name: Upload coverage report as artifact
         if: ${{ matrix.coverage }}
         uses: actions/upload-artifact@v4

--- a/notebooks/RCPSP tutorials/RCPSP-1 Introduction.ipynb
+++ b/notebooks/RCPSP tutorials/RCPSP-1 Introduction.ipynb
@@ -518,7 +518,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.8"
+   "version": "3.11.14"
   },
   "toc": {
    "base_numbering": 1,

--- a/notebooks/RCPSP tutorials/RCPSP-5 Constraint Programming.ipynb
+++ b/notebooks/RCPSP tutorials/RCPSP-5 Constraint Programming.ipynb
@@ -265,7 +265,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.8"
+   "version": "3.11.14"
   },
   "toc": {
    "base_numbering": 1,

--- a/notebooks/RCPSP tutorials/RCPSP-6 Large Neighbourhood Search .ipynb
+++ b/notebooks/RCPSP tutorials/RCPSP-6 Large Neighbourhood Search .ipynb
@@ -344,7 +344,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.8"
+   "version": "3.11.14"
   },
   "toc": {
    "base_numbering": 1,

--- a/src/discrete_optimization/rcpsp/problem.py
+++ b/src/discrete_optimization/rcpsp/problem.py
@@ -54,43 +54,98 @@ class ScheduleGenerationScheme(Enum):
 class RcpspProblem(
     MultimodeProblem[Task], SchedulingProblem[Task], PrecedenceProblem[Task]
 ):
-    """
+    """Main class for RCPSP problem.
 
     Attributes:
-        resources:
-        non_renewable_resources:
-        mode_details:
-        successors:
-        horizon:
-        horizon_multiplier:
-        tasks_list:
-        source_task:
-        sink_task:
-        name_task:
-        n_jobs (int):
-        n_jobs_non_dummy (int):   excluding dummy activities Start (0) and End (n)
-        special_constraints:
-        do_special_constraints (bool):
-        relax_the_start_at_end (bool): relax some conditions only if do_special_constraints
-        fixed_permutation (Optional[list[int]]):
-        fixed_modes (Optional[list[int]]):
+        resources (dict[str, Union[int, list[int]): mapping: name -> number of resources available,
+            either at each time (-if an integer),
+            or time step by time step (if a list of integers).
+        non_renewable_resources (list[str]): list of resources (specified by name) that are non-renewable
+        mode_details (dict[Hashable, dict[int, dict[str, int]]]): task -> (mode number -> resource needs and duration)
+            Ex:
+            >>> mode_details = { "task1" :
+            ...    {  # task1 details
+            ...        1: { "duration": 2, "R1": 1, "R2": 0, "R3": 4 },  # task1, mode 1: duration = 2, resource needs: R1=1, R3=4
+            ...        2: { "duration": 10, "R1": 0, "R2": 2, "R3": 0 },  # task1, mode 1: duration = 10, resource needs: R2=2
+            ...    },
+            ...    # [other tasks]
+            ... }
 
-    Args:
-        resources: {resource_name: number_of_resource}
-        non_renewable_resources: [resource_name3, resource_name4]
-        mode_details:  {job_id: {mode_id: {resource_name1: number_of_resources_needed, resource_name2: ...}}   one key being "duration"
-        successors:
-        horizon:
-        horizon_multiplier:
-        tasks_list:  {task_id: list of successor task ids}
-        source_task:
-        sink_task:
-        name_task:
-        special_constraints:
-        relax_the_start_at_end:
-        fixed_permutation:
-        fixed_modes:
-        **kwargs:
+        successors (dict[Hashable, list[Hashable]]): successors in the precedence graph of each task
+        horizon (int): max number of time steps allowed
+        horizon_multiplier: not used
+        tasks_list(list[Hashable]): list of tasks. Must correspond to `mode_details`. If not given will be equal to `list(mode_details)`.
+        source_task (Hashable): the id for the source task (i.e. the root in the precedence graph, all other tasks must follow it).
+            If not given and tasks_list is made of integers, the lowest one
+        sink_task (Hashable): the id for the source task (i.e. the last task in the precedence graph, follows all other tasks).
+            If not given and tasks_list is made of integers, the highest one.
+        tasks_list_non_dummy (list[Hashable]): tasks list excluding source and sink. Same order as tasks_list
+        name_task (dict[Hashable, str]): mapping task ids to task names. Default to id -> str(id)
+        n_jobs (int): numer of tasks (i.e. `len(tasks_list)`)
+        n_jobs_non_dummy (int): number of tasks  excluding dummy activities Start (0) and End (n). (i.e. `n_jobs - 2`)
+        index_task (dict[Hashable, int]): mapping task id to index among all tasks (from 0 to n_jobs)
+        index_task_non_dummy (dict[Hashable, int]): mapping task id to index among all non-dummy tasks (from 0 to n_jobs_non_dummy)
+        special_constraints (SpecialConstraintsDescription): special additional constraints
+        do_special_constraints (bool): True if they are special constraints to take into account
+        relax_the_start_at_end (bool): relax some conditions, only if do_special_constraints.
+        fixed_permutation (Optional[list[int]]): To be used by solutions specifying only `rcpsp_modes`,
+            e.g. in alternating genetic algorithms, that are updating only one solution attribute at a time.
+            See `RcpspSolution` for more details.
+        fixed_modes (Optional[list[int]]): To be used by solutions specifying only the `rpsp_permutation`,
+            e.g. in alternating genetic algorithms, that are updating only one solution attribute at a time.
+            See `RcpspSolution` for more details.
+
+    Example:
+        Initializing a simple RCPSP problem with 4 tasks, 2 resources, and
+        precedence constraints, then generating a baseline schedule.
+
+        >>> from discrete_optimization.rcpsp.problem import RcpspProblem
+        >>> from discrete_optimization.rcpsp.solution import RcpspSolution
+        >>> # Define resources
+        >>> resources = {"R1": 5, "R2": 2}
+        >>> non_renewable_resources = []  # Empty if all resources replenish when a task ends
+        >>> # Define mode details
+        >>> # Format: { task_id: { mode_id: { "duration": int, "resource_name": amount } } }
+        >>> mode_details = {
+        ...     "source": {1: {"duration": 0, "R1": 0, "R2": 0}},  # Source (Dummy)
+        ...     "task-1": {1: {"duration": 4, "R1": 2, "R2": 2}},
+        ...     "task-2": {1: {"duration": 3, "R1": 3, "R2": 0}},
+        ...     "task-3": {1: {"duration": 5, "R1": 2, "R2": 1}},
+        ...     "task-4": {1: {"duration": 2, "R1": 1, "R2": 1}},
+        ...     "sink": {1: {"duration": 0, "R1": 0, "R2": 0}},  # Sink (Dummy)
+        ... }
+        >>> # Define precedence graph
+        >>> successors = {
+        ...     "source": ["task-1", "task-2"],  # First tasks: 1 and 2
+        ...     "task-1": ["task-3"],            # Task 1 must finish before 3
+        ...     "task-2": ["task-4"],            # Task 2 must finish before 4
+        ...     "task-3": ["sink"],              # Task 3 leads to Sink
+        ...     "task-4": ["sink"],              # Task 4 leads to Sink
+        ...     "sink": [],                       # Sink has no successors
+        ... }
+        >>> # Initialize the Problem
+        >>> problem = RcpspProblem(
+        ...     resources=resources,
+        ...     non_renewable_resources=non_renewable_resources,
+        ...     mode_details=mode_details,
+        ...     successors=successors,
+        ...     horizon=20, # Maximum time allowed for the project
+        ...     source_task="source",
+        ...     sink_task="sink"
+        ... )
+        >>> # Get a dummy solution: use serial sgs on trivial permutation
+        >>> # See RcpspSolution docstring for more information.
+        >>> sol = problem.get_dummy_solution()
+        >>> print(sol.rcpsp_schedule)
+        {'source': {'start_time': 0, 'end_time': 0}, 'task-1': {'start_time': 0, 'end_time': 4}, 'task-2': {'start_time': 0, 'end_time': 3}, 'task-3': {'start_time': 4, 'end_time': 9}, 'task-4': {'start_time': 4, 'end_time': 6}, 'sink': {'start_time': 9, 'end_time': 9}}
+        >>> # index_task vs index_task_non_dummy
+        >>> problem.index_task  # index among all tasks: task-1 -> 1
+        {'source': 0, 'task-1': 1, 'task-2': 2, 'task-3': 3, 'task-4': 4, 'sink': 5}
+        >>> problem.index_task_non_dummy  # index among only non-dummy tasks: task-1 -> 0
+        {'task-1': 0, 'task-2': 1, 'task-3': 2, 'task-4': 3}
+        >>> # Convert permutation of tasks into a list opf non-dummy indices
+        >>> problem.convert_task_ids_to_permutation(["task-3", "task-2", "task-4", "task-1"])
+        [2, 1, 3, 0]
 
     """
 
@@ -115,6 +170,26 @@ class RcpspProblem(
         fixed_modes: Optional[list[int]] = None,
         **kwargs: Any,
     ):
+        """
+
+        Args:
+            resources:
+            non_renewable_resources:
+            mode_details:
+            successors:
+            horizon:
+            horizon_multiplier:
+            tasks_list:
+            source_task:
+            sink_task:
+            name_task:
+            calendar_details:
+            special_constraints:
+            relax_the_start_at_end:
+            fixed_permutation:
+            fixed_modes:
+            **kwargs:
+        """
         self.resources = resources
         self.resources_list = list(self.resources.keys())
         self.non_renewable_resources = non_renewable_resources
@@ -522,12 +597,37 @@ class RcpspProblem(
         return model
 
     def get_dummy_solution(self) -> RcpspSolution:
+        """Apply serial sgs on the trivial task permutation.
+
+        See RcpspSolution about details on conversion permutation -> schedule.
+
+        Returns:
+
+        """
         sol = RcpspSolution(
             problem=self,
             rcpsp_permutation=list(range(self.n_jobs_non_dummy)),
             rcpsp_modes=[1 for i in range(self.n_jobs_non_dummy)],
         )
         return sol
+
+    def convert_task_ids_to_permutation(self, tasks: list[Task]) -> list[int]:
+        """Convert list of task ids into a permutation in proper format for `RcpspSolution`.
+
+        - remove source and sink if present
+        - use the indices among non-dummy tasks
+
+        Args:
+            tasks:
+
+        Returns:
+
+        """
+        return [
+            self.index_task_non_dummy[task]
+            for task in tasks
+            if task in self.index_task_non_dummy
+        ]
 
     def get_resource_available(self, res: str, time: int) -> int:
         if self.is_calendar:

--- a/src/discrete_optimization/rcpsp/solution.py
+++ b/src/discrete_optimization/rcpsp/solution.py
@@ -34,21 +34,11 @@ class RcpspSolution(SchedulingSolution[Task], MultimodeSolution[Task]):
 
     Attributes:
         problem: RCPSP problem for which this is a solution
-        rcpsp_permutation: Tasks permutation.
-        rcpsp_schedule: Tasks schedule. ( task -> "start_time" or "end_time" -> time)
-            Potentially only partial if not feasible with given permutation, or for aggregated models.
-        rcpsp_modes: Mode used for each task. Same order as `problem.tasks_list_non_dummy`.
-        rcpsp_schedule_feasible: False if schedule generation from permutation failed, True else.
-        standardised_permutation: Permutation deduced uniquely from schedule.
-            Can be different from `rcpsp_permutation` as different permutations can lead to same schedule.
-        fast: boolean indicating if we us the fast functions to generate schedule from permutation.
-
-    Args:
-        problem: RCPSP problem for which this is a solution
-        rcpsp_permutation: Tasks permutation.
+        rcpsp_permutation: Tasks permutation, i.e. list of tasks indices among non-dummy tasks (i.e. excluding source and sink tasks).
+            See below how it is related to the schedule.
             If given and schedule not given, used to reconstruct the schedule.
             if not given, deduced from schedule.
-            If not given and schedule not given, it is set to `problem.fixed_permutation`
+            If not given and schedule not given, it is set to `problem.fixed_permutation` (useful for alternating genetic algorithms)
         rcpsp_schedule: Tasks schedule. ( task -> "start_time" or "end_time" -> time)
             If given used to construct `standardised_permutation`.
             If given and `rcpsp_permutation` not given, used to construct `rcpsp_permutation`.
@@ -64,7 +54,86 @@ class RcpspSolution(SchedulingSolution[Task], MultimodeSolution[Task]):
             Recomputed when schedule is (re)computed from permutation.
         standardised_permutation: Permutation deduced uniquely from schedule. If given, not recomputed.
             Can be different from `rcpsp_permutation` as different permutations can lead to same schedule.
-        fast: boolean indicating if we us the fast functions to generate schedule from permutation.
+        fast: boolean indicating if we use the fast functions to generate schedule from permutation.
+
+    ## More about conversion permutation <-> schedule:
+
+    ### Schedule -> permutation
+    Take the list of tasks indices among non-dummy tasks (i.e. excluding source and sink tasks),
+    sorted by their starting times.
+
+    ### Permutation -> schedule: serial-SGS (Schedule Generation Scheme)
+    - Initialization:
+        - the source task is set at time 0
+        - the resource availability is set to the initial calendar given by the problem
+    - Loop: the schedule is filled task by task, in the order given by the permutation, and taking into account
+        - the precedence constraints: a task starts after the end of the tasks before it in the precedence graph
+        - the resource constraints: during the task, the needed resource must be available
+      When a new task has been inserted, the availability of each resource is updated accordingly, i.e.
+      we remove the necessary resources for the task (according to the chosen mode set by `rcpsp_modes`) for the task duration,
+      and after if the resource is non-renewable.
+    - When hitting an impossibility (e.g. inserting a task after one of its successor, or when the resources are not enough available until the problem horizon)
+      the permutation is set infeasible (so `rcpsp_schedule_feasible` is set to `False`).
+
+    See "Compute a dummy solution for RCPSP" in the tutorial "notebooks/RCPSP tutorials/RCPSP-1 Introduction.ipynb" for more details.
+
+    Example:
+        This example demonstrates how a permutation of non-dummy tasks is
+        transformed into a schedule, adhering to precedence and resource constraints.
+
+        >>> from discrete_optimization.rcpsp.problem import RcpspProblem
+        >>> from discrete_optimization.rcpsp.solution import RcpspSolution
+        >>> # Define resources
+        >>> resources = {"R1": 5, "R2": 2}
+        >>> non_renewable_resources = []  # Empty if all resources replenish when a task ends
+        >>> # Define mode details
+        >>> # Format: { task_id: { mode_id: { "duration": int, "resource_name": amount } } }
+        >>> mode_details = {
+        ...     "source": {1: {"duration": 0, "R1": 0, "R2": 0}},  # Source (Dummy)
+        ...     "task-1": {1: {"duration": 4, "R1": 2, "R2": 2}},
+        ...     "task-2": {1: {"duration": 3, "R1": 3, "R2": 0}},
+        ...     "task-3": {1: {"duration": 5, "R1": 2, "R2": 1}},
+        ...     "task-4": {1: {"duration": 2, "R1": 1, "R2": 1}},
+        ...     "sink": {1: {"duration": 0, "R1": 0, "R2": 0}},  # Sink (Dummy)
+        ... }
+        >>> # Define precedence graph
+        >>> successors = {
+        ...     "source": ["task-1", "task-2"],  # First tasks: 1 and 2
+        ...     "task-1": ["task-3"],            # Task 1 must finish before 3
+        ...     "task-2": ["task-4"],            # Task 2 must finish before 4
+        ...     "task-3": ["sink"],              # Task 3 leads to Sink
+        ...     "task-4": ["sink"],              # Task 4 leads to Sink
+        ...     "sink": [],                       # Sink has no successors
+        ... }
+        >>> # Initialize the Problem
+        >>> problem = RcpspProblem(
+        ...     resources=resources,
+        ...     non_renewable_resources=non_renewable_resources,
+        ...     mode_details=mode_details,
+        ...     successors=successors,
+        ...     horizon=20, # Maximum time allowed for the project
+        ...     source_task="source",
+        ...     sink_task="sink"
+        ... )
+        >>> # Create solution
+        >>> # Convert list of task ids into a licit permutation (using indices among non-dummy tasks)
+        >>> rcpsp_permutation = problem.convert_task_ids_to_permutation(["task-2", "task-1", "task-4", "task-3"])
+        >>> print(rcpsp_permutation)
+        [1, 0, 3, 2]
+        >>> solution = RcpspSolution(
+        ...     problem=problem,
+        ...     rcpsp_permutation=rcpsp_permutation,
+        ...     rcpsp_modes=[1, 1, 1, 1]  # same mode for each task
+        ... )
+        >>> # The Serial SGS calculates the start/end times according:
+        >>> print(solution.rcpsp_schedule["task-2"])  # Task 2
+        {'start_time': 0, 'end_time': 3}
+        >>> print(solution.rcpsp_schedule["task-1"])  # Task 1 follows Task 2 in permutation
+        {'start_time': 0, 'end_time': 4}
+        >>> print(solution.rcpsp_schedule["task-4"])  # Task 4 can start after Task 2, but only when ressources are available (thus after task 1)
+        {'start_time': 4, 'end_time': 6}
+        >>> print(solution.rcpsp_schedule["task-3"])  # Task 3 can start after Task 1 (and ressources are available)
+        {'start_time': 4, 'end_time': 9}
 
     """
 
@@ -80,6 +149,17 @@ class RcpspSolution(SchedulingSolution[Task], MultimodeSolution[Task]):
         standardised_permutation: Optional[list[int]] = None,
         fast: bool = True,
     ):
+        """
+
+        Args:
+            problem:
+            rcpsp_permutation:
+            rcpsp_schedule:
+            rcpsp_modes:
+            rcpsp_schedule_feasible:
+            standardised_permutation:
+            fast:
+        """
         super().__init__(problem=problem)
         self.rcpsp_schedule_feasible = rcpsp_schedule_feasible
         self.fast = fast


### PR DESCRIPTION
- enrich dosctrings
- add explanation about permutation <-> schedule
- add examples in the docstring
- test examples via doctest
- add an utility method to convert task ids into non-dummy indices (needed by `RcpspSolution.rcpsp_permutation`)