### PR TITLE
Add mixins for problem with non-renewable resources

### DIFF
--- a/src/discrete_optimization/generic_rcpsp_tools/solvers/lns_cp_mzn/solution_repair.py
+++ b/src/discrete_optimization/generic_rcpsp_tools/solvers/lns_cp_mzn/solution_repair.py
@@ -64,9 +64,6 @@ ANY_RCPSP = Union[
 
 def compute_shift_extremities(model: ANY_RCPSP):
     ressource_names = model.get_resource_names()
-    ressource_arrays = {
-        r: model.get_resource_availability_array(r) for r in ressource_names
-    }
     if isinstance(model, MultiskillRcpspProblem):
         fake_tasks, fake_tasks_unit = create_fake_tasks_multiskills(model)
         f = fake_tasks + fake_tasks_unit

--- a/src/discrete_optimization/generic_tasks_tools/allocation_scheduling.py
+++ b/src/discrete_optimization/generic_tasks_tools/allocation_scheduling.py
@@ -15,6 +15,11 @@ from discrete_optimization.generic_tasks_tools.cumulative_resource import (
     CumulativeResourceProblem,
     CumulativeResourceSolution,
 )
+from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
+    NonRenewableResource,
+    NonRenewableResourceProblem,
+    NonRenewableResourceSolution,
+)
 
 CumulativeResource = TypeVar("CumulativeResource", bound=Hashable)
 Resource = Union[CumulativeResource, UnaryResource]
@@ -22,8 +27,9 @@ Resource = Union[CumulativeResource, UnaryResource]
 
 class AllocationSchedulingProblem(
     CumulativeResourceProblem[Task, Resource],
+    NonRenewableResourceProblem[Task, NonRenewableResource],
     AllocationProblem[Task, UnaryResource],
-    Generic[Task, UnaryResource, CumulativeResource],
+    Generic[Task, UnaryResource, CumulativeResource, NonRenewableResource],
 ):
     """Scheduling problem with unary resource allocation.
 
@@ -32,11 +38,13 @@ class AllocationSchedulingProblem(
     - multimode: the tasks have several mode on which the duration depends
     - cumulative: the tasks consume cumulative resources according to the chosen mode
     - allocation
+    - non-renewable: the tasks consume non-renewable resources according to the chosen mode
 
     Even though this class is generic but encompasses also more specific cases:
     - singlemode: actually only one mode per task
     - no cumulative ressources: if resources_list list only unary resources
     - no calendar: resource capacity can be given as a constant on [0, horizon)
+    - no non-renewable ressources: if non_renewable_resources_list empty
 
     We suppose that all renewable resources are
     - either cumulative ones
@@ -87,18 +95,23 @@ class AllocationSchedulingProblem(
 
 class AllocationSchedulingSolution(
     CumulativeResourceSolution[Task, Resource],
+    NonRenewableResourceSolution[Task, NonRenewableResource],
     AllocationSolution[Task, UnaryResource],
-    Generic[Task, UnaryResource, CumulativeResource],
+    Generic[Task, UnaryResource, CumulativeResource, NonRenewableResource],
 ):
     """Solution type associated to AllocationSchedulingProblem."""
 
-    problem: AllocationSchedulingProblem[Task, UnaryResource, CumulativeResource]
+    problem: AllocationSchedulingProblem[
+        Task, UnaryResource, CumulativeResource, NonRenewableResource
+    ]
 
-    def get_resource_consumption(self, resource: Resource, task: Task) -> int:
+    def get_renewable_resource_consumption(self, resource: Resource, task: Task) -> int:
         """"""
         if self.problem.is_unary_resource(resource=resource):
             # unary resources: 0 (not allocated) or 1 (allocated)
             return int(self.is_allocated(task=task, unary_resource=resource))
         else:
             # cumulative resources
-            return super().get_resource_consumption(resource=resource, task=task)
+            return super().get_renewable_resource_consumption(
+                resource=resource, task=task
+            )

--- a/src/discrete_optimization/generic_tasks_tools/cumulative_resource.py
+++ b/src/discrete_optimization/generic_tasks_tools/cumulative_resource.py
@@ -32,13 +32,13 @@ class CumulativeResourceProblem(
     """
 
     @abstractmethod
