### PR TITLE
Avoid random errors in test suite

### DIFF
--- a/tests/jsp/solvers/test_dp.py
+++ b/tests/jsp/solvers/test_dp.py
@@ -23,7 +23,7 @@ def test_dp_jsp_ws():
     file_path = [f for f in get_data_available() if "ta68" in f][0]
     problem = parse_file(file_path)
     solver_ws = CpSatJspSolver(problem)
-    sol_ws = solver_ws.solve(time_limit=2, callbacks=[NbIterationStopper(1)])[0][0]
+    sol_ws = solver_ws.solve(time_limit=5, callbacks=[NbIterationStopper(1)])[0][0]
     solver = DpJspSolver(problem=problem)
     solver.init_model()
     solver.set_warm_start(sol_ws)

--- a/tests/vrp/solvers/test_cpsat.py
+++ b/tests/vrp/solvers/test_cpsat.py
@@ -59,11 +59,7 @@ def test_cpsat_vrp(optional_node, cut_transition):
         compute_nb_nodes_in_path(sol)
 
     # test warm start
-    # start_solution = GreedyVrpSolver(problem=vrp_problem).solve(time_limit=20).get_best_solution_fit()[0]
-    start_solution = res[1][0]
-
-    # first solution is not start_solution
-    assert res[0][0].list_paths != start_solution.list_paths
+    start_solution = res[-1][0]
 
     # warm start at first solution
     solver = CpSatVrpSolver(problem=problem)

--- a/tests/workforce/allocation/test_cpsat.py
+++ b/tests/workforce/allocation/test_cpsat.py
@@ -354,7 +354,7 @@ def test_constraint_nb_usages(problem, modelisation_allocation):
             sign=SignEnum.LESS, target=target
         )
         sol = solver.solve(
-            callbacks=[NbIterationStopper(nb_iteration_max=1)], time_limit=5
+            callbacks=[NbIterationStopper(nb_iteration_max=1)], time_limit=15
         ).get_best_solution()
         assert sol.compute_nb_unary_resources_used() < target
 

--- a/tests/workforce/scheduling/test_cpsat.py
+++ b/tests/workforce/scheduling/test_cpsat.py
@@ -202,7 +202,7 @@ def test_cpsat_params(
     )
     res = solver.solve(
         callbacks=[NbIterationStopper(nb_iteration_max=1)],
-        time_limit=5,
+        time_limit=15,
         parameters_cp=parameters_cp,
         **kwargs,
     )
@@ -228,7 +228,7 @@ def test_cpsat_modelisation_dispersion(problem, modelisation_dispersion):
     )
     res = solver.solve(
         callbacks=[NbIterationStopper(nb_iteration_max=1)],
-        time_limit=5,
+        time_limit=10,
         parameters_cp=parameters_cp,
         **kwargs,
     )
@@ -244,7 +244,7 @@ def test_cpsat_set_model_obj_aggregated(problem):
     # solution to compare with for DELTA_TO_EXISTING_SOLUTION
     res = solver.solve(
         callbacks=[NbIterationStopper(nb_iteration_max=1)],
-        time_limit=5,
+        time_limit=10,
     )
     base_solution = res.get_best_solution()
 
@@ -279,7 +279,7 @@ def test_cpsat_lexico(problem):
     # solution to compare with for DELTA_TO_EXISTING_SOLUTION
     res = solver.solve(
         callbacks=[NbIterationStopper(nb_iteration_max=1)],
-        time_limit=5,
+        time_limit=10,
     )
     base_solution = res.get_best_solution()
 

--- a/tests/workforce/scheduling/test_lns_cpsat.py
+++ b/tests/workforce/scheduling/test_lns_cpsat.py
@@ -35,7 +35,7 @@ def problem():
     return parse_json_to_problem(instance)
 
 
-TIME_LIMIT_SUBSOLVER = 1
+TIME_LIMIT_SUBSOLVER = 2
 
 
 @pytest.mark.parametrize(
@@ -126,7 +126,7 @@ def test_lns_cpsat_subobjective(problem, objective_subproblem):
         constraint_handler=constraint_handler,
     )
     res = solver.solve(
-        nb_iteration_lns=3,
+        nb_iteration_lns=2,
         time_limit_subsolver=TIME_LIMIT_SUBSOLVER,
         parameters_cp=parameters_cp,
         skip_initial_solution_provider=True,


### PR DESCRIPTION
- When testing warm start we stop checking that the chosen starting solution is different from the first found before warm start. This resulted in errors in some rare case where the solver stopped before finding 2 solutions.
- Other solvers need a larger timeout to ensure a solution is always found