-    def get_resource_consumption(
+    def get_renewable_resource_consumption(
         self, resource: Resource, task: Task, mode: int
     ) -> int:
         """Get resource consumption of the task in the given mode
 
         Args:
-            resource:
+            resource: *renewable* resource
             task:
             mode: not used for single mode problems
 
@@ -73,7 +73,7 @@ class CumulativeResourceSolution(
 
     problem: CumulativeResourceProblem[Task, Resource]
 
-    def get_resource_consumption(self, resource: Resource, task: Task) -> int:
+    def get_renewable_resource_consumption(self, resource: Resource, task: Task) -> int:
         """Get resource consumption by given task.
 
         Default implementation works only for cumulative resources whose consumptions depend only on task mode.
@@ -86,7 +86,7 @@ class CumulativeResourceSolution(
 
         """
         if self.problem.is_cumulative_resource(resource):
-            return self.problem.get_resource_consumption(
+            return self.problem.get_renewable_resource_consumption(
                 resource=resource, task=task, mode=self.get_mode(task)
             )
         else:

--- a/src/discrete_optimization/generic_tasks_tools/non_renewable_resource.py
+++ b/src/discrete_optimization/generic_tasks_tools/non_renewable_resource.py
@@ -1,0 +1,154 @@
+#  Copyright (c) 2026 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+import logging
+from abc import abstractmethod
+from collections.abc import Hashable, Iterable
+from typing import Generic, TypeVar
+
+from discrete_optimization.generic_tasks_tools.base import Task
+from discrete_optimization.generic_tasks_tools.multimode import (
+    MultimodeProblem,
+    MultimodeSolution,
+)
+
+logger = logging.getLogger(__name__)
+
+NonRenewableResource = TypeVar("NonRenewableResource", bound=Hashable)
+
+
+class NonRenewableResourceProblem(
+    MultimodeProblem[Task], Generic[Task, NonRenewableResource]
+):
+    """Base class for problems dealing with non-renewable resources consumed by tasks.
+
+    The task consumption of these non-renewable resources is supposed to be determined entirely determined
+    by the task mode.
+
+    """
+
+    @property
+    @abstractmethod
+    def non_renewable_resources_list(self) -> list[NonRenewableResource]:
+        """Non-renewable resources used by the tasks."""
+        ...
+
+    @abstractmethod
+    def get_non_renewable_resource_capacity(
+        self, resource: NonRenewableResource
+    ) -> int:
+        """Get resource max capacity
+
+        Args:
+            resource:
+
+        Returns:
+
+        """
+        ...
+
+    @abstractmethod
+    def get_non_renewable_resource_consumption(
+        self, resource: NonRenewableResource, task: Task, mode: int
+    ) -> int:
+        """Get resource consumption of the task in the given mode
+
+        Args:
+            resource: non-renewable resource
+            task:
+            mode: not used for single mode problems
+
+        Returns:.
+
+        Raises:
+            ValueError: if resource consumption is depending on other variables than mode
+
+        """
+        ...
+
+
+class NonRenewableResourceSolution(
+    MultimodeSolution[Task], Generic[Task, NonRenewableResource]
+):
+    problem: NonRenewableResourceProblem[Task, NonRenewableResource]
+
+    def get_non_renewable_resource_consumption(
+        self, resource: NonRenewableResource, task: Task
+    ) -> int:
+        """Get resource consumption by given task.
+
+        Args:
+            resource:
+            task:
+
+        Returns:
+
+        """
+        return self.problem.get_non_renewable_resource_consumption(
+            resource=resource, task=task, mode=self.get_mode(task)
+        )
+
+    def check_non_renewable_resource_capacity_constraint(
+        self, resource: NonRenewableResource
+    ) -> bool:
+        """Check capacity constraint on given renewable resource."""
+        return self.check_non_renewable_resource_capacity_constraints(
+            resources=(resource,)
+        )
+
+    def check_non_renewable_resource_capacity_constraints(
+        self, resources: Iterable[NonRenewableResource]
+    ):
+        resources_consumption = {resource: 0 for resource in resources}
+        for task in self.problem.tasks_list:
+            for resource in resources:
+                resources_consumption[resource] += (
+                    self.get_non_renewable_resource_consumption(
+                        resource=resource, task=task
+                    )
+                )
+        resources_capa_violation = {
+            resource: conso
+            > self.problem.get_non_renewable_resource_capacity(resource=resource)
+            for resource, conso in resources_consumption.items()
+        }
+        if any(resources_capa_violation.values()):
+            logger.debug("Violations on non-renewable resource capacities:")
+            for resource, violation in resources_capa_violation.items():
+                if violation:
+                    logger.debug(f"resource '{resource}'")
+            return False
+        else:
+            return True
+
+    def check_all_non_renewable_resource_capacity_constraints(self) -> bool:
+        """Check capacity constraint on all renewable resources."""
+        return self.check_non_renewable_resource_capacity_constraints(
+            resources=self.problem.non_renewable_resources_list
+        )
+
+
+class WithoutNonRenewableResourceProblem(
+    NonRenewableResourceProblem[Task, NonRenewableResource]
+):
+    """Mixin for problem without non-renewable resources.
+
+    To be used has an additional mixin with generic `AllocationSchedulingProblem`.
+
+    """
+
+    @property
+    def non_renewable_resources_list(self) -> list[NonRenewableResource]:
+        return []
+
+    def get_non_renewable_resource_capacity(
+        self, resource: NonRenewableResource
+    ) -> int:
+        raise RuntimeError("This problem has no non-renewable resource.")
+
+    def get_non_renewable_resource_consumption(
+        self, resource: NonRenewableResource, task: Task, mode: int
+    ) -> int:
+        raise RuntimeError("This problem has no non-renewable resource.")

--- a/src/discrete_optimization/generic_tasks_tools/renewable_resource.py
+++ b/src/discrete_optimization/generic_tasks_tools/renewable_resource.py
@@ -158,7 +158,7 @@ class RenewableResourceSolution(SchedulingSolution[Task], Generic[Task, Resource
     problem: RenewableResourceProblem[Task, Resource]
 
     @abstractmethod
-    def get_resource_consumption(self, resource: Resource, task: Task) -> int:
+    def get_renewable_resource_consumption(self, resource: Resource, task: Task) -> int:
         """Get resource consumption by given task.
 
         Args:
@@ -170,15 +170,17 @@ class RenewableResourceSolution(SchedulingSolution[Task], Generic[Task, Resource
         """
         ...
 
-    def check_resource_capacity_constraint(self, resource: Resource) -> bool:
+    def check_renewable_resource_capacity_constraint(self, resource: Resource) -> bool:
         """Check capacity constraint on given renewable resource."""
-        return self._check_resources_capacity_constraint_np(resources=(resource,))
+        return self.check_renewable_resource_capacity_constraints(resources=(resource,))
 
-    def _check_resource_capacity_constraint_naive(self, resource: Resource) -> bool:
+    def _check_renewable_resource_capacity_constraint_naive(
+        self, resource: Resource
+    ) -> bool:
         makespan = self.get_max_end_time()
         return all(
             sum(
-                self.get_resource_consumption(resource=resource, task=task)
+                self.get_renewable_resource_consumption(resource=resource, task=task)
                 for task in self.get_running_tasks(time=t)
             )
             <= value
@@ -188,7 +190,7 @@ class RenewableResourceSolution(SchedulingSolution[Task], Generic[Task, Resource
             if t < makespan
         )
 
-    def _check_resources_capacity_constraint_np(
+    def _check_renewable_resource_capacity_constraint_np(
         self, resources: Iterable[Resource]
     ) -> bool:
         makespan = self.get_max_end_time()
@@ -200,7 +202,9 @@ class RenewableResourceSolution(SchedulingSolution[Task], Generic[Task, Resource
             end = self.get_end_time(task)
             for resource in resources:
                 resources_consumption[resource][start:end] += (
-                    self.get_resource_consumption(resource=resource, task=task)
+                    self.get_renewable_resource_consumption(
+                        resource=resource, task=task
+                    )
                 )
 
         resources_capa_violation = {
@@ -228,7 +232,7 @@ class RenewableResourceSolution(SchedulingSolution[Task], Generic[Task, Resource
         else:
             return True
 
-    def check_resources_capacity_constraints(
+    def check_renewable_resource_capacity_constraints(
         self, resources: Iterable[Resource]
     ) -> bool:
         """Check capacity constraint respected on given resources.
@@ -236,11 +240,13 @@ class RenewableResourceSolution(SchedulingSolution[Task], Generic[Task, Resource
         Do it simultaneously on all resources to optimize computation time.
 
         """
-        return self._check_resources_capacity_constraint_np(resources=resources)
+        return self._check_renewable_resource_capacity_constraint_np(
+            resources=resources
+        )
 
-    def check_all_resource_capacity_constraints(self) -> bool:
+    def check_all_renewable_resource_capacity_constraints(self) -> bool:
         """Check capacity constraint on all renewable resources."""
-        return self._check_resources_capacity_constraint_np(
+        return self.check_renewable_resource_capacity_constraints(
             resources=self.problem.renewable_resources_list
         )
 

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat.py
@@ -30,6 +30,10 @@ from discrete_optimization.generic_tasks_tools.multimode import (
 from discrete_optimization.generic_tasks_tools.multimode_scheduling import (
     MultimodeSchedulingProblem,
 )
+from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
+    NonRenewableResource,
+    NonRenewableResourceProblem,
+)
 from discrete_optimization.generic_tasks_tools.renewable_resource import (
     RenewableResourceProblem,
     Resource,
@@ -764,12 +768,7 @@ class CumulativeResourceSchedulingCpSatSolver(
     MultimodeSchedulingCpSatSolver[Task],
     Generic[Task, Resource],
 ):
-    """Base class for cpast solvers dealing with scheduling problems handling cumulative resources.
-
-    This class manages the creation of interval variables for each (task, mode) tuple, with
-    If actually single mode  (only 1 mode per task), it
-
-    """
+    """Base class for cpsat solvers dealing with scheduling problems handling cumulative resources."""
 
     problem: CumulativeResourceProblem[Task, Resource]
 
@@ -780,7 +779,7 @@ class CumulativeResourceSchedulingCpSatSolver(
             return [
                 (
                     self.get_task_mode_interval(task=task, mode=mode),
-                    self.problem.get_resource_consumption(
+                    self.problem.get_renewable_resource_consumption(
                         resource=resource, task=task, mode=mode
                     ),
                 )
@@ -793,15 +792,47 @@ class CumulativeResourceSchedulingCpSatSolver(
             )
 
 
+class NonRenewableCpSatSolver(
+    MultimodeCpSatSolver[Task], Generic[Task, NonRenewableResource]
+):
+    """Base class for cpsat solvers dealing with problem with non-renewable resources."""
+
+    problem: NonRenewableResourceProblem
+
+    def create_non_renewable_resources_constraint(self, resource: NonRenewableResource):
+        """Add the constraint for a non-renewable resource to the cpsat model.
+
+        Constraint ensuring that the total demand on the given resource stay below its capacity.
+
+        """
+        self.cp_model.add(
+            sum(
+                self.get_task_mode_is_present_variable(task=task, mode=mode) * conso
+                for task in self.problem.tasks_list
+                for mode in self.problem.get_task_modes(task)
+                if (
+                    conso := self.problem.get_non_renewable_resource_consumption(
+                        resource=resource, task=task, mode=mode
+                    )
+                )
+                > 0
+            )
+            <= self.problem.get_non_renewable_resource_capacity(resource)
+        )
+
+
 Resource = UnaryOrCumulativeResource
 
 
 class AllocationSchedulingCpSatSolver(
     CumulativeResourceSchedulingCpSatSolver[Task, Resource],
+    NonRenewableCpSatSolver[Task, NonRenewableResource],
     AllocationCpSatSolver[Task, UnaryResource],
-    Generic[Task, UnaryResource, CumulativeResource],
+    Generic[Task, UnaryResource, CumulativeResource, NonRenewableResource],
 ):
-    problem: AllocationSchedulingProblem[Task, UnaryResource, CumulativeResource]
+    problem: AllocationSchedulingProblem[
+        Task, UnaryResource, CumulativeResource, NonRenewableResource
+    ]
 
     def get_resource_consumption_intervals(
         self, resource: Resource

--- a/src/discrete_optimization/rcpsp/problem.py
+++ b/src/discrete_optimization/rcpsp/problem.py
@@ -23,6 +23,9 @@ from discrete_optimization.generic_tasks_tools.cumulative_resource import (
 from discrete_optimization.generic_tasks_tools.multimode_scheduling import (
     MultimodeSchedulingProblem,
 )
+from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
+    NonRenewableResourceProblem,
+)
 from discrete_optimization.generic_tasks_tools.precedence import PrecedenceProblem
 from discrete_optimization.generic_tasks_tools.renewable_resource import (
     convert_calendar_to_availability_intervals,
@@ -43,7 +46,12 @@ from discrete_optimization.rcpsp.fast_function import (
     sgs_fast,
     sgs_fast_partial_schedule_incomplete_permutation_tasks,
 )
-from discrete_optimization.rcpsp.solution import RcpspSolution, Resource, Task
+from discrete_optimization.rcpsp.solution import (
+    NonRenewableResource,
+    RcpspSolution,
+    Resource,
+    Task,
+)
 from discrete_optimization.rcpsp.special_constraints import (
     PairModeConstraint,
     SpecialConstraintsDescription,
@@ -61,14 +69,16 @@ class ScheduleGenerationScheme(Enum):
 class RcpspProblem(
     PrecedenceProblem[Task],
     CumulativeResourceProblem[Task, Resource],
+    NonRenewableResourceProblem[Task, NonRenewableResource],
     MultimodeSchedulingProblem[Task],
 ):
     """Main class for RCPSP problem.
 
     Attributes:
         resources (dict[str, Union[int, list[int]): mapping: name -> number of resources available,
-            either at each time (-if an integer),
+            either at each time (if an integer),
             or time step by time step (if a list of integers).
+            For non-renewable resources, should be an integer or a constant list (i.e. with same integer repeated)
         non_renewable_resources (list[str]): list of resources (specified by name) that are non-renewable
         mode_details (dict[Hashable, dict[int, dict[str, int]]]): task -> (mode number -> resource needs and duration)
             Ex:
@@ -323,12 +333,20 @@ class RcpspProblem(
                 )
                 > 1
             )
-            if not self.is_calendar:
+            if self.is_calendar:
+                # consolidate calendars: same length = horizon, missing values = 0
                 self.resources = {
-                    r: self.resources[r]
-                    if np.isscalar(self.resources[r])
-                    else self.resources[r][0]  # type: ignore
-                    for r in self.resources
+                    r: [int(calendar)] * self.horizon
+                    if np.isscalar(calendar)
+                    else list(calendar)[: self.horizon]
+                    + [0] * (self.horizon - len(calendar))
+                    for r, calendar in self.resources.items()
+                }
+            else:
+                # keep only integers
+                self.resources = {
+                    r: int(calendar) if np.isscalar(calendar) else int(calendar[0])
+                    for r, calendar in self.resources.items()
                 }
         self.update_resource_availabilities()
 
@@ -339,6 +357,25 @@ class RcpspProblem(
     @property
     def tasks_list(self) -> list[Task]:
         return self._tasks_list
+
+    @property
+    def non_renewable_resources_list(self) -> list[NonRenewableResource]:
+        return self.non_renewable_resources
+
+    def get_non_renewable_resource_capacity(
+        self, resource: NonRenewableResource
+    ) -> int:
+        capacity = self.resources[resource]
+        if np.isscalar(capacity):
+            return capacity
+        else:
+            return capacity[0]
+
+    def get_non_renewable_resource_consumption(
+        self, resource: NonRenewableResource, task: Task, mode: int
+    ) -> int:
+        mode_detail = self.mode_details[task][mode]
+        return mode_detail.get(resource, 0)
 
     @property
     def renewable_resources_list(self) -> list[Resource]:
@@ -363,10 +400,7 @@ class RcpspProblem(
             raise ValueError(f"{resource} is not a cumulative resource of the problem.")
         else:
             mode_detail = self.mode_details[task][mode]
-            if resource not in mode_detail:
-                return 0
-            else:
-                return mode_detail[resource]
+            return mode_detail.get(resource, 0)
 
     def is_cumulative_resource(self, resource: Resource) -> bool:
         return resource in self.resources_list
@@ -525,20 +559,9 @@ class RcpspProblem(
             return False
 
         # Check for non-renewable resource violation
-        modes_dict = self.build_mode_dict(
-            rcpsp_modes_from_solution=variable.rcpsp_modes
-        )
-        for res in self.non_renewable_resources:
-            usage = 0
-            for act_id in variable.rcpsp_schedule:
-                mode = modes_dict[act_id]
-                usage += self.mode_details[act_id][mode][res]
-                if usage > self.get_max_resource_capacity(res):
-                    logger.debug(
-                        f"Non-renewable resource violation: act_id: {act_id}"
-                        f"res {res} res_usage: {usage} res_avail: {self.resources[res]}"
-                    )
-                    return False
+        if not variable.check_all_non_renewable_resource_capacity_constraints():
+            return False
+
         # Check precedences / successors
         for act_id in list(self.successors.keys()):
             for succ_id in self.successors[act_id]:

--- a/src/discrete_optimization/rcpsp/problem.py
+++ b/src/discrete_optimization/rcpsp/problem.py
@@ -356,7 +356,7 @@ class RcpspProblem(
             calendar=self.resources[resource], horizon=self.horizon
         )
 
-    def get_resource_consumption(
+    def get_renewable_resource_consumption(
         self, resource: Resource, task: Task, mode: int
     ) -> int:
         if not self.is_cumulative_resource(resource):
@@ -520,7 +520,8 @@ class RcpspProblem(
             ):
                 return False
 
-        if not variable.check_all_resource_capacity_constraints():
+        # Check for cumumative resource violation
+        if not variable.check_all_renewable_resource_capacity_constraints():
             return False
 
         # Check for non-renewable resource violation

--- a/src/discrete_optimization/rcpsp/problem_specialized_constraints.py
+++ b/src/discrete_optimization/rcpsp/problem_specialized_constraints.py
@@ -1161,7 +1161,9 @@ def generate_schedule_from_permutation_serial_sgs_partial_schedule_preempptive(
                         for res in rcpsp_problem.resources_list:
                             for t in range(starts[ac][-1], ends[ac][-1]):
                                 resource_avail_in_time[res][t] -= (
-                                    rcpsp_problem.mode_details[ac][modes_dict[ac]][res]
+                                    rcpsp_problem.mode_details[ac][modes_dict[ac]].get(
+                                        res, 0
+                                    )
                                 )
                                 if resource_avail_in_time[res][t] < 0:
                                     logger.warning(
@@ -1178,7 +1180,9 @@ def generate_schedule_from_permutation_serial_sgs_partial_schedule_preempptive(
                         for res in rcpsp_problem.resources_list:
                             for t in range(starts[ac][-1], ends[ac][-1]):
                                 resource_avail_in_time[res][t] -= (
-                                    rcpsp_problem.mode_details[ac][modes_dict[ac]][res]
+                                    rcpsp_problem.mode_details[ac][modes_dict[ac]].get(
+                                        res, 0
+                                    )
                                 )
                                 if resource_avail_in_time[res][t] < 0:
                                     logger.warning(
@@ -1192,7 +1196,7 @@ def generate_schedule_from_permutation_serial_sgs_partial_schedule_preempptive(
                                         resource_avail_in_time[res][tt] -= (
                                             rcpsp_problem.mode_details[ac][
                                                 modes_dict[ac]
-                                            ][res]
+                                            ].get(res, 0)
                                         )
                                         if resource_avail_in_time[res][tt] < 0:
                                             unfeasible_non_renewable_resources = True

--- a/src/discrete_optimization/rcpsp/solution.py
+++ b/src/discrete_optimization/rcpsp/solution.py
@@ -19,6 +19,9 @@ from discrete_optimization.generic_tasks_tools.cumulative_resource import (
 from discrete_optimization.generic_tasks_tools.multimode_scheduling import (
     MultimodeSchedulingSolution,
 )
+from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
+    NonRenewableResourceSolution,
+)
 from discrete_optimization.generic_tools.do_problem import RobustProblem
 
 if TYPE_CHECKING:  # avoid circular imports due to annotations
@@ -26,6 +29,7 @@ if TYPE_CHECKING:  # avoid circular imports due to annotations
 
 Task = Hashable
 Resource = str
+NonRenewableResource = str
 
 
 class TaskDetails:
@@ -35,7 +39,9 @@ class TaskDetails:
 
 
 class RcpspSolution(
-    CumulativeResourceSolution[Task, Resource], MultimodeSchedulingSolution[Task]
+    CumulativeResourceSolution[Task, Resource],
+    NonRenewableResourceSolution[Task, NonRenewableResource],
+    MultimodeSchedulingSolution[Task],
 ):
     """Solution to RcpspProblem problems.
 

--- a/src/discrete_optimization/rcpsp/solvers/cpsat.py
+++ b/src/discrete_optimization/rcpsp/solvers/cpsat.py
@@ -419,7 +419,7 @@ class CpSatResourceRcpspSolver(CpSatRcpspSolver):
                 self.get_task_mode_is_present_variable(task=task, mode=mode)
                 for task in self.problem.tasks_list
                 for mode in self.problem.get_task_modes(task=task)
-                if self.problem.get_resource_consumption(
+                if self.problem.get_renewable_resource_consumption(
                     resource=resource, task=task, mode=mode
                 )
                 > 0

--- a/src/discrete_optimization/rcpsp/solvers/cpsat.py
+++ b/src/discrete_optimization/rcpsp/solvers/cpsat.py
@@ -22,6 +22,7 @@ from ortools.sat.python.cp_model import (
 from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
 from discrete_optimization.generic_tasks_tools.solvers.cpsat import (
     CumulativeResourceSchedulingCpSatSolver,
+    NonRenewableCpSatSolver,
 )
 from discrete_optimization.generic_tools.do_problem import ParamsObjectiveFunction
 from discrete_optimization.generic_tools.do_solver import WarmstartMixin
@@ -37,6 +38,7 @@ from discrete_optimization.rcpsp.problem import (
     Resource,
     Task,
 )
+from discrete_optimization.rcpsp.solution import NonRenewableResource
 from discrete_optimization.rcpsp.solvers import RcpspSolver
 from discrete_optimization.rcpsp.special_constraints import PairModeConstraint
 from discrete_optimization.rcpsp.utils import (
@@ -49,6 +51,7 @@ logger = logging.getLogger(__name__)
 
 class CpSatRcpspSolver(
     CumulativeResourceSchedulingCpSatSolver[Task, Resource],
+    NonRenewableCpSatSolver[Task, NonRenewableResource],
     RcpspSolver,
     WarmstartMixin,
 ):
@@ -145,24 +148,10 @@ class CpSatRcpspSolver(
 
     def create_cumulative_constraint(
         self,
-        model: CpModel,
         resource: str,
-        is_present_var: dict[tuple[Hashable, int], IntVar],
     ):
         if resource in self.problem.non_renewable_resources:
-            task_modes_consuming = [
-                (
-                    (task, mode),
-                    self.problem.mode_details[task][mode].get(resource, 0),
-                )
-                for task in self.problem.tasks_list
-                for mode in self.problem.mode_details[task]
-                if self.problem.mode_details[task][mode].get(resource, 0) > 0
-            ]
-            model.Add(
-                sum([is_present_var[x[0]] * x[1] for x in task_modes_consuming])
-                <= self.problem.get_max_resource_capacity(resource)
-            )
+            self.create_non_renewable_resources_constraint(resource=resource)
         else:
             self.create_renewable_resources_constraint(resource=resource)
 
@@ -312,9 +301,7 @@ class CpSatRcpspSolver(
         resources = self.problem.resources_list
         for resource in resources:
             self.create_cumulative_constraint(
-                model=model,
                 resource=resource,
-                is_present_var=is_present_var,
             )
         if include_special_constraints:
             if self.problem.special_constraints.pair_mode_constraint is not None:
@@ -392,42 +379,32 @@ class CpSatResourceRcpspSolver(CpSatRcpspSolver):
         model: CpModel,
         resource: str,
         is_used_resource: dict[str, IntVar],
-        is_present_var: dict[tuple[Hashable, int], IntVar],
     ):
+        # resource consumption <= capacity
         if resource in self.problem.non_renewable_resources:
-            task_modes_consuming = [
-                (
-                    (task, mode),
-                    int(self.problem.mode_details[task][mode].get(resource, 0)),
+            self.create_non_renewable_resources_constraint(resource=resource)
+
+            def get_resource_consumption(task: Task, mode: int) -> int:
+                return self.problem.get_non_renewable_resource_consumption(
+                    resource=resource, task=task, mode=mode
                 )
-                for task in self.problem.tasks_list
-                for mode in self.problem.mode_details[task]
-                if self.problem.mode_details[task][mode].get(resource, 0) > 0
-            ]
-            model.Add(
-                sum([is_present_var[x[0]] * x[1] for x in task_modes_consuming])
-                <= int(self.problem.get_max_resource_capacity(resource))
-            )
-            model.AddMaxEquality(
-                is_used_resource[resource],
-                [is_present_var[x[0]] for x in task_modes_consuming],
-            )
         else:
             self.create_renewable_resources_constraint(resource=resource)
 
-            resource_is_present_vars = [
-                self.get_task_mode_is_present_variable(task=task, mode=mode)
-                for task in self.problem.tasks_list
-                for mode in self.problem.get_task_modes(task=task)
-                if self.problem.get_renewable_resource_consumption(
+            def get_resource_consumption(task: Task, mode: int) -> int:
+                return self.problem.get_renewable_resource_consumption(
                     resource=resource, task=task, mode=mode
                 )
-                > 0
-            ]
-            if len(resource_is_present_vars) > 0:
-                model.add_max_equality(
-                    is_used_resource[resource], resource_is_present_vars
-                )
+
+        # is_used_resource definition
+        resource_is_present_vars = [
+            self.get_task_mode_is_present_variable(task=task, mode=mode)
+            for task in self.problem.tasks_list
+            for mode in self.problem.get_task_modes(task=task)
+            if get_resource_consumption(task=task, mode=mode) > 0
+        ]
+        if len(resource_is_present_vars) > 0:
+            model.add_max_equality(is_used_resource[resource], resource_is_present_vars)
 
     def init_model(self, **kwargs):
         include_special_constraints = kwargs.get(
@@ -466,7 +443,6 @@ class CpSatResourceRcpspSolver(CpSatRcpspSolver):
                 model=model,
                 resource=resource,
                 is_used_resource=is_used_resource,
-                is_present_var=is_present_var,
             )
         if include_special_constraints:
             if self.problem.special_constraints.pair_mode_constraint is not None:
@@ -579,31 +555,24 @@ class CpSatCumulativeResourceRcpspSolver(CpSatRcpspSolver):
         is_present_var: dict[tuple[Hashable, int], IntVar],
         use_overlap_for_disjunctive_resource: bool,
     ):
-        if resource in self.problem.non_renewable_resources:
-            task_modes_consuming = [
-                (
-                    (task, mode),
-                    self.problem.mode_details[task][mode].get(resource, 0),
-                )
-                for task in self.problem.tasks_list
-                for mode in self.problem.mode_details[task]
-                if self.problem.mode_details[task][mode].get(resource, 0) > 0
-            ]
-            model.Add(
-                sum([is_present_var[x[0]] * x[1] for x in task_modes_consuming])
-                <= resource_capacity_var[resource]
+        task_modes_consuming = [
+            (
+                (task, mode),
+                self.problem.mode_details[task][mode].get(resource, 0),
             )
+            for task in self.problem.tasks_list
+            for mode in self.problem.mode_details[task]
+            if self.problem.mode_details[task][mode].get(resource, 0) > 0
+        ]
+        if resource in self.problem.non_renewable_resources:
+            self.create_non_renewable_resources_constraint(resource=resource)
+            if len(task_modes_consuming) > 0:
+                model.Add(
+                    sum([is_present_var[x[0]] * x[1] for x in task_modes_consuming])
+                    <= resource_capacity_var[resource]
+                )
         else:
             self.create_renewable_resources_constraint(resource=resource)
-            task_modes_consuming = [
-                (
-                    (task, mode),
-                    self.problem.mode_details[task][mode].get(resource, 0),
-                )
-                for task in self.problem.tasks_list
-                for mode in self.problem.mode_details[task]
-                if self.problem.mode_details[task][mode].get(resource, 0) > 0
-            ]
             if len(task_modes_consuming) == 0:
                 # when empty, the constraints don't work !
                 return

--- a/src/discrete_optimization/rcpsp/solvers/dp.py
+++ b/src/discrete_optimization/rcpsp/solvers/dp.py
@@ -647,7 +647,7 @@ class DpRcpspSolver(DpSolver, RcpspSolver, WarmstartMixin):
         merged_calendars = []
         for res in self.problem.resources_list:
             cld = create_resource_consumption_from_calendar(
-                self.problem.get_resource_availability_array(res)
+                np.array(self.problem.get_resource_availability_array(res))
             )
             for t in cld:
                 t.update({res: t["value"]})

--- a/src/discrete_optimization/rcpsp_multiskill/multiskill_to_rcpsp.py
+++ b/src/discrete_optimization/rcpsp_multiskill/multiskill_to_rcpsp.py
@@ -73,7 +73,10 @@ class MultiSkillToRcpsp:
                     dtype=np.int_,
                 )
             calendar_worker_type[map_names_to_understandable[worker_type]] = calend
-        resources_dict = self.multiskill_model.resources_availability
+        resources_dict = {
+            r: np.array([av]) if np.isscalar(av) else np.array(av)
+            for r, av in self.multiskill_model.resources_availability.items()
+        }
         usage_worker_in_chosen_modes = {k: 0 for k in calendar_worker_type}
         for k in calendar_worker_type:
             resources_dict[k] = calendar_worker_type[k]

--- a/src/discrete_optimization/rcpsp_multiskill/problem.py
+++ b/src/discrete_optimization/rcpsp_multiskill/problem.py
@@ -11,7 +11,7 @@ from collections.abc import Hashable
 from copy import deepcopy
 from enum import Enum
 from functools import cache, partial
-from typing import Iterable, Optional, Union
+from typing import Optional, Union
 
 import numpy as np
 import scipy.stats as ss
@@ -930,7 +930,7 @@ def sgs_multi_skill(solution: VariantMultiskillRcpspSolution):
                 if res in problem.non_renewable_resources:
                     resource_avail_in_time[res][end_t + 1 :] -= problem.mode_details[
                         act_id
-                    ][modes_dict[act_id]][res]
+                    ][modes_dict[act_id]].get(res, 0)
                     if resource_avail_in_time[res][-1] < 0:
                         unfeasible_non_renewable_resources = True
             if worker_ids is not None:
@@ -1220,7 +1220,7 @@ def sgs_multi_skill_preemptive(solution: VariantPreemptiveMultiskillRcpspSolutio
                     ].get(res, 0)
                     if res in problem.non_renewable_resources and e == end_t:
                         resource_avail_in_time[res][end_t + 1 :] -= (
-                            problem.mode_details[act_id][modes_dict[act_id]][res]
+                            problem.mode_details[act_id][modes_dict[act_id]].get(res, 0)
                         )
                         if resource_avail_in_time[res][-1] < 0:
                             unfeasible_non_renewable_resources = True
@@ -1327,7 +1327,7 @@ def sgs_multi_skill_preemptive_partial_schedule(
                 ].get(res, 0)
                 if res in problem.non_renewable_resources and e == end_time[-1]:
                     resource_avail_in_time[res][end_time[-1] + 1 :] -= (
-                        problem.mode_details[c][modes_dict[c]][res]
+                        problem.mode_details[c][modes_dict[c]].get(res, 0)
                     )
                     if resource_avail_in_time[res][-1] < 0:
                         unfeasible_non_renewable_resources = True
@@ -1363,7 +1363,7 @@ def sgs_multi_skill_preemptive_partial_schedule(
                 ].get(res, 0)
                 if res in problem.non_renewable_resources and e == end_time[-1]:
                     resource_avail_in_time[res][end_time[-1] + 1 :] -= (
-                        problem.mode_details[c][modes_dict[c]][res]
+                        problem.mode_details[c][modes_dict[c]].get(res, 0)
                     )
                     if resource_avail_in_time[res][-1] < 0:
                         unfeasible_non_renewable_resources = True
@@ -1556,7 +1556,7 @@ def sgs_multi_skill_preemptive_partial_schedule(
                     ].get(res, 0)
                     if res in problem.non_renewable_resources and e == end_t:
                         resource_avail_in_time[res][end_t + 1 :] -= (
-                            problem.mode_details[act_id][modes_dict[act_id]][res]
+                            problem.mode_details[act_id][modes_dict[act_id]].get(res, 0)
                         )
                         if resource_avail_in_time[res][-1] < 0:
                             unfeasible_non_renewable_resources = True
@@ -1653,7 +1653,7 @@ def sgs_multi_skill_partial_schedule(
             if res in problem.non_renewable_resources:
                 resource_avail_in_time[res][end_time:] -= problem.mode_details[c][
                     modes_dict[c]
-                ][res]
+                ].get(res, 0)
                 if resource_avail_in_time[res][-1] < 0:
                     unfeasible_non_renewable_resources = True
         for unit in completed_tasks[c].resource_units_used:
@@ -1688,7 +1688,7 @@ def sgs_multi_skill_partial_schedule(
             if res in problem.non_renewable_resources:
                 resource_avail_in_time[res][end_time:] -= problem.mode_details[c][
                     modes_dict[c]
-                ][res]
+                ].get(res, 0)
                 if resource_avail_in_time[res][-1] < 0:
                     unfeasible_non_renewable_resources = True
         for unit in scheduled_tasks_start_times[c].resource_units_used:
@@ -1822,7 +1822,7 @@ def sgs_multi_skill_partial_schedule(
                 if res in problem.non_renewable_resources:
                     resource_avail_in_time[res][end_t + 1 :] -= problem.mode_details[
                         act_id
-                    ][modes_dict[act_id]][res]
+                    ][modes_dict[act_id]].get(res, 0)
                     if resource_avail_in_time[res][-1] < 0:
                         unfeasible_non_renewable_resources = True
             if worker_ids is not None:
@@ -2033,9 +2033,7 @@ class MultiskillRcpspProblem(
         self.skills_list = sorted(self.skills_set)
 
         self.resources_set = resources_set
-        self.resources_list = list(self.resources_set)
         self.non_renewable_resources = non_renewable_resources
-        self._non_renewable_resources_list = list(non_renewable_resources)
         self.resources_availability = resources_availability
         self.employees = employees
         self.mode_details = mode_details
@@ -2093,6 +2091,42 @@ class MultiskillRcpspProblem(
         self.partial_preemption_data = partial_preemption_data
         self.always_releasable_resources = always_releasable_resources
         self.never_releasable_resources = never_releasable_resources
+        self.strictly_disjunctive_subtasks = strictly_disjunctive_subtasks
+        if resource_blocking_data is None:
+            self.resource_blocking_data = []
+        else:
+            self.resource_blocking_data = resource_blocking_data
+
+        self.update_problem()
+
+    def update_problem(self):
+        """Method to call when some attributes have been modified.
+
+        It recomputes what is needed (numba functions, calendars, ...)
+        It take into account modifications of:
+        - horizon
+        - resource/employee calendars
+        - duration/resource consumption/skill requirement for a given task, mode
+        - special constraints
+        - successors
+
+        NB: special constraints may add precedence constraints. A new call to update_problem()
+        with different special constraints will not roll back the updated precedence constraints.
+
+        """
+        self._max_skill_over_worker_to_recompute = True
+        self.update_resource_sets()
+        self.create_employee_task_compatibility()
+        self.update_calendars()
+        self.update_special_constraints()
+        self.update_functions()
+
+    def update_resource_sets(self):
+        assert self.resources_set == set(self.resources_availability), (
+            "resources_set should match resources_availability keys."
+        )
+        self.resources_list = list(self.resources_set)
+        self._non_renewable_resources_list = list(self.non_renewable_resources)
         if all(
             f is None
             for f in [
@@ -2142,34 +2176,6 @@ class MultiskillRcpspProblem(
                     for m in self.partial_preemption_data[t]
                 ):
                     self.always_releasable_resources.add(r)
-        self.strictly_disjunctive_subtasks = strictly_disjunctive_subtasks
-        if resource_blocking_data is None:
-            self.resource_blocking_data = []
-        else:
-            self.resource_blocking_data = resource_blocking_data
-
-        self.update_problem()
-
-    def update_problem(self):
-        """Method to call when some attributes have been modified.
-
-        It recomputes what is needed (numba functions, calendars, ...)
-        It take into account modifications of:
-        - horizon
-        - resource/employee calendars
-        - duration/resource consumption/skill requirement for a given task, mode
-        - special constraints
-        - successors
-
-        NB: special constraints may add precedence constraints. A new call to update_problem()
-        with different special constraints will not roll back the updated precedence constraints.
-
-        """
-        self._max_skill_over_worker_to_recompute = True
-        self.create_employee_task_compatibility()
-        self.update_calendars()
-        self.update_special_constraints()
-        self.update_functions()
 
     def update_special_constraints(self):
         self.do_special_constraints = self.special_constraints is not None
@@ -2197,31 +2203,22 @@ class MultiskillRcpspProblem(
         self.predecessors = self.graph.predecessors_dict
 
     def update_calendars(self):
-        self.is_calendar = False
-        if any(
-            isinstance(self.resources_availability[res], Iterable)
-            for res in self.resources_availability
-        ):
-            self.is_calendar = (
-                max(
-                    [
-                        len(
-                            set(self.resources_availability[res])
-                            if isinstance(self.resources_availability[res], Iterable)
-                            else {self.resources_availability[res]}
-                        )
-                        for res in self.resources_availability
-                    ]
-                )
-                > 1
+        self.is_calendar = len(self.resources_availability) > 0
+        self.max_resource_capacity = {
+            r: max(self.resources_availability[r]) for r in self.resources_availability
+        }
+        # consolidate calendars -> list of size horizon
+        self.resources_availability = {
+            res: (
+                # non-renewable: constant calendar with max capacity
+                [calendar[0]] * self.horizon
+                if res in self.non_renewable_resources
+                # renewable: fill missing values with 0
+                else list(calendar)[: self.horizon]
+                + [0] * (self.horizon - len(calendar))
             )
-        self.max_resource_capacity = {}
-        for r in self.resources_availability:
-            if isinstance(self.resources_availability[r], Iterable):
-                self.max_resource_capacity[r] = max(self.resources_availability[r])
-            else:
-                self.max_resource_capacity[r] = self.resources_availability[r]
-
+            for res, calendar in self.resources_availability.items()
+        }
         self.total_number_step_available = {
             employee: sum(self.employees[employee].calendar_employee[: self.horizon])
             for employee in self.employees
@@ -2557,9 +2554,10 @@ class MultiskillRcpspProblem(
         for task in self.tasks_list:
             mode = rcpsp_sol.modes[task]
             required_skills = {
-                s: self.mode_details[task][mode][s]
+                s: conso
                 for s in self.mode_details[task][mode]
-                if s in self.skills_set and self.mode_details[task][mode][s] > 0
+                if s in self.skills_set
+                and (conso := self.mode_details[task][mode][s]) > 0
             }
             # Skills for the given task are used
             if len(required_skills) > 0:
@@ -2714,7 +2712,7 @@ class MultiskillRcpspProblem(
             usage = 0
             for act_id in self.tasks_list:
                 mode = rcpsp_sol.modes[act_id]
-                usage += self.mode_details[act_id][mode][res]
+                usage += self.mode_details[act_id][mode].get(res, 0)
             if usage > self.resources_availability[res][0]:
                 logger.debug(
                     (

--- a/src/discrete_optimization/rcpsp_multiskill/problem.py
+++ b/src/discrete_optimization/rcpsp_multiskill/problem.py
@@ -112,10 +112,13 @@ Task = Hashable
 UnaryResource = Hashable
 CumulativeResource = str
 Resource = Union[CumulativeResource, UnaryResource]
+NonRenewableResource = str
 
 
 class MultiskillRcpspSolution(
-    AllocationSchedulingSolution[Task, UnaryResource, CumulativeResource],
+    AllocationSchedulingSolution[
+        Task, UnaryResource, CumulativeResource, NonRenewableResource
+    ],
 ):
     problem: MultiskillRcpspProblem
 
@@ -1981,7 +1984,9 @@ def intersect(i1, i2):
 
 
 class MultiskillRcpspProblem(
-    AllocationSchedulingProblem[Task, UnaryResource, CumulativeResource],
+    AllocationSchedulingProblem[
+        Task, UnaryResource, CumulativeResource, NonRenewableResource
+    ],
     PrecedenceProblem[Task],
 ):
     sgs: ScheduleGenerationScheme
@@ -2030,6 +2035,7 @@ class MultiskillRcpspProblem(
         self.resources_set = resources_set
         self.resources_list = list(self.resources_set)
         self.non_renewable_resources = non_renewable_resources
+        self._non_renewable_resources_list = list(non_renewable_resources)
         self.resources_availability = resources_availability
         self.employees = employees
         self.mode_details = mode_details
@@ -2231,6 +2237,20 @@ class MultiskillRcpspProblem(
         return self._tasks_list
 
     @property
+    def non_renewable_resources_list(self) -> list[NonRenewableResource]:
+        return self._non_renewable_resources_list
+
+    def get_non_renewable_resource_capacity(
+        self, resource: NonRenewableResource
+    ) -> int:
+        return self.max_resource_capacity[resource]
+
+    def get_non_renewable_resource_consumption(
+        self, resource: NonRenewableResource, task: Task, mode: int
+    ) -> int:
+        return self.mode_details[task][mode].get(resource, 0)
+
+    @property
     def cumulative_resources_list(self) -> list[CumulativeResource]:
         """List of cumulative resources.
 
@@ -2247,7 +2267,7 @@ class MultiskillRcpspProblem(
             + [NB_EMPLOYEES_LB]
         )
 
-    def get_resource_consumption(
+    def get_renewable_resource_consumption(
         self, resource: CumulativeResource, task: Task, mode: int
     ) -> int:
         """Get resource consumption of the task in the given mode
@@ -2559,23 +2579,9 @@ class MultiskillRcpspProblem(
             return False
 
         # Check for non-renewable resource violation
-        for res in self.non_renewable_resources:
-            usage = 0
-            for act_id in self.tasks_list:
-                mode = rcpsp_sol.modes[act_id]
-                usage += self.mode_details[act_id][mode][res]
-            if usage > self.resources_availability[res][0]:
-                logger.debug(
-                    (
-                        "Non-renewable res",
-                        res,
-                        "res_usage: ",
-                        usage,
-                        "res_avail: ",
-                        self.resources_availability[res][0],
-                    )
-                )
-                return False
+        if not rcpsp_sol.check_all_non_renewable_resource_capacity_constraints():
+            return False
+
         # Check precedences / successors
         for act_id in list(self.successors.keys()):
             for succ_id in self.successors[act_id]:

--- a/src/discrete_optimization/rcpsp_multiskill/problem.py
+++ b/src/discrete_optimization/rcpsp_multiskill/problem.py
@@ -2555,7 +2555,7 @@ class MultiskillRcpspProblem(
 
         # Check for renewable resources capacity violations
         # include employees and cumulative resources
-        if not rcpsp_sol.check_all_resource_capacity_constraints():
+        if not rcpsp_sol.check_all_renewable_resource_capacity_constraints():
             return False
 
         # Check for non-renewable resource violation

--- a/src/discrete_optimization/rcpsp_multiskill/solvers/cpsat.py
+++ b/src/discrete_optimization/rcpsp_multiskill/solvers/cpsat.py
@@ -29,6 +29,7 @@ from discrete_optimization.rcpsp_multiskill.problem import (
     CumulativeResource,
     MultiskillRcpspProblem,
     MultiskillRcpspSolution,
+    NonRenewableResource,
     Task,
     UnaryResource,
 )
@@ -37,7 +38,9 @@ logger = logging.getLogger(__name__)
 
 
 class CpSatMultiskillRcpspSolver(
-    AllocationSchedulingCpSatSolver[Task, UnaryResource, CumulativeResource],
+    AllocationSchedulingCpSatSolver[
+        Task, UnaryResource, CumulativeResource, NonRenewableResource
+    ],
 ):
     hyperparameters = [
         CategoricalHyperparameter(
@@ -483,36 +486,9 @@ class CpSatMultiskillRcpspSolver(
     def create_constraint_resource(self):
         for r in self.problem.resources_list:
             if r in self.problem.non_renewable_resources:
-                self.create_non_renewable_res_constraint(r)
+                self.create_non_renewable_resources_constraint(r)
             else:
                 self.create_renewable_resources_constraint(r)
-
-    def create_non_renewable_res_constraint(self, res: str):
-        vars_consume = []
-        for task in self.problem.tasks_list:
-            modes = list(self.problem.mode_details[task].keys())
-            if len(modes) == 1:
-                if self.problem.mode_details[task][modes[0]].get(res, 0) > 0:
-                    vars_consume.append(
-                        (1, self.problem.mode_details[task][modes[0]][res])
-                    )
-            else:
-                for mode in modes:
-                    if self.problem.mode_details[task][mode].get(res, 0) > 0:
-                        vars_consume.append(
-                            (
-                                self.variables["mode_variable"]["is_present"][task][
-                                    mode
-                                ],
-                                self.problem.mode_details[task][mode][res],
-                            )
-                        )
-        self.cp_model.Add(
-            LinearExpr.weighted_sum(
-                [x[0] for x in vars_consume], [x[1] for x in vars_consume]
-            )
-            <= self.problem.get_max_resource_capacity(res)
-        )
 
     def create_disjunctive_worker(self):
         for worker in self.problem.employees:

--- a/src/discrete_optimization/rcpsp_multiskill/solvers/lp.py
+++ b/src/discrete_optimization/rcpsp_multiskill/solvers/lp.py
@@ -217,7 +217,7 @@ class MathOptMultiskillRcpspSolver(OrtoolsMathOptMilpSolver):
         for r, t in product(renewable, times):
             self.add_linear_constraint(
                 self.construct_linear_sum(
-                    int(self.problem.mode_details[task][mode][r])
+                    int(self.problem.mode_details[task][mode].get(r, 0))
                     * self.start_times[task][mode][time]
                     for task in self.start_times
                     for mode in self.start_times[task]
@@ -232,7 +232,7 @@ class MathOptMultiskillRcpspSolver(OrtoolsMathOptMilpSolver):
         for r in non_renewable:
             self.add_linear_constraint(
                 self.construct_linear_sum(
-                    int(self.problem.mode_details[task][mode][r])
+                    int(self.problem.mode_details[task][mode].get(r, 0))
                     * self.start_times[task][mode][time]
                     for task in self.start_times
                     for mode in self.start_times[task]

--- a/src/discrete_optimization/workforce/scheduling/problem.py
+++ b/src/discrete_optimization/workforce/scheduling/problem.py
@@ -20,6 +20,9 @@ from discrete_optimization.generic_tasks_tools.multimode import (
     SinglemodeProblem,
     SinglemodeSolution,
 )
+from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
+    WithoutNonRenewableResourceProblem,
+)
 from discrete_optimization.generic_tasks_tools.precedence import PrecedenceProblem
 from discrete_optimization.generic_tasks_tools.renewable_resource import (
     convert_calendar_to_availability_intervals,
@@ -46,10 +49,13 @@ Task = Hashable
 UnaryResource = Hashable
 CumulativeResource = str
 Resource = Union[UnaryResource, CumulativeResource]
+NonRenewableResource = str
 
 
 class AllocSchedulingSolution(
-    AllocationSchedulingSolution[Task, UnaryResource, CumulativeResource],
+    AllocationSchedulingSolution[
+        Task, UnaryResource, CumulativeResource, NonRenewableResource
+    ],
     SinglemodeSolution[Task],
 ):
     problem: AllocSchedulingProblem
@@ -98,7 +104,10 @@ class TasksDescription:
 
 
 class AllocSchedulingProblem(
-    AllocationSchedulingProblem[Task, UnaryResource, CumulativeResource],
+    AllocationSchedulingProblem[
+        Task, UnaryResource, CumulativeResource, NonRenewableResource
+    ],
+    WithoutNonRenewableResourceProblem[Task, NonRenewableResource],
     SinglemodeProblem[Task],
     PrecedenceProblem[Task],
 ):

--- a/src/discrete_optimization/workforce/scheduling/problem.py
+++ b/src/discrete_optimization/workforce/scheduling/problem.py
@@ -164,7 +164,7 @@ class AllocSchedulingProblem(
     def cumulative_resources_list(self) -> list[CumulativeResource]:
         return self.resources_list
 
-    def get_resource_consumption(
+    def get_renewable_resource_consumption(
         self, resource: Resource, task: Task, mode: int
     ) -> int:
         if self.is_cumulative_resource(resource):
@@ -551,7 +551,7 @@ def satisfy_renewable_resources(
     Returns:
 
     """
-    return solution.check_all_resource_capacity_constraints()
+    return solution.check_all_renewable_resource_capacity_constraints()
 
 
 def satisfy_calendars(

--- a/src/discrete_optimization/workforce/scheduling/solvers/cpsat.py
+++ b/src/discrete_optimization/workforce/scheduling/solvers/cpsat.py
@@ -42,6 +42,7 @@ from discrete_optimization.workforce.scheduling.problem import (
     AllocSchedulingProblem,
     AllocSchedulingSolution,
     CumulativeResource,
+    NonRenewableResource,
     Task,
     UnaryResource,
 )
@@ -94,7 +95,9 @@ class AdditionalCPConstraints:
 
 
 class CPSatAllocSchedulingSolver(
-    AllocationSchedulingCpSatSolver[Task, UnaryResource, CumulativeResource],
+    AllocationSchedulingCpSatSolver[
+        Task, UnaryResource, CumulativeResource, NonRenewableResource
+    ],
     SinglemodeCpSatSolver[Task],
     SolverAllocScheduling,
     WarmstartMixin,

--- a/tests/generic_tasks_tools/test_cumulative_resource.py
+++ b/tests/generic_tasks_tools/test_cumulative_resource.py
@@ -73,7 +73,7 @@ class MyCumulativeResourceProblem(CumulativeResourceProblem[Task, Resource]):
     def tasks_list(self) -> list[Task]:
         return list(self.mode_details)
 
-    def get_resource_consumption(
+    def get_renewable_resource_consumption(
         self, resource: Resource, task: Task, mode: int
     ) -> int:
         try:
@@ -167,34 +167,34 @@ def test_cumulative_resource_solution():
         modes={"task-1": 0, "task-2": 0},
         starts={"task-1": 0, "task-2": 0},
     )
-    assert solution.check_resource_capacity_constraint("R1")
-    assert not solution.check_resource_capacity_constraint("R5")
-    assert not solution.check_all_resource_capacity_constraints()
+    assert solution.check_renewable_resource_capacity_constraint("R1")
+    assert not solution.check_renewable_resource_capacity_constraint("R5")
+    assert not solution.check_all_renewable_resource_capacity_constraints()
     solution = MyCumulativeResourceSolution(
         problem=pb,
         modes={"task-1": 1, "task-2": 0},
         starts={"task-1": 2, "task-2": 3},
     )
-    assert not solution.check_all_resource_capacity_constraints()
+    assert not solution.check_all_renewable_resource_capacity_constraints()
     # ok
     solution = MyCumulativeResourceSolution(
         problem=pb,
         modes={"task-1": 0, "task-2": 0},
         starts={"task-1": 1, "task-2": 2},
     )
-    assert solution.check_all_resource_capacity_constraints()
+    assert solution.check_all_renewable_resource_capacity_constraints()
     solution = MyCumulativeResourceSolution(
         problem=pb,
         modes={"task-1": 1, "task-2": 0},
         starts={"task-1": 1, "task-2": 1},
     )
-    assert solution.check_all_resource_capacity_constraints()
+    assert solution.check_all_renewable_resource_capacity_constraints()
     solution = MyCumulativeResourceSolution(
         problem=pb,
         modes={"task-1": 1, "task-2": 0},
         starts={"task-1": 1, "task-2": 3},
     )
-    assert solution.check_all_resource_capacity_constraints()
+    assert solution.check_all_renewable_resource_capacity_constraints()
 
 
 def test_convert_calendar_to_availability_intervals():

--- a/tests/generic_tasks_tools/test_non_renewable_resource.py
+++ b/tests/generic_tasks_tools/test_non_renewable_resource.py
@@ -1,0 +1,99 @@
+#  Copyright (c) 2026 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+import logging
+
+from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
+    NonRenewableResourceProblem,
+    NonRenewableResourceSolution,
+)
+from discrete_optimization.generic_tools.do_problem import ObjectiveRegister, Solution
+
+NonRenewableResource = str
+Task = str
+
+
+class MyNonRenewableResourceProblem(
+    NonRenewableResourceProblem[Task, NonRenewableResource]
+):
+    resource_capacities = {"R0": 2, "R1": 5}
+    mode_details = {
+        "task-1": {0: {"R0": 2}, 1: {"R1": 3}},
+        "task-2": {
+            0: {"R0": 2, "R1": 1},
+        },
+    }
+
+    @property
+    def non_renewable_resources_list(self) -> list[NonRenewableResource]:
+        return list(self.resource_capacities)
+
+    def get_non_renewable_resource_capacity(
+        self, resource: NonRenewableResource
+    ) -> int:
+        return self.resource_capacities[resource]
+
+    def get_non_renewable_resource_consumption(
+        self, resource: NonRenewableResource, task: Task, mode: int
+    ) -> int:
+        return self.mode_details[task][mode].get(resource, 0)
+
+    def get_task_modes(self, task: Task) -> set[int]:
+        return set(self.mode_details[task])
+
+    @property
+    def tasks_list(self) -> list[Task]:
+        return list(self.mode_details)
+
+    def evaluate(self, variable: Solution) -> dict[str, float]:
+        pass
+
+    def satisfy(self, variable: MyNonRenewableResourceSolution) -> bool:
+        return variable.check_all_non_renewable_resource_capacity_constraints()
+
+    def get_solution_type(self) -> type[Solution]:
+        return MyNonRenewableResourceSolution
+
+    def get_objective_register(self) -> ObjectiveRegister:
+        pass
+
+
+class MyNonRenewableResourceSolution(
+    NonRenewableResourceSolution[Task, NonRenewableResource]
+):
+    problem: MyNonRenewableResourceProblem
+
+    def __init__(
+        self,
+        problem: MyNonRenewableResourceProblem,
+        modes: dict[Task, int],
+    ):
+        super().__init__(problem)
+        self.modes = modes
+
+    def get_mode(self, task: Task) -> int:
+        return self.modes[task]
+
+    def copy(self) -> Solution:
+        pass
+
+
+def test_non_renewable_resource_check(caplog):
+    pb = MyNonRenewableResourceProblem()
+    # ok
+    solution = MyNonRenewableResourceSolution(
+        problem=pb,
+        modes={"task-1": 1, "task-2": 0},
+    )
+    assert pb.satisfy(solution)
+    # nok
+    solution = MyNonRenewableResourceSolution(
+        problem=pb,
+        modes={"task-1": 0, "task-2": 0},
+    )
+    with caplog.at_level(logging.DEBUG):
+        assert not pb.satisfy(solution)
+    assert "R0" in caplog.text
+    assert "R1" not in caplog.text

--- a/tests/rcpsp/solvers/test_cpsat.py
+++ b/tests/rcpsp/solvers/test_cpsat.py
@@ -61,7 +61,7 @@ def test_ortools(model):
     fit_2 = rcpsp_problem.evaluate(solution_rebuilt)
     assert fit == -fit_2["makespan"]
     assert rcpsp_problem.satisfy(solution)
-    assert solution.check_all_resource_capacity_constraints()
+    assert solution.check_all_renewable_resource_capacity_constraints()
     rcpsp_problem.plot_ressource_view(solution)
     plot_task_gantt(rcpsp_problem, solution)
 
@@ -264,7 +264,7 @@ def test_ortools_with_calendar_resource(model):
     fit_2 = rcpsp_problem.evaluate(solution_rebuilt)
     assert fit == -fit_2["makespan"]
     assert rcpsp_problem.satisfy(solution)
-    assert solution.check_all_resource_capacity_constraints()
+    assert solution.check_all_renewable_resource_capacity_constraints()
 
     rcpsp_problem.plot_ressource_view(solution)
     plot_task_gantt(rcpsp_problem, solution)
@@ -301,7 +301,7 @@ def test_ortools_cumulativeresource_optim(model):
     result_storage = solver.solve(time_limit=50)
     solution, fit = result_storage.get_best_solution_fit()
     assert rcpsp_problem.satisfy(solution)
-    assert solution.check_all_resource_capacity_constraints()
+    assert solution.check_all_renewable_resource_capacity_constraints()
 
 
 @pytest.mark.parametrize(
@@ -316,7 +316,7 @@ def test_ortools_resource_optim(model):
     result_storage = solver.solve(time_limit=50)
     solution, fit = result_storage.get_best_solution_fit()
     assert rcpsp_problem.satisfy(solution)
-    assert solution.check_all_resource_capacity_constraints()
+    assert solution.check_all_renewable_resource_capacity_constraints()
 
 
 def test_ortools_with_cb(caplog, random_seed):

--- a/tests/rcpsp/test_problem.py
+++ b/tests/rcpsp/test_problem.py
@@ -184,10 +184,11 @@ def test_partial_sgs(rcpsp_problem_file):
 @pytest.fixture
 def small_problem():
     resources = {
-        "R1": [0, 5, 5, 2, 3, 2, 2, 2, 2, 3, 2, 2] + [0] * 3,
+        "R1": [0, 5, 5, 2, 3, 2, 2, 2, 2, 3, 2, 2],
         "R2": [1, 2, 1, 3, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3],
+        "R3": 4,
     }
-    non_renewable_resources = []  # Empty if all resources replenish when a task ends
+    non_renewable_resources = ["R3"]
     # Define mode details
     # Format: { task_id: { mode_id: { "duration": int, "resource_name": amount } } }
     mode_details = {
@@ -195,7 +196,49 @@ def small_problem():
         "task-1": {1: {"duration": 4, "R1": 1, "R2": 1}},
         "task-2": {1: {"duration": 1, "R1": 0, "R2": 1}},
         "task-3": {1: {"duration": 2, "R1": 0, "R2": 2}},
-        "task-4": {1: {"duration": 2, "R1": 2, "R2": 1}},
+        "task-4": {
+            1: {"duration": 2, "R1": 2, "R2": 1, "R3": 3},
+            2: {"duration": 2, "R1": 2, "R2": 1, "R3": 5},
+        },
+        "sink": {1: {"duration": 0, "R1": 0, "R2": 0}},  # Sink (Dummy)
+    }
+    # Define precedence graph
+    successors = {
+        "source": ["task-1", "task-2"],  # First tasks: 1 and 2
+        "task-1": ["task-3"],  # Task 1 must finish before 3
+        "task-2": ["task-4"],  # Task 2 must finish before 4
+        "task-3": ["sink"],  # Task 3 leads to Sink
+        "task-4": ["sink"],  # Task 4 leads to Sink
+        "sink": [],  # Sink has no successors
+    }
+    # Initialize the Problem
+    problem = RcpspProblem(
+        resources=resources,
+        non_renewable_resources=non_renewable_resources,
+        mode_details=mode_details,
+        successors=successors,
+        horizon=15,  # Maximum time allowed for the project
+        source_task="source",
+        sink_task="sink",
+    )
+    return problem
+
+
+@pytest.fixture
+def small_problem_no_calendar():
+    resources = {"R1": 5, "R2": 3, "R3": 4}
+    non_renewable_resources = ["R3"]
+    # Define mode details
+    # Format: { task_id: { mode_id: { "duration": int, "resource_name": amount } } }
+    mode_details = {
+        "source": {1: {"duration": 0, "R1": 0, "R2": 0}},  # Source (Dummy)
+        "task-1": {1: {"duration": 4, "R1": 1, "R2": 1}},
+        "task-2": {1: {"duration": 1, "R1": 0, "R2": 1}},
+        "task-3": {1: {"duration": 2, "R1": 0, "R2": 2}},
+        "task-4": {
+            1: {"duration": 2, "R1": 2, "R2": 1, "R3": 3},
+            2: {"duration": 2, "R1": 2, "R2": 1, "R3": 5},
+        },
         "sink": {1: {"duration": 0, "R1": 0, "R2": 0}},  # Sink (Dummy)
     }
     # Define precedence graph
@@ -235,7 +278,7 @@ def test_update_problem(small_problem):
     assert len(problem.get_resource_availabilities("R1")) == 9
 
 
-def test_satisfy_nok(small_problem, caplog):
+def test_satisfy_renewable_nok(small_problem, caplog):
     problem = small_problem
     solution = RcpspSolution(
         problem=problem,
@@ -254,3 +297,41 @@ def test_satisfy_nok(small_problem, caplog):
         assert not problem.satisfy(solution)
     assert resource in caplog.text
     assert f"time {t}" in caplog.text
+
+
+def test_satisfy_non_renewable_nok(small_problem):
+    problem = small_problem
+    solution = RcpspSolution(
+        problem=problem,
+        rcpsp_permutation=[1, 0, 3, 2],
+        fast=False,  # avoid overhead for first call to numba functions
+    )  # => task-1 and task-4 together at time 4
+    assert problem.satisfy(solution)
+
+    # change mode to violate non-renewable constraint
+    solution = RcpspSolution(
+        problem=problem,
+        rcpsp_permutation=[1, 0, 3, 2],
+        rcpsp_modes=[1, 1, 1, 2],
+        fast=True,  # avoid overhead for first call to numba functions
+    )
+    assert not problem.satisfy(solution)
+
+
+def test_satisfy_non_renewable_no_calendar_nok(small_problem_no_calendar):
+    problem = small_problem_no_calendar
+    solution = RcpspSolution(
+        problem=problem,
+        rcpsp_permutation=[1, 0, 3, 2],
+        fast=False,  # avoid overhead for first call to numba functions
+    )  # => task-1 and task-4 together at time 4
+    assert problem.satisfy(solution)
+
+    # change mode to violate non-renewable constraint
+    solution = RcpspSolution(
+        problem=problem,
+        rcpsp_permutation=[1, 0, 3, 2],
+        rcpsp_modes=[1, 1, 1, 2],
+        fast=True,  # avoid overhead for first call to numba functions
+    )
+    assert not problem.satisfy(solution)

--- a/tests/rcpsp_multiskill/solvers/test_cpsat.py
+++ b/tests/rcpsp_multiskill/solvers/test_cpsat.py
@@ -33,9 +33,66 @@ def test_imopse_cpsat():
     )
     cp_model.cp_model.Minimize(cp_model.variables["makespan"])
     p = ParametersCp.default_cpsat()
-    res = cp_model.solve(parameters_cp=p, time_limit=20)
+    res = cp_model.solve(
+        parameters_cp=p, time_limit=20, callbacks=[NbIterationStopper(1)]
+    )
     solution: MultiskillRcpspSolution = res.get_best_solution_fit()[0]
     assert model.satisfy(solution)
+
+
+def test_imopse_cpsat_w_non_renewable_n_cumulative_resource():
+    file = [f for f in get_data_available() if "100_5_64_9.def" in f][0]
+    model, _ = parse_file(file, max_horizon=1000)
+
+    cp_model = CpSatMultiskillRcpspSolver(
+        problem=model,
+    )
+    cp_model.init_model(
+        one_worker_per_task=True,
+    )
+    cp_model.cp_model.Minimize(cp_model.variables["makespan"])
+    p = ParametersCp.default_cpsat()
+    res = cp_model.solve(
+        parameters_cp=p, time_limit=20, callbacks=[NbIterationStopper(1)]
+    )
+    solution: MultiskillRcpspSolution = res.get_best_solution_fit()[0]
+    assert model.satisfy(solution)
+
+    # add resources that should change schedule and mode choice
+    task = model.tasks_list[0]
+    t = solution.get_start_time(task)
+    assert solution.get_mode(task) == 1
+    calendar = [2] * model.horizon
+    calendar[t] = 1
+    model.non_renewable_resources = {"R0"}
+    model.resources_availability = {"R0": [1], "R1": calendar}
+    model.resources_set = set(model.resources_availability)
+    model.partial_preemption_data = None
+    model.always_releasable_resources = None
+    model.never_releasable_resources = None
+    # resource R1 not available at previous starting time
+    model.mode_details[task][1]["R1"] = 2
+    # new mode ok
+    model.mode_details[task][2] = dict(model.mode_details[task][1])
+    model.mode_details[task][2]["R0"] = 1
+    # previous mode ko
+    model.mode_details[task][1]["R0"] = 2
+    model.update_problem()
+    cp_model = CpSatMultiskillRcpspSolver(
+        problem=model,
+    )
+    cp_model.init_model(
+        one_worker_per_task=True,
+    )
+    cp_model.cp_model.Minimize(cp_model.variables["makespan"])
+    p = ParametersCp.default_cpsat()
+    res = cp_model.solve(
+        parameters_cp=p, time_limit=20, callbacks=[NbIterationStopper(1)]
+    )
+    solution: MultiskillRcpspSolution = res.get_best_solution_fit()[0]
+    assert model.satisfy(solution)
+    assert solution.get_start_time(task) != t
+    assert solution.get_mode(task) == 2
 
 
 def test_imopse_cpsat_with_calendar(caplog):
@@ -58,7 +115,9 @@ def test_imopse_cpsat_with_calendar(caplog):
     )
     cp_model.cp_model.Minimize(cp_model.variables["makespan"])
     p = ParametersCp.default_cpsat()
-    res = cp_model.solve(parameters_cp=p, time_limit=20)
+    res = cp_model.solve(
+        parameters_cp=p, time_limit=20, callbacks=[NbIterationStopper(1)]
+    )
     solution = res.get_best_solution_fit()[0]
     assert model.satisfy(solution)
 

--- a/tests/rcpsp_multiskill/test_problem.py
+++ b/tests/rcpsp_multiskill/test_problem.py
@@ -1,7 +1,7 @@
 #  Copyright (c) 2022-2025 AIRBUS and its affiliates.
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
-
+import logging
 import random
 from collections.abc import Hashable
 
@@ -233,3 +233,76 @@ def test_nok_same_name_resource_n_skill():
     problem.resources_availability["Q1"] = [0] * problem.horizon
     with pytest.raises(AssertionError):
         problem.update_problem()
+
+
+def test_check_non_renewable_resource_nok(caplog):
+    rcpsp_problem_file = [
+        f for f in get_data_available() if f.endswith("100_5_64_9.def")
+    ][0]
+    problem = parse_file(rcpsp_problem_file)[0]
+    problem = problem.to_variant_model()
+    # dummy solution
+    sol = VariantMultiskillRcpspSolution(
+        problem=problem,
+        priority_list_task=[i for i in range(problem.n_jobs_non_dummy)],
+        modes_vector=[1 for i in range(problem.n_jobs_non_dummy)],
+        priority_worker_per_task=[
+            [w for w in problem.employees] for i in range(problem.n_jobs_non_dummy)
+        ],
+        fast=False,  # avoid overhead for first call to numba functions
+    )
+    assert problem.satisfy(sol)
+    # add resources and twist mode details to violate max capacity
+    problem.non_renewable_resources = {"R0"}
+    problem.resources_availability = {
+        "R0": [1],
+        "R1": [2] + [1] * (problem.horizon - 1),
+    }
+    problem.resources_set = set(problem.resources_availability)
+    problem.partial_preemption_data = None
+    problem.always_releasable_resources = None
+    problem.never_releasable_resources = None
+    problem.mode_details[2][1]["R0"] = 2
+    problem.update_problem()
+    with caplog.at_level(logging.DEBUG):
+        assert not problem.satisfy(sol)
+    assert "R0" in caplog.text
+
+
+def test_check_cumulative_resource_nok(caplog):
+    rcpsp_problem_file = [
+        f for f in get_data_available() if f.endswith("100_5_64_9.def")
+    ][0]
+    problem = parse_file(rcpsp_problem_file)[0]
+    problem = problem.to_variant_model()
+    # dummy solution
+    sol = VariantMultiskillRcpspSolution(
+        problem=problem,
+        priority_list_task=[i for i in range(problem.n_jobs_non_dummy)],
+        modes_vector=[1 for i in range(problem.n_jobs_non_dummy)],
+        priority_worker_per_task=[
+            [w for w in problem.employees] for i in range(problem.n_jobs_non_dummy)
+        ],
+        fast=False,  # avoid overhead for first call to numba functions
+    )
+    assert problem.satisfy(sol)
+    # add resources and twist mode details to violate availability
+    problem.non_renewable_resources = ["R0"]
+    problem.resources_availability = {
+        "R0": [1],
+        "R1": [2] + [1] * (problem.horizon - 1),
+    }
+    problem.resources_set = set(problem.resources_availability)
+    problem.partial_preemption_data = None
+    problem.always_releasable_resources = None
+    problem.never_releasable_resources = None
+    problem.mode_details[2][1]["R1"] = 1
+    problem.update_problem()
+    assert problem.satisfy(sol)
+    task = problem.tasks_list[0]
+    t = sol.get_start_time(task)
+    problem.resources_availability["R1"][t] = 0
+    problem.update_problem()
+    with caplog.at_level(logging.DEBUG):
+        assert not problem.satisfy(sol)
+    assert "R1" in caplog.text

--- a/tests/workforce/scheduling/test_cpsat.py
+++ b/tests/workforce/scheduling/test_cpsat.py
@@ -59,7 +59,7 @@ def test_cpsat(problem):
     )
     assert len(res) == 1
     sol: AllocSchedulingSolution = res[-1][0]
-    assert sol.check_all_resource_capacity_constraints()
+    assert sol.check_all_renewable_resource_capacity_constraints()
     assert problem.satisfy(sol)
     problem.evaluate(sol)
 


### PR DESCRIPTION
- a non-renewable resource is consumed by tasks and not released after the task
- so no calendar involved only a (max) capacity
- we assume that the non-renewable consumption of a task depends only on chosen mode for the task
- we include the mixin in the generic AllocationSchedulingProblem
- we add generic check 
- we add generic constraint in a dedicated mixin for cpsat solvers
- we adapt rcpsp, rcpsp_multiskill and workforce/scheduling to it
- we add tests
- we fix rcpsp_multiskill to be able to add resources to a problem after init to test the new mixin more easily