### PR TITLE
Create a generic "auto" cpsat solver for scheduling problems

### DIFF
--- a/src/discrete_optimization/fjsp/problem.py
+++ b/src/discrete_optimization/fjsp/problem.py
@@ -7,13 +7,28 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
-from discrete_optimization.generic_tasks_tools.multimode_scheduling import (
-    MultimodeSchedulingProblem,
-    MultimodeSchedulingSolution,
+from discrete_optimization.generic_tasks_tools.allocation import (
+    NoUnaryResource,
+    WithoutAllocationProblem,
+    WithoutAllocationSolution,
 )
-from discrete_optimization.generic_tasks_tools.precedence_scheduling import (
-    PrecedenceSchedulingProblem,
-    PrecedenceSchedulingSolution,
+from discrete_optimization.generic_tasks_tools.cumulative_resource import (
+    NoCumulativeResource,
+    WithoutCumulativeResourceProblem,
+    WithoutCumulativeResourceSolution,
+)
+from discrete_optimization.generic_tasks_tools.generic_scheduling import (
+    GenericSchedulingProblem,
+    GenericSchedulingSolution,
+)
+from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
+    NoNonRenewableResource,
+    WithoutNonRenewableResourceProblem,
+    WithoutNonRenewableResourceSolution,
+)
+from discrete_optimization.generic_tasks_tools.renewable_resource import (
+    WithoutRenewableResourceProblem,
+    WithoutRenewableResourceSolution,
 )
 from discrete_optimization.generic_tools.do_problem import (
     ModeOptim,
@@ -29,7 +44,13 @@ logger = logging.getLogger(__name__)
 
 
 class FJobShopSolution(
-    PrecedenceSchedulingSolution[Task], MultimodeSchedulingSolution[Task]
+    GenericSchedulingSolution[
+        Task, NoUnaryResource, NoCumulativeResource, NoNonRenewableResource
+    ],
+    WithoutCumulativeResourceSolution[Task, NoUnaryResource],
+    WithoutNonRenewableResourceSolution[Task],
+    WithoutAllocationSolution[Task],
+    WithoutRenewableResourceSolution[Task],
 ):
     problem: FJobShopProblem
 
@@ -71,7 +92,13 @@ class Job:
 
 
 class FJobShopProblem(
-    PrecedenceSchedulingProblem[Task], MultimodeSchedulingProblem[Task]
+    GenericSchedulingProblem[
+        Task, NoUnaryResource, NoCumulativeResource, NoNonRenewableResource
+    ],
+    WithoutCumulativeResourceProblem[Task, NoUnaryResource],
+    WithoutNonRenewableResourceProblem[Task],
+    WithoutAllocationProblem[Task],
+    WithoutRenewableResourceProblem[Task],
 ):
     n_jobs: int
     n_machines: int

--- a/src/discrete_optimization/fjsp/problem.py
+++ b/src/discrete_optimization/fjsp/problem.py
@@ -12,6 +12,10 @@ from discrete_optimization.generic_tasks_tools.allocation import (
     WithoutAllocationProblem,
     WithoutAllocationSolution,
 )
+from discrete_optimization.generic_tasks_tools.calendar_resource import (
+    WithoutCalendarResourceProblem,
+    WithoutCalendarResourceSolution,
+)
 from discrete_optimization.generic_tasks_tools.cumulative_resource import (
     NoCumulativeResource,
     WithoutCumulativeResourceProblem,
@@ -25,10 +29,6 @@ from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
     NoNonRenewableResource,
     WithoutNonRenewableResourceProblem,
     WithoutNonRenewableResourceSolution,
-)
-from discrete_optimization.generic_tasks_tools.renewable_resource import (
-    WithoutRenewableResourceProblem,
-    WithoutRenewableResourceSolution,
 )
 from discrete_optimization.generic_tools.do_problem import (
     ModeOptim,
@@ -50,7 +50,7 @@ class FJobShopSolution(
     WithoutCumulativeResourceSolution[Task, NoUnaryResource],
     WithoutNonRenewableResourceSolution[Task],
     WithoutAllocationSolution[Task],
-    WithoutRenewableResourceSolution[Task],
+    WithoutCalendarResourceSolution[Task],
 ):
     problem: FJobShopProblem
 
@@ -98,7 +98,7 @@ class FJobShopProblem(
     WithoutCumulativeResourceProblem[Task, NoUnaryResource],
     WithoutNonRenewableResourceProblem[Task],
     WithoutAllocationProblem[Task],
-    WithoutRenewableResourceProblem[Task],
+    WithoutCalendarResourceProblem[Task],
 ):
     n_jobs: int
     n_machines: int

--- a/src/discrete_optimization/fjsp/solvers/cpsat_auto.py
+++ b/src/discrete_optimization/fjsp/solvers/cpsat_auto.py
@@ -1,0 +1,116 @@
+#  Copyright (c) 2024 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+
+import logging
+from typing import Any
+
+from discrete_optimization.fjsp.problem import FJobShopProblem, FJobShopSolution, Task
+from discrete_optimization.generic_tasks_tools.allocation import (
+    NoUnaryResource,
+    UnaryResource,
+)
+from discrete_optimization.generic_tasks_tools.cumulative_resource import (
+    NoCumulativeResource,
+)
+from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
+from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
+    NoNonRenewableResource,
+)
+from discrete_optimization.generic_tasks_tools.solvers.cpsat.auto import (
+    GenericSchedulingAutoCpSatSolver,
+    TemporarySolution,
+)
+from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
+    CategoricalHyperparameter,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class CpSatAutoFjspSolver(
+    GenericSchedulingAutoCpSatSolver[
+        Task, NoUnaryResource, NoCumulativeResource, NoNonRenewableResource
+    ],
+):
+    hyperparameters = [
+        CategoricalHyperparameter(
+            name="duplicate_temporal_var", choices=[True, False], default=False
+        ),
+        CategoricalHyperparameter(
+            name="add_cumulative_constraint", choices=[True, False], default=False
+        ),
+    ]
+    problem: FJobShopProblem
+
+    def init_model(self, **kwargs: Any) -> None:
+        # optional parameters
+        kwargs = self.complete_with_default_hyperparameters(kwargs)
+        self._max_time = kwargs.get(
+            "max_time", self.problem.get_makespan_upper_bound()
+        )  # update the upper bound for makespan
+        self.duplicate_start_var_per_mode = kwargs["duplicate_temporal_var"]
+        # compute start/end of task lower bounds by forward propagation
+        self.compute_start_and_end_lower_bound()
+
+        super().init_model(**kwargs)
+        self.create_disjunctive_constraints(**kwargs)
+
+    def get_makespan_upper_bound(self) -> int:
+        return self._max_time
+
+    def compute_start_and_end_lower_bound(self) -> None:
+        self.start_lower_bound: dict[Task, int] = {}
+        self.end_lower_bound: dict[Task, int] = {}
+
+        for j, job in enumerate(self.problem.list_jobs):
+            lb = 0
+            for k, sub_job_options in enumerate(job.sub_jobs):
+                task = j, k
+                possible_durations = [
+                    sub_job.processing_time for sub_job in sub_job_options
+                ]
+                self.start_lower_bound[task] = lb
+                lb += min(possible_durations)
+                self.end_lower_bound[task] = lb
+
+    def get_task_start_or_end_lower_bound(
+        self, task: Task, start_or_end: StartOrEnd
+    ) -> int:
+        match start_or_end:
+            case StartOrEnd.START:
+                return self.start_lower_bound[task]
+            case _:
+                return self.end_lower_bound[task]
+
+    def convert_task_variables_to_solution(
+        self, temp_sol: TemporarySolution[Task, UnaryResource]
+    ) -> FJobShopSolution:
+        schedule = [
+            [
+                (
+                    (task_var := temp_sol.task_variables[j, k]).start,
+                    task_var.end,
+                    self.problem.mode2machine[j, k][task_var.mode],
+                    task_var.mode,
+                )
+                for k, sub_job in enumerate(job.sub_jobs)
+            ]
+            for j, job in enumerate(self.problem.list_jobs)
+        ]
+        return FJobShopSolution(problem=self.problem, schedule=schedule)
+
+    def create_disjunctive_constraints(self, **kwargs):
+        add_cumulative_constraint = kwargs["add_cumulative_constraint"]
+        for machine_tasks in self.problem.job_per_machines.values():
+            machine_intervals = [
+                self.get_task_mode_interval(task=(j, k), mode=i_opt)
+                for j, k, i_opt in machine_tasks
+            ]
+            self.cp_model.add_no_overlap(machine_intervals)
+            if add_cumulative_constraint:
+                self.cp_model.add_cumulative(
+                    intervals=machine_intervals,
+                    demands=[1 for _ in range(len(machine_tasks))],
+                    capacity=1,
+                )

--- a/src/discrete_optimization/generic_tasks_tools/allocation.py
+++ b/src/discrete_optimization/generic_tasks_tools/allocation.py
@@ -262,6 +262,21 @@ class AllocationCpSolver(TasksCpSolver[Task], Generic[Task, UnaryResource]):
         """
         ...
 
+    def is_compatible_task_unary_resource(
+        self, task: Task, unary_resource: UnaryResource
+    ) -> bool:
+        """Should return False if the unary_resource can never be allocated to task.
+
+        This is only a hint used to reduce the number of variables or constraints generated.
+        Default to use `problem.is_compatible_task_unary_resource()`.
+
+        But you can override it if you want to have more constraints in the solver than in the problem.
+
+        """
+        return self.problem.is_compatible_task_unary_resource(
+            task=task, unary_resource=unary_resource
+        )
+
 
 def get_default_tasks_n_unary_resources(
     problem: AllocationProblem,

--- a/src/discrete_optimization/generic_tasks_tools/allocation.py
+++ b/src/discrete_optimization/generic_tasks_tools/allocation.py
@@ -273,3 +273,23 @@ def get_default_tasks_n_unary_resources(
     if unary_resources is None:
         unary_resources = problem.unary_resources_list
     return tasks, unary_resources
+
+
+NoUnaryResource = None
+
+
+class WithoutAllocationProblem(AllocationProblem[Task, NoUnaryResource], Generic[Task]):
+    """Mixin to simplify deriving from GenericSchedulingProblem when no allocation is needed."""
+
+    @property
+    def unary_resources_list(self) -> list[NoUnaryResource]:
+        return []
+
+
+class WithoutAllocationSolution(
+    AllocationSolution[Task, NoUnaryResource], Generic[Task]
+):
+    """Mixin to simplify deriving from GenericSchedulingSolution when no allocation is needed."""
+
+    def is_allocated(self, task: Task, unary_resource: UnaryResource) -> bool:
+        return False

--- a/src/discrete_optimization/generic_tasks_tools/calendar_resource.py
+++ b/src/discrete_optimization/generic_tasks_tools/calendar_resource.py
@@ -22,17 +22,18 @@ logger = logging.getLogger(__name__)
 Resource = TypeVar("Resource", bound=Hashable)
 
 
-class RenewableResourceProblem(SchedulingProblem[Task], Generic[Task, Resource]):
+class CalendarResourceProblem(SchedulingProblem[Task], Generic[Task, Resource]):
     """Base class for scheduling problems dealing with renewable resources whose availability depend on a calendar."""
 
     @property
     @abstractmethod
-    def renewable_resources_list(self) -> list[Resource]:
-        """Renewable resources used by the tasks.
+    def calendar_resources_list(self) -> list[Resource]:
+        """Renewable resources with an availability calendar used by the tasks.
 
         Notes:
             - renewable = the resource replenishes as soon as a task using it ends;
             - it can be a mix of unary resources (e.g. employees) and cumulative resources (e.g. tool types).
+            - calendar can be constant
 
         """
         ...
@@ -154,11 +155,11 @@ class RenewableResourceProblem(SchedulingProblem[Task], Generic[Task, Resource])
         ]
 
 
-class RenewableResourceSolution(SchedulingSolution[Task], Generic[Task, Resource]):
-    problem: RenewableResourceProblem[Task, Resource]
+class CalendarResourceSolution(SchedulingSolution[Task], Generic[Task, Resource]):
+    problem: CalendarResourceProblem[Task, Resource]
 
     @abstractmethod
-    def get_renewable_resource_consumption(self, resource: Resource, task: Task) -> int:
+    def get_calendar_resource_consumption(self, resource: Resource, task: Task) -> int:
         """Get resource consumption by given task.
 
         Args:
@@ -170,17 +171,17 @@ class RenewableResourceSolution(SchedulingSolution[Task], Generic[Task, Resource
         """
         ...
 
-    def check_renewable_resource_capacity_constraint(self, resource: Resource) -> bool:
-        """Check capacity constraint on given renewable resource."""
-        return self.check_renewable_resource_capacity_constraints(resources=(resource,))
+    def check_calendar_resource_capacity_constraint(self, resource: Resource) -> bool:
+        """Check capacity constraint on given resource."""
+        return self.check_calendar_resource_capacity_constraints(resources=(resource,))
 
-    def _check_renewable_resource_capacity_constraint_naive(
+    def _check_calendar_resource_capacity_constraint_naive(
         self, resource: Resource
     ) -> bool:
         makespan = self.get_max_end_time()
         return all(
             sum(
-                self.get_renewable_resource_consumption(resource=resource, task=task)
+                self.get_calendar_resource_consumption(resource=resource, task=task)
                 for task in self.get_running_tasks(time=t)
             )
             <= value
@@ -190,7 +191,7 @@ class RenewableResourceSolution(SchedulingSolution[Task], Generic[Task, Resource
             if t < makespan
         )
 
-    def _compute_renewable_resource_consumption_np(
+    def _compute_calendar_resource_consumption_np(
         self, resources: Iterable[Resource]
     ) -> dict[Resource, np.ndarray]:
         makespan = self.get_max_end_time()
@@ -202,16 +203,14 @@ class RenewableResourceSolution(SchedulingSolution[Task], Generic[Task, Resource
             end = self.get_end_time(task)
             for resource in resources:
                 resources_consumption[resource][start:end] += (
-                    self.get_renewable_resource_consumption(
-                        resource=resource, task=task
-                    )
+                    self.get_calendar_resource_consumption(resource=resource, task=task)
                 )
         return resources_consumption
 
-    def _check_renewable_resource_capacity_constraint_np(
+    def _check_calendar_resource_capacity_constraint_np(
         self, resources: Iterable[Resource]
     ) -> bool:
-        resources_consumption = self._compute_renewable_resource_consumption_np(
+        resources_consumption = self._compute_calendar_resource_consumption_np(
             resources=resources
         )
         resources_capa_violation = {
@@ -227,7 +226,7 @@ class RenewableResourceSolution(SchedulingSolution[Task], Generic[Task, Resource
             resource_cap_violation.any()
             for resource_cap_violation in resources_capa_violation.values()
         ):
-            logger.debug("Violations on renewable resource capacities:")
+            logger.debug("Violations on calendar resource capacities:")
             violations = {
                 resource: violation_timesteps
                 for resource, resource_cap_violation in resources_capa_violation.items()
@@ -241,7 +240,7 @@ class RenewableResourceSolution(SchedulingSolution[Task], Generic[Task, Resource
         else:
             return True
 
-    def check_renewable_resource_capacity_constraints(
+    def check_calendar_resource_capacity_constraints(
         self, resources: Iterable[Resource]
     ) -> bool:
         """Check capacity constraint respected on given resources.
@@ -249,29 +248,27 @@ class RenewableResourceSolution(SchedulingSolution[Task], Generic[Task, Resource
         Do it simultaneously on all resources to optimize computation time.
 
         """
-        return self._check_renewable_resource_capacity_constraint_np(
-            resources=resources
+        return self._check_calendar_resource_capacity_constraint_np(resources=resources)
+
+    def check_all_calendar_resource_capacity_constraints(self) -> bool:
+        """Check capacity constraint on all calendar resources."""
+        return self.check_calendar_resource_capacity_constraints(
+            resources=self.problem.calendar_resources_list
         )
 
-    def check_all_renewable_resource_capacity_constraints(self) -> bool:
-        """Check capacity constraint on all renewable resources."""
-        return self.check_renewable_resource_capacity_constraints(
-            resources=self.problem.renewable_resources_list
-        )
-
-    def compute_renewable_resources_consumptions(self) -> dict[Resource, int]:
-        """Compute total consumption of each renewable resource by the solution."""
+    def compute_calendar_resources_consumptions(self) -> dict[Resource, int]:
+        """Compute total consumption of each calendar resource by the solution."""
         return {
             resource: int(timed_conso.max())
-            for resource, timed_conso in self._compute_renewable_resource_consumption_np(
-                resources=self.problem.renewable_resources_list
+            for resource, timed_conso in self._compute_calendar_resource_consumption_np(
+                resources=self.problem.calendar_resources_list
             ).items()
         }
 
-    def compute_aggregated_renewable_resources_consumptions(
+    def compute_aggregated_calendar_resources_consumptions(
         self, weights: Optional[dict[Resource, int]] = None
     ):
-        """Compute aggregated consumption of each renewable resource by the solution.
+        """Compute aggregated consumption of each calendar resource by the solution.
 
         Args:
             weights: optional weights to apply to each resource in the sum. Default to 1.
@@ -281,13 +278,13 @@ class RenewableResourceSolution(SchedulingSolution[Task], Generic[Task, Resource
             weights = {}
         return sum(
             conso * weights.get(resource, 1)
-            for resource, conso in self.compute_renewable_resources_consumptions().items()
+            for resource, conso in self.compute_calendar_resources_consumptions().items()
         )
 
-    def compute_nb_renewable_resources_used(
+    def compute_nb_calendar_resources_used(
         self, weights: Optional[dict[Resource, int]] = None
     ) -> int:
-        """Compute number of renewable resources used by at least one task.
+        """Compute number of calendar resources used by at least one task.
 
         Args:
             weights: optional weights to apply to each resource in the sum. Default to 1.
@@ -300,18 +297,18 @@ class RenewableResourceSolution(SchedulingSolution[Task], Generic[Task, Resource
             weights = {}
         return sum(
             (conso > 0) * weights.get(resource, 1)
-            for resource, conso in self.compute_renewable_resources_consumptions().items()
+            for resource, conso in self.compute_calendar_resources_consumptions().items()
         )
 
 
-NoRenewableResource = None
+NoCalendarResource = None
 
 
-class WithoutRenewableResourceProblem(
-    RenewableResourceProblem[Task, NoRenewableResource], Generic[Task]
+class WithoutCalendarResourceProblem(
+    CalendarResourceProblem[Task, NoCalendarResource], Generic[Task]
 ):
     @property
-    def renewable_resources_list(self) -> list[Resource]:
+    def calendar_resources_list(self) -> list[Resource]:
         return []
 
     def get_resource_availabilities(
@@ -320,11 +317,11 @@ class WithoutRenewableResourceProblem(
         return []
 
 
-class WithoutRenewableResourceSolution(
-    RenewableResourceSolution[Task, NoRenewableResource], Generic[Task]
+class WithoutCalendarResourceSolution(
+    CalendarResourceSolution[Task, NoCalendarResource], Generic[Task]
 ):
-    def get_renewable_resource_consumption(self, resource: Resource, task: Task) -> int:
-        raise ValueError(f"{resource} is not a renewable resource of the problem.")
+    def get_calendar_resource_consumption(self, resource: Resource, task: Task) -> int:
+        raise ValueError(f"{resource} is not a calendar resource of the problem.")
 
 
 def convert_calendar_to_availability_intervals(

--- a/src/discrete_optimization/generic_tasks_tools/cumulative_resource.py
+++ b/src/discrete_optimization/generic_tasks_tools/cumulative_resource.py
@@ -96,3 +96,39 @@ class CumulativeResourceSolution(
             raise NotImplementedError(
                 f"{resource} is not a cumulative resource whose consumption depends only on task mode."
             )
+
+
+NoCumulativeResource = None
+
+
+class WithoutCumulativeResourceProblem(
+    CumulativeResourceProblem[Task, NoCumulativeResource, OtherRenewableResource],
+    Generic[Task, OtherRenewableResource],
+):
+    """Mixin for problem without non-renewable resources.
+
+    To be used has an additional mixin with generic `GenericSchedulingProblem`.
+
+    """
+
+    @property
+    def cumulative_resources_list(self) -> list[CumulativeResource]:
+        return []
+
+    def get_renewable_resource_consumption(
+        self, resource: CumulativeResource, task: Task, mode: int
+    ) -> int:
+        raise ValueError(f"{resource} is not a cumulative resource of the problem.")
+
+
+class WithoutCumulativeResourceSolution(
+    CumulativeResourceSolution[Task, NoCumulativeResource, OtherRenewableResource],
+    Generic[Task, OtherRenewableResource],
+):
+    """Mixin for solution without cumulative resources.
+
+    To be used has an additional mixin with generic `GenericSchedulingSolution`.
+
+    """
+
+    ...

--- a/src/discrete_optimization/generic_tasks_tools/cumulative_resource.py
+++ b/src/discrete_optimization/generic_tasks_tools/cumulative_resource.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Generic
+from typing import Generic, Hashable, TypeVar, Union
 
 from discrete_optimization.generic_tasks_tools.base import Task
 from discrete_optimization.generic_tasks_tools.multimode_scheduling import (
@@ -14,14 +14,17 @@ from discrete_optimization.generic_tasks_tools.multimode_scheduling import (
 from discrete_optimization.generic_tasks_tools.renewable_resource import (
     RenewableResourceProblem,
     RenewableResourceSolution,
-    Resource,
 )
+
+CumulativeResource = TypeVar("CumulativeResource", bound=Hashable)
+OtherRenewableResource = TypeVar("OtherRenewableResource", bound=Hashable)
+Resource = Union[CumulativeResource, OtherRenewableResource]
 
 
 class CumulativeResourceProblem(
     RenewableResourceProblem[Task, Resource],
     MultimodeSchedulingProblem[Task],
-    Generic[Task, Resource],
+    Generic[Task, CumulativeResource, OtherRenewableResource],
 ):
     """Scheduling problem with cumulative resources consumed by task.
 
@@ -33,9 +36,9 @@ class CumulativeResourceProblem(
 
     @abstractmethod
     def get_renewable_resource_consumption(
-        self, resource: Resource, task: Task, mode: int
+        self, resource: CumulativeResource, task: Task, mode: int
     ) -> int:
-        """Get resource consumption of the task in the given mode
+        """Get cumulative resource consumption of the task in the given mode
 
         Args:
             resource: *renewable* resource
@@ -45,13 +48,13 @@ class CumulativeResourceProblem(
         Returns:
             the consumption for cumulative resources.
 
-        Raises:
-            ValueError: if resource consumption is depending on other variables than mode
-
         """
         ...
 
+    @property
     @abstractmethod
+    def cumulative_resources_list(self) -> list[CumulativeResource]: ...
+
     def is_cumulative_resource(self, resource: Resource) -> bool:
         """Check if given resource is a cumulative resource whose consumption depends only on task mode.
 
@@ -61,17 +64,17 @@ class CumulativeResourceProblem(
         Returns:
 
         """
-        ...
+        return resource in self.cumulative_resources_list
 
 
 class CumulativeResourceSolution(
     RenewableResourceSolution[Task, Resource],
     MultimodeSchedulingSolution[Task],
-    Generic[Task, Resource],
+    Generic[Task, CumulativeResource, OtherRenewableResource],
 ):
     """Solution type associated to CumulativeResourceProblem."""
 
-    problem: CumulativeResourceProblem[Task, Resource]
+    problem: CumulativeResourceProblem[Task, CumulativeResource, OtherRenewableResource]
 
     def get_renewable_resource_consumption(self, resource: Resource, task: Task) -> int:
         """Get resource consumption by given task.

--- a/src/discrete_optimization/generic_tasks_tools/cumulative_resource.py
+++ b/src/discrete_optimization/generic_tasks_tools/cumulative_resource.py
@@ -7,41 +7,41 @@ from abc import abstractmethod
 from typing import Generic, Hashable, TypeVar, Union
 
 from discrete_optimization.generic_tasks_tools.base import Task
+from discrete_optimization.generic_tasks_tools.calendar_resource import (
+    CalendarResourceProblem,
+    CalendarResourceSolution,
+)
 from discrete_optimization.generic_tasks_tools.multimode_scheduling import (
     MultimodeSchedulingProblem,
     MultimodeSchedulingSolution,
 )
-from discrete_optimization.generic_tasks_tools.renewable_resource import (
-    RenewableResourceProblem,
-    RenewableResourceSolution,
-)
 
 CumulativeResource = TypeVar("CumulativeResource", bound=Hashable)
-OtherRenewableResource = TypeVar("OtherRenewableResource", bound=Hashable)
-Resource = Union[CumulativeResource, OtherRenewableResource]
+OtherCalendarResource = TypeVar("OtherCalendarResource", bound=Hashable)
+Resource = Union[CumulativeResource, OtherCalendarResource]
 
 
 class CumulativeResourceProblem(
-    RenewableResourceProblem[Task, Resource],
+    CalendarResourceProblem[Task, Resource],
     MultimodeSchedulingProblem[Task],
-    Generic[Task, CumulativeResource, OtherRenewableResource],
+    Generic[Task, CumulativeResource, OtherCalendarResource],
 ):
     """Scheduling problem with cumulative resources consumed by task.
 
-    This derives from problem with renewable resources, some of them are cumulative, some are not (e.g. unary resource
+    This derives from problem with renewable calendar resources, some of them are cumulative, some are not (e.g. unary resource
     if it is moreover an allocation problem).
     The task consumption of these cumulative resources is supposed to be determined entirely determined by the task mode.
 
     """
 
     @abstractmethod
-    def get_renewable_resource_consumption(
+    def get_cumulative_resource_consumption(
         self, resource: CumulativeResource, task: Task, mode: int
     ) -> int:
         """Get cumulative resource consumption of the task in the given mode
 
         Args:
-            resource: *renewable* resource
+            resource: cumulative resource
             task:
             mode: not used for single mode problems
 
@@ -68,15 +68,15 @@ class CumulativeResourceProblem(
 
 
 class CumulativeResourceSolution(
-    RenewableResourceSolution[Task, Resource],
+    CalendarResourceSolution[Task, Resource],
     MultimodeSchedulingSolution[Task],
-    Generic[Task, CumulativeResource, OtherRenewableResource],
+    Generic[Task, CumulativeResource, OtherCalendarResource],
 ):
     """Solution type associated to CumulativeResourceProblem."""
 
-    problem: CumulativeResourceProblem[Task, CumulativeResource, OtherRenewableResource]
+    problem: CumulativeResourceProblem[Task, CumulativeResource, OtherCalendarResource]
 
-    def get_renewable_resource_consumption(self, resource: Resource, task: Task) -> int:
+    def get_calendar_resource_consumption(self, resource: Resource, task: Task) -> int:
         """Get resource consumption by given task.
 
         Default implementation works only for cumulative resources whose consumptions depend only on task mode.
@@ -89,7 +89,7 @@ class CumulativeResourceSolution(
 
         """
         if self.problem.is_cumulative_resource(resource):
-            return self.problem.get_renewable_resource_consumption(
+            return self.problem.get_cumulative_resource_consumption(
                 resource=resource, task=task, mode=self.get_mode(task)
             )
         else:
@@ -102,10 +102,10 @@ NoCumulativeResource = None
 
 
 class WithoutCumulativeResourceProblem(
-    CumulativeResourceProblem[Task, NoCumulativeResource, OtherRenewableResource],
-    Generic[Task, OtherRenewableResource],
+    CumulativeResourceProblem[Task, NoCumulativeResource, OtherCalendarResource],
+    Generic[Task, OtherCalendarResource],
 ):
-    """Mixin for problem without non-renewable resources.
+    """Mixin for problem without cumulative resources.
 
     To be used has an additional mixin with generic `GenericSchedulingProblem`.
 
@@ -115,15 +115,15 @@ class WithoutCumulativeResourceProblem(
     def cumulative_resources_list(self) -> list[CumulativeResource]:
         return []
 
-    def get_renewable_resource_consumption(
+    def get_cumulative_resource_consumption(
         self, resource: CumulativeResource, task: Task, mode: int
     ) -> int:
         raise ValueError(f"{resource} is not a cumulative resource of the problem.")
 
 
 class WithoutCumulativeResourceSolution(
-    CumulativeResourceSolution[Task, NoCumulativeResource, OtherRenewableResource],
-    Generic[Task, OtherRenewableResource],
+    CumulativeResourceSolution[Task, NoCumulativeResource, OtherCalendarResource],
+    Generic[Task, OtherCalendarResource],
 ):
     """Mixin for solution without cumulative resources.
 

--- a/src/discrete_optimization/generic_tasks_tools/generic_scheduling.py
+++ b/src/discrete_optimization/generic_tasks_tools/generic_scheduling.py
@@ -1,9 +1,7 @@
 #  Copyright (c) 2026 AIRBUS and its affiliates.
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
-from abc import abstractmethod
-from collections.abc import Hashable
-from typing import Generic, TypeVar, Union
+from typing import Generic, Union
 
 from discrete_optimization.generic_tasks_tools.allocation import (
     AllocationProblem,
@@ -12,6 +10,7 @@ from discrete_optimization.generic_tasks_tools.allocation import (
 )
 from discrete_optimization.generic_tasks_tools.base import Task
 from discrete_optimization.generic_tasks_tools.cumulative_resource import (
+    CumulativeResource,
     CumulativeResourceProblem,
     CumulativeResourceSolution,
 )
@@ -25,12 +24,11 @@ from discrete_optimization.generic_tasks_tools.precedence_scheduling import (
     PrecedenceSchedulingSolution,
 )
 
-CumulativeResource = TypeVar("CumulativeResource", bound=Hashable)
 Resource = Union[CumulativeResource, UnaryResource]
 
 
 class GenericSchedulingProblem(
-    CumulativeResourceProblem[Task, Resource],
+    CumulativeResourceProblem[Task, CumulativeResource, UnaryResource],
     NonRenewableResourceProblem[Task, NonRenewableResource],
     AllocationProblem[Task, UnaryResource],
     PrecedenceSchedulingProblem[Task],
@@ -63,10 +61,6 @@ class GenericSchedulingProblem(
     """
 
     @property
-    @abstractmethod
-    def cumulative_resources_list(self) -> list[CumulativeResource]: ...
-
-    @property
     def renewable_resources_list(self) -> list[Resource]:
         return self.unary_resources_list + self.cumulative_resources_list
 
@@ -91,17 +85,13 @@ class GenericSchedulingProblem(
         super().update_resource_availabilities()
         self.check_renewable_resources_list()
 
-    def is_cumulative_resource(self, resource: Resource) -> bool:
-        """Check if given resource is a cumulative resource."""
-        return resource in self.cumulative_resources_list
-
     def is_unary_resource(self, resource: Resource) -> bool:
         """Check if given resource is a unary resource."""
         return resource in self.unary_resources_list
 
 
 class GenericSchedulingSolution(
-    CumulativeResourceSolution[Task, Resource],
+    CumulativeResourceSolution[Task, CumulativeResource, UnaryResource],
     NonRenewableResourceSolution[Task, NonRenewableResource],
     PrecedenceSchedulingSolution[Task],
     AllocationSolution[Task, UnaryResource],

--- a/src/discrete_optimization/generic_tasks_tools/generic_scheduling.py
+++ b/src/discrete_optimization/generic_tasks_tools/generic_scheduling.py
@@ -38,7 +38,7 @@ class GenericSchedulingProblem(
 
     This class derives from other mixins to provide utilities that require that mix:
     - scheduling: tasks need to be scheduled
-    - renewable: the renewable resources have their own calendar that will be used for constraining allocations
+    - calendar: the renewable resources have their own calendar that will be used for constraining allocations and schedule
     - multimode: the tasks have several mode on which the duration depends
     - cumulative: the tasks consume cumulative resources according to the chosen mode
     - allocation: the tasks can have unary resources allocated to them
@@ -61,11 +61,11 @@ class GenericSchedulingProblem(
     """
 
     @property
-    def renewable_resources_list(self) -> list[Resource]:
+    def calendar_resources_list(self) -> list[Resource]:
         return self.unary_resources_list + self.cumulative_resources_list
 
-    def check_renewable_resources_list(self) -> None:
-        """Check renewable resources list.
+    def check_calendar_resources_list(self) -> None:
+        """Check calendar resources list.
 
         Raises:
             AssertionError: if duplicates appear in the list
@@ -73,17 +73,17 @@ class GenericSchedulingProblem(
         Returns:
 
         """
-        renewable_resources_list = (
+        calendar_resources_list = (
             self.unary_resources_list + self.cumulative_resources_list
         )
-        assert len(renewable_resources_list) == len(set(renewable_resources_list)), (
-            "There are duplicates in renewable resources list, "
+        assert len(calendar_resources_list) == len(set(calendar_resources_list)), (
+            "There are duplicates in calendar resources list, "
             "potentially because unary and cumulative resources intersect."
         )
 
     def update_resource_availabilities(self) -> None:
         super().update_resource_availabilities()
-        self.check_renewable_resources_list()
+        self.check_calendar_resources_list()
 
     def is_unary_resource(self, resource: Resource) -> bool:
         """Check if given resource is a unary resource."""
@@ -103,13 +103,13 @@ class GenericSchedulingSolution(
         Task, UnaryResource, CumulativeResource, NonRenewableResource
     ]
 
-    def get_renewable_resource_consumption(self, resource: Resource, task: Task) -> int:
+    def get_calendar_resource_consumption(self, resource: Resource, task: Task) -> int:
         """"""
         if self.problem.is_unary_resource(resource=resource):
             # unary resources: 0 (not allocated) or 1 (allocated)
             return int(self.is_allocated(task=task, unary_resource=resource))
         else:
             # cumulative resources
-            return super().get_renewable_resource_consumption(
+            return super().get_calendar_resource_consumption(
                 resource=resource, task=task
             )

--- a/src/discrete_optimization/generic_tasks_tools/generic_scheduling.py
+++ b/src/discrete_optimization/generic_tasks_tools/generic_scheduling.py
@@ -29,22 +29,23 @@ CumulativeResource = TypeVar("CumulativeResource", bound=Hashable)
 Resource = Union[CumulativeResource, UnaryResource]
 
 
-class AllocationSchedulingProblem(
+class GenericSchedulingProblem(
     CumulativeResourceProblem[Task, Resource],
     NonRenewableResourceProblem[Task, NonRenewableResource],
     AllocationProblem[Task, UnaryResource],
     PrecedenceSchedulingProblem[Task],
     Generic[Task, UnaryResource, CumulativeResource, NonRenewableResource],
 ):
-    """Scheduling problem with unary resource allocation.
+    """Scheduling problem with all optional features
 
     This class derives from other mixins to provide utilities that require that mix:
-    - renewable: the unary resources have their own calendar that will be used for constraining allocations
+    - scheduling: tasks need to be scheduled
+    - renewable: the renewable resources have their own calendar that will be used for constraining allocations
     - multimode: the tasks have several mode on which the duration depends
     - cumulative: the tasks consume cumulative resources according to the chosen mode
-    - allocation
+    - allocation: the tasks can have unary resources allocated to them
     - non-renewable: the tasks consume non-renewable resources according to the chosen mode
-    - precedence
+    - precedence: precedence constraints between tasks
 
     Even though this class is generic but encompasses also more specific cases:
     - singlemode: actually only one mode per task
@@ -57,8 +58,7 @@ class AllocationSchedulingProblem(
     - either cumulative ones
     - or unary resources
 
-    This generic class is to be used to construct generic solvers (e.g. cpsat)
-    that will require no methods implementation to work.
+    This generic class is to be used to construct generic automatic solvers (e.g. ).
 
     """
 
@@ -100,16 +100,16 @@ class AllocationSchedulingProblem(
         return resource in self.unary_resources_list
 
 
-class AllocationSchedulingSolution(
+class GenericSchedulingSolution(
     CumulativeResourceSolution[Task, Resource],
     NonRenewableResourceSolution[Task, NonRenewableResource],
     PrecedenceSchedulingSolution[Task],
     AllocationSolution[Task, UnaryResource],
     Generic[Task, UnaryResource, CumulativeResource, NonRenewableResource],
 ):
-    """Solution type associated to AllocationSchedulingProblem."""
+    """Solution type associated to GenericSchedulingProblem."""
 
-    problem: AllocationSchedulingProblem[
+    problem: GenericSchedulingProblem[
         Task, UnaryResource, CumulativeResource, NonRenewableResource
     ]
 

--- a/src/discrete_optimization/generic_tasks_tools/multimode.py
+++ b/src/discrete_optimization/generic_tasks_tools/multimode.py
@@ -68,7 +68,7 @@ class SinglemodeProblem(MultimodeProblem[Task]):
 
     @property
     def is_multimode(self) -> bool:
-        return True
+        return False
 
     @property
     def max_number_of_mode(self) -> int:

--- a/src/discrete_optimization/generic_tasks_tools/multimode_scheduling.py
+++ b/src/discrete_optimization/generic_tasks_tools/multimode_scheduling.py
@@ -25,13 +25,7 @@ class MultimodeSchedulingProblem(
     MultimodeProblem[Task],
     Generic[Task],
 ):
-    """Scheduling problem whose tasks durations depend only on mode.
-
-    This derives from problem with renewable resources, some of them are cumulative, some are not (e.g. unary resource
-    if it is moreover an allocation problem).
-    The task consumption of these cumulative resources is supposed to be determined entirely determined by the task mode.
-
-    """
+    """Scheduling problem whose tasks durations depend only on mode."""
 
     @abstractmethod
     def get_task_mode_duration(self, task: Task, mode: int) -> int:

--- a/src/discrete_optimization/generic_tasks_tools/multimode_scheduling.py
+++ b/src/discrete_optimization/generic_tasks_tools/multimode_scheduling.py
@@ -9,6 +9,8 @@ from discrete_optimization.generic_tasks_tools.base import Task
 from discrete_optimization.generic_tasks_tools.multimode import (
     MultimodeProblem,
     MultimodeSolution,
+    SinglemodeProblem,
+    SinglemodeSolution,
 )
 from discrete_optimization.generic_tasks_tools.scheduling import (
     SchedulingProblem,
@@ -45,6 +47,32 @@ class MultimodeSchedulingProblem(
         ...
 
 
+class SinglemodeSchedulingProblem(
+    SinglemodeProblem[Task],
+    MultimodeSchedulingProblem[Task],
+):
+    """Single mode scheduling problems with fixed task durations.
+
+    Utility class simplifying MultimodeSchedulingProblem when single mode only.
+
+    """
+
+    @abstractmethod
+    def get_task_duration(self, task: Task) -> int:
+        """Get task duration according to mode.
+
+        Args:
+            task:
+
+        Returns:
+
+        """
+        ...
+
+    def get_task_mode_duration(self, task: Task, mode: int) -> int:
+        return self.get_task_duration(task=task)
+
+
 class MultimodeSchedulingSolution(
     SchedulingSolution[Task],
     MultimodeSolution[Task],
@@ -72,3 +100,15 @@ class MultimodeSchedulingSolution(
                     )
                     break
         return check
+
+
+class SinglemodeSchedulingSolution(
+    SinglemodeSolution[Task],
+    MultimodeSchedulingSolution[Task],
+):
+    """Solution for single mode scheduling problem with fixed task durations.
+
+    Utility class useful when needing to derive from GenericSchedulingSolution without multi mode
+    to be able to use cpsat auto solver.
+
+    """

--- a/src/discrete_optimization/generic_tasks_tools/non_renewable_resource.py
+++ b/src/discrete_optimization/generic_tasks_tools/non_renewable_resource.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import logging
 from abc import abstractmethod
 from collections.abc import Hashable, Iterable
-from typing import Generic, TypeVar
+from typing import Generic, Optional, TypeVar
 
 from discrete_optimization.generic_tasks_tools.base import Task
 from discrete_optimization.generic_tasks_tools.multimode import (
@@ -127,6 +127,55 @@ class NonRenewableResourceSolution(
         """Check capacity constraint on all renewable resources."""
         return self.check_non_renewable_resource_capacity_constraints(
             resources=self.problem.non_renewable_resources_list
+        )
+
+    def compute_non_renewable_resources_consumptions(
+        self,
+    ) -> dict[NonRenewableResource, int]:
+        """Compute total consumption of each non-renewable resource by the solution."""
+        return {
+            resource: sum(
+                self.get_non_renewable_resource_consumption(
+                    resource=resource, task=task
+                )
+                for task in self.problem.tasks_list
+            )
+            for resource in self.problem.non_renewable_resources_list
+        }
+
+    def compute_aggregated_non_renewable_resources_consumptions(
+        self, weights: Optional[dict[NonRenewableResource, int]] = None
+    ):
+        """Compute aggregated consumption of each non-renewable resource by the solution.
+
+        Args:
+            weights: optional weights to apply to each resource in the sum. Default to 1.
+
+        """
+        if weights is None:
+            weights = {}
+        return sum(
+            conso * weights.get(resource, 1)
+            for resource, conso in self.compute_non_renewable_resources_consumptions().items()
+        )
+
+    def compute_nb_non_renewable_resources_used(
+        self, weights: Optional[dict[NonRenewableResource, int]] = None
+    ) -> int:
+        """Compute number of non-renewable resources used by at least one task.
+
+        Args:
+            weights: optional weights to apply to each resource in the sum. Default to 1.
+
+
+        Returns:
+
+        """
+        if weights is None:
+            weights = {}
+        return sum(
+            (conso > 0) * weights.get(resource, 1)
+            for resource, conso in self.compute_non_renewable_resources_consumptions().items()
         )
 
 

--- a/src/discrete_optimization/generic_tasks_tools/non_renewable_resource.py
+++ b/src/discrete_optimization/generic_tasks_tools/non_renewable_resource.py
@@ -130,12 +130,15 @@ class NonRenewableResourceSolution(
         )
 
 
+NoNonRenewableResource = None
+
+
 class WithoutNonRenewableResourceProblem(
-    NonRenewableResourceProblem[Task, NonRenewableResource]
+    NonRenewableResourceProblem[Task, NoNonRenewableResource], Generic[Task]
 ):
     """Mixin for problem without non-renewable resources.
 
-    To be used has an additional mixin with generic `AllocationSchedulingProblem`.
+    To be used has an additional mixin with generic `GenericSchedulingProblem`.
 
     """
 
@@ -152,3 +155,15 @@ class WithoutNonRenewableResourceProblem(
         self, resource: NonRenewableResource, task: Task, mode: int
     ) -> int:
         raise RuntimeError("This problem has no non-renewable resource.")
+
+
+class WithoutNonRenewableResourceSolution(
+    NonRenewableResourceSolution[Task, NoNonRenewableResource], Generic[Task]
+):
+    """Mixin for solution without non-renewable resources.
+
+    To be used has an additional mixin with generic `GenericSchedulingSolution`.
+
+    """
+
+    ...

--- a/src/discrete_optimization/generic_tasks_tools/precedence.py
+++ b/src/discrete_optimization/generic_tasks_tools/precedence.py
@@ -71,7 +71,7 @@ class PrecedenceSolution(TasksSolution[Task]):
 class WithoutPrecedenceProblem(PrecedenceProblem[Task]):
     """Utility mixin for problem w/o precedence constraints.
 
-    To be used has an additional mixin with generic `AllocationSchedulingProblem`.
+    To be used has an additional mixin with generic `GenericSchedulingProblem`.
 
     """
 

--- a/src/discrete_optimization/generic_tasks_tools/renewable_resource.py
+++ b/src/discrete_optimization/generic_tasks_tools/renewable_resource.py
@@ -251,6 +251,29 @@ class RenewableResourceSolution(SchedulingSolution[Task], Generic[Task, Resource
         )
 
 
+NoRenewableResource = None
+
+
+class WithoutRenewableResourceProblem(
+    RenewableResourceProblem[Task, NoRenewableResource], Generic[Task]
+):
+    @property
+    def renewable_resources_list(self) -> list[Resource]:
+        return []
+
+    def get_resource_availabilities(
+        self, resource: Resource
+    ) -> list[tuple[int, int, int]]:
+        return []
+
+
+class WithoutRenewableResourceSolution(
+    RenewableResourceSolution[Task, NoRenewableResource], Generic[Task]
+):
+    def get_renewable_resource_consumption(self, resource: Resource, task: Task) -> int:
+        raise ValueError(f"{resource} is not a renewable resource of the problem.")
+
+
 def convert_calendar_to_availability_intervals(
     calendar: Union[int, list[int]], horizon: int
 ) -> list[tuple[int, int, int]]:

--- a/src/discrete_optimization/generic_tasks_tools/renewable_resource.py
+++ b/src/discrete_optimization/generic_tasks_tools/renewable_resource.py
@@ -190,9 +190,9 @@ class RenewableResourceSolution(SchedulingSolution[Task], Generic[Task, Resource
             if t < makespan
         )
 
-    def _check_renewable_resource_capacity_constraint_np(
+    def _compute_renewable_resource_consumption_np(
         self, resources: Iterable[Resource]
-    ) -> bool:
+    ) -> dict[Resource, np.ndarray]:
         makespan = self.get_max_end_time()
         resources_consumption = {
             resource: np.zeros(makespan, dtype=int) for resource in resources
@@ -206,11 +206,20 @@ class RenewableResourceSolution(SchedulingSolution[Task], Generic[Task, Resource
                         resource=resource, task=task
                     )
                 )
+        return resources_consumption
 
+    def _check_renewable_resource_capacity_constraint_np(
+        self, resources: Iterable[Resource]
+    ) -> bool:
+        resources_consumption = self._compute_renewable_resource_consumption_np(
+            resources=resources
+        )
         resources_capa_violation = {
             resource: conso
             > np.array(
-                self.problem.get_resource_calendar(resource=resource, horizon=makespan)
+                self.problem.get_resource_calendar(
+                    resource=resource, horizon=len(conso)
+                )
             )
             for resource, conso in resources_consumption.items()
         }
@@ -248,6 +257,50 @@ class RenewableResourceSolution(SchedulingSolution[Task], Generic[Task, Resource
         """Check capacity constraint on all renewable resources."""
         return self.check_renewable_resource_capacity_constraints(
             resources=self.problem.renewable_resources_list
+        )
+
+    def compute_renewable_resources_consumptions(self) -> dict[Resource, int]:
+        """Compute total consumption of each renewable resource by the solution."""
+        return {
+            resource: int(timed_conso.max())
+            for resource, timed_conso in self._compute_renewable_resource_consumption_np(
+                resources=self.problem.renewable_resources_list
+            ).items()
+        }
+
+    def compute_aggregated_renewable_resources_consumptions(
+        self, weights: Optional[dict[Resource, int]] = None
+    ):
+        """Compute aggregated consumption of each renewable resource by the solution.
+
+        Args:
+            weights: optional weights to apply to each resource in the sum. Default to 1.
+
+        """
+        if weights is None:
+            weights = {}
+        return sum(
+            conso * weights.get(resource, 1)
+            for resource, conso in self.compute_renewable_resources_consumptions().items()
+        )
+
+    def compute_nb_renewable_resources_used(
+        self, weights: Optional[dict[Resource, int]] = None
+    ) -> int:
+        """Compute number of renewable resources used by at least one task.
+
+        Args:
+            weights: optional weights to apply to each resource in the sum. Default to 1.
+
+
+        Returns:
+
+        """
+        if weights is None:
+            weights = {}
+        return sum(
+            (conso > 0) * weights.get(resource, 1)
+            for resource, conso in self.compute_renewable_resources_consumptions().items()
         )
 
 

--- a/src/discrete_optimization/generic_tasks_tools/scheduling.py
+++ b/src/discrete_optimization/generic_tasks_tools/scheduling.py
@@ -39,8 +39,40 @@ class SchedulingProblem(TasksProblem[Task]):
 
     @abstractmethod
     def get_makespan_upper_bound(self) -> int:
-        """Get a upper bound on global makespan."""
+        """Get an upper bound on global makespan."""
         pass
+
+    def get_task_start_or_end_lower_bound(
+        self, task: Task, start_or_end: StartOrEnd
+    ) -> int:
+        """Get a lower bound on start or end of a given task.
+
+        Default implementation: 0
+
+        Args:
+            task:
+            start_or_end:
+
+        Returns:
+
+        """
+        return 0
+
+    def get_task_start_or_end_upper_bound(
+        self, task: Task, start_or_end: StartOrEnd
+    ) -> int:
+        """Get an upper bound on start or end of a given task.
+
+        Default implementation: makespan upper bound
+
+        Args:
+            task:
+            start_or_end:
+
+        Returns:
+
+        """
+        return self.get_makespan_upper_bound()
 
 
 class SchedulingSolution(TasksSolution[Task]):

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/allocation.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/allocation.py
@@ -30,6 +30,13 @@ class AllocationCpSatSolver(
 
     """
 
+    at_most_one_unary_resource_per_task = False
+    """Flag telling if the problem accept at most one unary_resource per task.
+
+    Default to False, ie several resources allowed per task.
+
+    """
+
     allocation_changes_variables_created = False
     """Flag telling whether 'allocation changes variables' have been created"""
     allocation_changes_variables: dict[tuple[Task, UnaryResource], IntVar]
@@ -42,13 +49,8 @@ class AllocationCpSatSolver(
     """Flag telling whether 'done variables' have been created"""
     done_variables: dict[Task, IntVar]
     """Variables tracking whether a task has at least one unary resource allocated."""
-
-    at_most_one_unary_resource_per_task = False
-    """Flag telling if the problem accept at most one unary_resource per task.
-
-    Default to False, ie several resources allowed per task.
-
-    """
+    at_most_one_unary_resource_per_task_constraints_added = False
+    """Flag telling whether constraints ensuring at most one unary resource per task have been created"""
 
     @property
     def subset_tasks_of_interest(self) -> Iterable[Task]:
@@ -88,6 +90,7 @@ class AllocationCpSatSolver(
         self.used_variables = {}
         self.done_variables_created = False
         self.done_variables_created = {}
+        self.at_most_one_unary_resource_per_task_constraints_added = False
 
     @abstractmethod
     def get_task_unary_resource_is_present_variable(
@@ -252,7 +255,8 @@ class AllocationCpSatSolver(
                 ]
                 if len(list_is_present_variables) > 0:
                     if self.at_most_one_unary_resource_per_task:
-                        self.cp_model.add_at_most_one(list_is_present_variables)
+                        if not self.at_most_one_unary_resource_per_task_constraints_added:
+                            self.cp_model.add_at_most_one(list_is_present_variables)
                         nb_teams_allocated_to_task = sum(list_is_present_variables)
                         self.cp_model.add(
                             nb_teams_allocated_to_task == 1
@@ -265,6 +269,37 @@ class AllocationCpSatSolver(
                 else:
                     self.cp_model.add(done == 0)
             self.done_variables_created = True
+            if self.at_most_one_unary_resource_per_task:
+                self.at_most_one_unary_resource_per_task_constraints_added = True
+
+    def add_at_most_one_unary_resource_per_task_constraints(self):
+        """Add constraints to cp model so that no more than one unary resource is allocated per task.
+
+        Calling method avoid recreating the constraint if already done (e.g. when calling `create_done_variables()`)
+
+        """
+        if (
+            self.at_most_one_unary_resource_per_task
+            and not self.at_most_one_unary_resource_per_task_constraints_added
+        ):
+            for task in self.subset_tasks_of_interest:
+                list_is_present_variables = [
+                    is_present
+                    for unary_resource in self.subset_unaryresources_allowed
+                    # filter out trivial 0's corresponding to incompatible (task, resource)
+                    if not (
+                        is_a_trivial_zero(
+                            is_present
+                            := self.get_task_unary_resource_is_present_variable(
+                                task, unary_resource
+                            )
+                        )
+                    )
+                ]
+                if len(list_is_present_variables) > 0:
+                    self.cp_model.add_at_most_one(list_is_present_variables)
+
+            self.at_most_one_unary_resource_per_task_constraints_added = True
 
     def get_nb_tasks_done_variable(self) -> Any:
         self.create_done_variables()

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/allocation.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/allocation.py
@@ -312,7 +312,7 @@ class AllocationIntegerModellingCpSatSolver(
             self.is_present_variables = {}
             for task in tasks:
                 for unary_resource in unary_resources:
-                    if self.problem.is_compatible_task_unary_resource(
+                    if self.is_compatible_task_unary_resource(
                         task=task, unary_resource=unary_resource
                     ):
                         boolvar = self.cp_model.new_bool_var(

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto.py
@@ -1,0 +1,804 @@
+#  Copyright (c) 2026 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+import logging
+from abc import abstractmethod
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Generic, Optional, Union
+
+from ortools.sat.python.cp_model import (
+    CpSolverSolutionCallback,
+    Domain,
+    IntervalVar,
+    IntVar,
+    LinearExprT,
+)
+
+from discrete_optimization.generic_tasks_tools.allocation import UnaryResource
+from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
+from discrete_optimization.generic_tasks_tools.generic_scheduling import (
+    CumulativeResource,
+    GenericSchedulingSolution,
+    Resource,
+)
+from discrete_optimization.generic_tasks_tools.multimode import SinglemodeProblem
+from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
+    NonRenewableResource,
+)
+from discrete_optimization.generic_tasks_tools.scheduling import (
+    Task,
+)
+from discrete_optimization.generic_tasks_tools.solvers.cpsat.generic_scheduling import (
+    GenericSchedulingCpSatSolver,
+)
+from discrete_optimization.generic_tasks_tools.solvers.cpsat.multimode_scheduling import (
+    SinglemodeSchedulingCpSatSolver,
+)
+from discrete_optimization.generic_tools.do_problem import Solution
+from discrete_optimization.generic_tools.do_solver import WarmstartMixin
+
+logger = logging.getLogger(__name__)
+
+
+class Objective(Enum):
+    """Objective to be used by the solver."""
+
+    MAKESPAN = "makespan"
+    """Global makespan of the schedule, to minimize."""
+    NB_TASKS_DONE = "nb_tasks_done"
+    """Number of tasks with at least one resource allocated, to maximize."""
+    NB_UNARY_RESOURCES_USED = "nb_unary_resources_used"
+    """Number of allocated unary resources, to minimize."""
+    NB_RESOURCES_USED = "nb_resources_used"
+    """Weighted sum of resources used, to minimize.
+
+    Include non-renewable, cumulative, and unary resources.
+    The weigths are to be defined in `solver.objective_resource_weights`.
+
+    """
+    RESOURCES_CONSUMPTION = "resources_consumption"
+    """Weighted sum of resources consumptions, to minimize.
+
+    Include non-renewable, cumulative, and unary resources.
+    The weigths are to be defined in `solver.objective_resource_weights`.
+
+    """
+    CUSTOM = "custom_objective"
+
+
+@dataclass
+class TaskVariable(Generic[UnaryResource]):
+    """Task characteristics found by a cpsat solution."""
+
+    start: int  # start time of the task
+    end: int  # end time of the task
+    mode: int  # chosen mode for the task
+    allocated: list[UnaryResource] = field(
+        default_factory=list
+    )  # resources allocated to the task
+    info: dict[str, Any] = field(
+        default_factory=dict
+    )  # additional information if needed
+
+
+@dataclass
+class TemporarySolution(Generic[Task, UnaryResource]):
+    """Temporary format for a cpsat solution."""
+
+    task_variables: dict[Task, TaskVariable[UnaryResource]]
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class GenericSchedulingAutoCpSatSolver(
+    GenericSchedulingCpSatSolver[
+        Task, UnaryResource, CumulativeResource, NonRenewableResource
+    ],
+    WarmstartMixin,
+):
+    """Generic cpsat solver for scheduling problems (with or without allocation).
+
+    The needed variables are automatically created, with common constraints (precedence, resource capacity).
+    The objective is set by default to global makespan but can be changed by modifying `solver.default_objective` value.
+
+    This solver class needs still to be derived to create a solution from the proper class.
+    You will need at least to implement the conversion from the task variables to the actual solution object.
+
+    If custom constraints are needed, override `init_model()`.
+    If a custom objective is needed, set `solver.default_objective` to `Objective.CUSTOM` so that no objective is set
+    by default and override `init_model()` to define your objective.
+
+    """
+
+    # objective settings
+    objective = Objective.MAKESPAN  # Objective set by `init_model()`
+    objective_resource_weights: Optional[
+        dict[Union[CumulativeResource, UnaryResource, NonRenewableResource], int]
+    ] = None
+    """Weights to be used by the objective when summing used resources or resources consumption.
+
+    This is the case if `objective` is set to `Objective.NB_RESOURCES_USED` or  `Objective.RESOURCES_CONSUMPTION`.
+    Default to 1 for resources not mentioned.
+
+    Hypothesis: cumulative, unary, and non-renewable resources have different values.
+    (It could happen that non-renewable resources and renewable lists intersect which whould be a problem
+    for weights definition).
+
+    """
+
+    # allocation settings
+    exactly_one_unary_resource_per_task = (
+        False  # if True, enforce exactly one resource allocated to each task
+    )
+
+    # multimode settings
+    duplicate_start_var_per_mode = (
+        False  # if True, add a start variable for each task mode
+    )
+
+    # cpsat variables
+    start_or_end_variables: dict[tuple[Task, StartOrEnd], LinearExprT]
+    duration_variables: dict[Task, LinearExprT]
+    task_interval_variables = dict[Task, IntervalVar]
+    modes_is_present: dict[Task, dict[int, LinearExprT]]
+    modes_intervals: dict[Task, dict[int, IntervalVar]]
+    modes_start_variables: dict[Task, dict[int, LinearExprT]]
+    allocation_is_present: dict[Task, dict[UnaryResource, LinearExprT]]
+    allocation_intervals: dict[Task, dict[UnaryResource, IntervalVar]]
+    all_used_variables: dict[
+        Union[NonRenewableResource, UnaryResource, CumulativeResource], IntVar
+    ]
+    """Variables tracking whether a (unary, cumulative, or non-renewable) resource has been used at least once."""
+    all_used_variables_created = False
+    """Flag telling whether 'all_used_variables' have been created"""
+    resource_consumption_variables: dict[
+        Union[NonRenewableResource, UnaryResource, CumulativeResource], LinearExprT
+    ]
+    """Variables tracking total consumption of each (unary, cumulative, or non-renewable) resource."""
+    resource_consumption_variables_created = False
+    """Flag telling whether 'resource_consumption_variables' have been created"""
+
+    @property
+    def needs_duration_variables(self) -> bool:
+        """Whether the task duration variables are needed by the model.
+
+        Default implementation, returns True only if the problem is an allocation one (at least one unary resource).
+        If additional custom constraints require them, override it.
+
+        """
+        return len(self.problem.unary_resources_list) > 0
+
+    @property
+    def needs_task_interval(self) -> bool:
+        """Whether the task interval variables are needed by the model.
+
+        By default, these variables are only constraints on durations variables and need not to be stored.
+        If additional custom constraints require them, override this property.
+
+        """
+        return False
+
+    def include_constraint_on_cumulative_resource(
+        self, resource: CumulativeResource
+    ) -> bool:
+        """Whether the cp model should take into account the constraint on the given cumulative resource.
+
+        Some problems define "redundant" cumulative resources that are computed from others.
+        If you want to avoid adding redundant constraints in your model, please override this method.
+
+        Args:
+            resource:
+
+        Returns:
+
+        """
+        return True
+
+    def get_task_start_or_end_lower_bound(
+        self, task: Task, start_or_end: StartOrEnd
+    ) -> int:
+        """Get a lower bound on start or end of a given task.
+
+        Default implementation: calls self.problem.get_task_start_or_end_lower_bound()
+
+        Args:
+            task:
+            start_or_end:
+
+        Returns:
+
+        """
+        return self.problem.get_task_start_or_end_lower_bound(
+            task=task, start_or_end=start_or_end
+        )
+
+    def get_task_start_or_end_upper_bound(
+        self, task: Task, start_or_end: StartOrEnd
+    ) -> int:
+        """Get an upper bound on start or end of a given task.
+
+        Default implementation: takes best of
+        - self.problem.get_task_start_or_end_upper_bound()
+        - self.get_makespan_upper_bound()
+
+        Args:
+            task:
+            start_or_end:
+
+        Returns:
+
+        """
+        return min(
+            self.problem.get_task_start_or_end_upper_bound(
+                task=task, start_or_end=start_or_end
+            ),
+            self.get_makespan_upper_bound(),
+        )
+
+    def init_model(self, **kwargs: Any) -> None:
+        """Init cp model and reset stored variables if any."""
+        super().init_model(**kwargs)
+
+        self._reset_variables()
+        self._create_variables()
+        self._add_constraints()
+        self._set_objective()
+
+    def _reset_variables(self):
+        """Forget about previous variables."""
+        self.start_or_end_variables = {}
+        self.duration_variables = {}
+        self.task_interval_variables = {}
+        self.modes_is_present = {}
+        self.modes_intervals = {}
+        self.modes_start_variables = {}
+        self.allocation_is_present = {}
+        self.allocation_intervals = {}
+
+        self.all_used_variables_created = False
+        self.all_used_variables = {}
+        self.resource_consumption_variables_created = False
+        self.resource_consumption_variables = {}
+
+    def _create_variables(self):
+        self._create_start_or_end_variables()
+        if self.needs_duration_variables or self.needs_task_interval:
+            self._create_task_duration_and_interval_variables()
+        self._create_mode_variables()
+        self._create_allocation_variables()
+
+    def _create_start_or_end_variables(self):
+        for task in self.problem.tasks_list:
+            for start_or_end in StartOrEnd:
+                self.start_or_end_variables[task, start_or_end] = (
+                    self.cp_model.new_int_var(
+                        lb=self.get_task_start_or_end_lower_bound(
+                            task=task, start_or_end=start_or_end
+                        ),
+                        ub=self.get_task_start_or_end_upper_bound(
+                            task=task, start_or_end=start_or_end
+                        ),
+                        name=f"{start_or_end.value}_{task}",
+                    )
+                )
+
+    def _create_task_duration_and_interval_variables(self):
+        """Create task duration variables.
+
+        Also add the interval constraint that tells duration = end - start
+
+        """
+        for task in self.problem.tasks_list:
+            possible_durations = [
+                self.problem.get_task_mode_duration(task=task, mode=mode)
+                for mode in self.problem.get_task_modes(task)
+            ]
+            if len(possible_durations) == 1:
+                # single mode: fixed duration
+                self.duration_variables[task] = possible_durations[0]
+                if self.needs_task_interval:
+                    # interval var required
+                    self.task_interval_variables[task] = (
+                        self.cp_model.new_fixed_size_interval_var(
+                            start=self.start_or_end_variables[task, StartOrEnd.START],
+                            size=self.duration_variables[task],
+                            name=f"interval_{task}",
+                        )
+                    )
+            else:
+                # multi mode
+                self.duration_variables[task] = self.cp_model.new_int_var_from_domain(
+                    domain=Domain.from_values(possible_durations),
+                    name=f"duration_{task}",
+                )
+                # interval constraint
+                task_interval = self.cp_model.new_interval_var(
+                    start=self.start_or_end_variables[task, StartOrEnd.START],
+                    size=self.duration_variables[task],
+                    end=self.start_or_end_variables[task, StartOrEnd.END],
+                    name=f"interval_{task}",
+                )
+                if self.needs_task_interval:
+                    # interval var required
+                    self.task_interval_variables[task] = task_interval
+
+    def _create_mode_variables(self):
+        for task in self.problem.tasks_list:
+            self.modes_is_present[task] = {}
+            self.modes_intervals[task] = {}
+            self.modes_start_variables[task] = {}
+            modes = self.problem.get_task_modes(task=task)
+            if len(modes) == 1:
+                # single mode (at least for this very task)
+                mode = next(iter(modes))
+                self.modes_is_present[task][mode] = 1
+                # create the interval var with start and end => constraint on end - start
+                self.modes_intervals[task][mode] = self.cp_model.new_interval_var(
+                    start=self.start_or_end_variables[task, StartOrEnd.START],
+                    size=self.problem.get_task_mode_duration(task=task, mode=mode),
+                    end=self.start_or_end_variables[task, StartOrEnd.END],
+                    name=f"interval_mode_{task}_{mode}",
+                )
+                if self.duplicate_start_var_per_mode:
+                    self.modes_start_variables[task][mode] = (
+                        self.start_or_end_variables[task, StartOrEnd.START]
+                    )
+            else:
+                for mode in modes:
+                    # multi mode
+                    is_present_mode = self.cp_model.new_bool_var(
+                        name=f"is_present_mode_{task}_{mode}"
+                    )
+                    self.modes_is_present[task][mode] = is_present_mode
+                    start = self.start_or_end_variables[task, StartOrEnd.START]
+                    end = self.start_or_end_variables[task, StartOrEnd.END]
+                    duration_mode = self.problem.get_task_mode_duration(
+                        task=task, mode=mode
+                    )
+                    if self.duplicate_start_var_per_mode:
+                        # create new start variable per mode to model the interval
+                        start_mode = self.cp_model.new_int_var(
+                            lb=self.get_task_start_or_end_lower_bound(
+                                task=task, start_or_end=StartOrEnd.START
+                            ),
+                            ub=self.get_task_start_or_end_upper_bound(
+                                task=task, start_or_end=StartOrEnd.START
+                            ),
+                            name=f"start_{task}_{mode}",
+                        )
+                        self.modes_start_variables[task][mode] = start_mode
+                        self.modes_intervals[task][mode] = (
+                            self.cp_model.new_optional_fixed_size_interval_var(
+                                start=start_mode,
+                                size=duration_mode,
+                                is_present=is_present_mode,
+                                name=f"interval_mode_{task}_{mode}",
+                            )
+                        )
+                        self.cp_model.add(start_mode == start).only_enforce_if(
+                            is_present_mode
+                        )
+                        self.cp_model.add(
+                            start_mode + duration_mode == end
+                        ).only_enforce_if(is_present_mode)
+                    else:
+                        self.modes_intervals[task][mode] = (
+                            self.cp_model.new_optional_interval_var(
+                                start=start,
+                                size=duration_mode,
+                                end=end,
+                                is_present=is_present_mode,
+                                name=f"interval_mode_{task}_{mode}",
+                            )
+                        )
+                self.cp_model.add_exactly_one(
+                    self.modes_is_present[task][mode] for mode in modes
+                )
+
+    def _create_allocation_variables(self):
+        for task in self.problem.tasks_list:
+            self.allocation_is_present[task] = {}
+            self.allocation_intervals[task] = {}
+            for unary_resource in self.problem.unary_resources_list:
+                if self.is_compatible_task_unary_resource(
+                    task=task, unary_resource=unary_resource
+                ):
+                    is_allocated = self.cp_model.new_bool_var(
+                        name=f"is_allocated_{task}_{unary_resource}"
+                    )
+                    self.allocation_is_present[task][unary_resource] = is_allocated
+                    self.allocation_intervals[task][unary_resource] = (
+                        self.cp_model.new_optional_interval_var(
+                            start=self.start_or_end_variables[task, StartOrEnd.START],
+                            size=self.duration_variables[task],
+                            end=self.start_or_end_variables[task, StartOrEnd.END],
+                            is_present=is_allocated,
+                            name=f"interval_allocated_{task}_{unary_resource}",
+                        )
+                    )
+
+    def _create_all_used_variables(self):
+        if not self.all_used_variables_created:
+            self.check_resources_lists()
+            self.create_used_variables()
+            self.all_used_variables = {}
+            for resource in self.problem.unary_resources_list:
+                self.all_used_variables[resource] = self.used_variables[resource]
+            for resource in self.problem.cumulative_resources_list:
+
+                def conso_fn(task: Task, mode: int) -> int:
+                    return self.problem.get_renewable_resource_consumption(
+                        resource=resource, task=task, mode=mode
+                    )
+
+                self.all_used_variables[resource] = (
+                    self._create_mode_resource_used_variable(
+                        resource=resource, conso_fn=conso_fn
+                    )
+                )
+            for resource in self.problem.non_renewable_resources_list:
+
+                def conso_fn(task: Task, mode: int) -> int:
+                    return self.problem.get_non_renewable_resource_consumption(
+                        resource=resource, task=task, mode=mode
+                    )
+
+                self.all_used_variables[resource] = (
+                    self._create_mode_resource_used_variable(
+                        resource=resource, conso_fn=conso_fn
+                    )
+                )
+            self.all_used_variables_created = True
+
+    def _create_mode_resource_used_variable(
+        self,
+        resource: Union[Resource, NonRenewableResource],
+        conso_fn: Callable[[Task, int], int],
+    ) -> IntVar:
+        used = self.cp_model.new_bool_var(f"used_{resource}")
+        list_is_present_variables = [
+            self.get_task_mode_is_present_variable(task=task, mode=mode)
+            for task in self.problem.tasks_list
+            for mode in self.problem.get_task_modes(task=task)
+            if conso_fn(task, mode) > 0
+        ]
+        if len(list_is_present_variables) > 0:
+            self.cp_model.add_max_equality(used, list_is_present_variables)
+        else:
+            self.cp_model.add(used == 0)
+        return used
+
+    def _create_resource_consumption_variables(self):
+        if not self.resource_consumption_variables_created:
+            self.check_resources_lists()
+            self.create_used_variables()
+            # allocated unary resources
+            for resource in self.problem.unary_resources_list:
+                self.resource_consumption_variables[resource] = self.used_variables[
+                    resource
+                ]
+            # cumulative resources
+            for resource in self.problem.cumulative_resources_list:
+                max_capacity = self.problem.get_resource_max_capacity(resource)
+                conso_var = self.cp_model.new_int_var(
+                    lb=0, ub=max_capacity, name=f"conso_{resource}"
+                )
+                if max_capacity > 1:
+                    # cumulative constraint on the new "conso" variable
+                    mode_intervals_consumptions_is_present = [
+                        (
+                            self.get_task_mode_interval(task=task, mode=mode),
+                            conso,
+                            self.get_task_mode_is_present_variable(
+                                task=task, mode=mode
+                            ),
+                        )
+                        for task in self.problem.tasks_list
+                        for mode in self.problem.get_task_modes(task=task)
+                        if (
+                            conso := self.problem.get_renewable_resource_consumption(
+                                resource=resource, task=task, mode=mode
+                            )
+                        )
+                        > 0
+                    ]
+                    intervals = [
+                        interval
+                        for interval, conso, is_present in mode_intervals_consumptions_is_present
+                    ]
+                    demands = [
+                        conso
+                        for interval, conso, is_present in mode_intervals_consumptions_is_present
+                    ]
+                    if len(intervals) > 0:
+                        self.cp_model.add_cumulative(
+                            intervals=intervals,
+                            demands=demands,
+                            capacity=conso_var,
+                        )
+                        for (
+                            _,
+                            conso,
+                            is_present,
+                        ) in mode_intervals_consumptions_is_present:
+                            self.cp_model.add(conso_var >= conso * is_present)
+                    else:
+                        conso_var = 0
+                else:
+                    # disjunctive resource, no need to use the interval variables
+                    # (no overlap constraint already handled by `create_renewable_resources_constraint()`
+                    list_is_present_variables = [
+                        self.get_task_mode_is_present_variable(task=task, mode=mode)
+                        for task in self.problem.tasks_list
+                        for mode in self.problem.get_task_modes(task=task)
+                        if self.problem.get_renewable_resource_consumption(
+                            resource=resource, task=task, mode=mode
+                        )
+                        > 0
+                    ]
+                    if len(list_is_present_variables) > 0:
+                        self.cp_model.add_max_equality(
+                            conso_var, list_is_present_variables
+                        )
+                    else:
+                        conso_var = 0
+
+                self.resource_consumption_variables[resource] = conso_var
+            # non-renewable resources
+            for resource in self.problem.non_renewable_resources_list:
+                self.resource_consumption_variables[resource] = sum(
+                    conso * self.get_task_mode_is_present_variable(task=task, mode=mode)
+                    for task in self.problem.tasks_list
+                    for mode in self.problem.get_task_modes(task=task)
+                    if (
+                        conso := self.problem.get_non_renewable_resource_consumption(
+                            resource=resource, task=task, mode=mode
+                        )
+                    )
+                    > 0
+                )
+
+            self.resource_consumption_variables_created = True
+
+    def check_resources_lists(self):
+        resources_list = (
+            self.problem.renewable_resources_list
+            + self.problem.non_renewable_resources_list
+        )
+        assert len(resources_list) == len(set(resources_list)), (
+            "There are duplicates in resources list, "
+            "potentially because renewable and non-renewable resources intersect."
+        )
+
+    def get_nb_resources_used_variable(self) -> Any:
+        """Get cpsat variable tracking number of resources used at least in one task.
+
+        If necessary, intermediate variables tracking is a specific resource is used are created.
+
+        """
+        weights = self.objective_resource_weights
+        if weights is None:
+            weights = {}
+        self._create_all_used_variables()
+        return sum(
+            weights.get(resource, 1) * used
+            for resource, used in self.all_used_variables.items()
+        )
+
+    def get_aggregated_resources_consumptions_variable(self) -> Any:
+        """Get cpsat variable aggregating consumptions of each resource."""
+        weights = self.objective_resource_weights
+        if weights is None:
+            weights = {}
+        self._create_resource_consumption_variables()
+        return sum(
+            weights.get(resource, 1) * conso
+            for resource, conso in self.resource_consumption_variables.items()
+        )
+
+    def _add_constraints(self) -> None:
+        # non-renewable resources capacity
+        for resource in self.problem.non_renewable_resources_list:
+            self.create_non_renewable_resources_constraint(resource=resource)
+        # cumulative + unary resources calendar
+        for resource in self.problem.renewable_resources_list:
+            if not self.problem.is_cumulative_resource(
+                resource
+            ) or self.include_constraint_on_cumulative_resource(resource=resource):
+                self.create_renewable_resources_constraint(resource=resource)
+        # precedence
+        self.create_precedence_constraints()
+        # at most or exactly one resource allocated per task?
+        self._add_unary_resources_per_task_constraints()
+
+    def _add_unary_resources_per_task_constraints(self) -> None:
+        if self.exactly_one_unary_resource_per_task:
+            if not self.at_most_one_unary_resource_per_task:
+                logger.warning(
+                    "`at_most_one_unary_resource_per_task` False `exactly_one_unary_resource_per_task` set to True. "
+                    "`exactly_one_unary_resource_per_task` will take the precedence."
+                )
+
+            for is_allocated_task_vars_mapping in self.allocation_is_present.values():
+                self.cp_model.add_exactly_one(is_allocated_task_vars_mapping.values())
+                # avoid adding at most constraint when creating done variables
+                self.at_most_one_unary_resource_per_task_constraints_added = True
+        elif self.at_most_one_unary_resource_per_task:
+            self.add_at_most_one_unary_resource_per_task_constraints()
+
+    def _set_objective(self) -> None:
+        objective = None
+        match self.objective:
+            case Objective.MAKESPAN:
+                objective = self.get_global_makespan_variable()
+            case Objective.NB_TASKS_DONE:
+                objective = -self.get_nb_tasks_done_variable()
+            case Objective.NB_UNARY_RESOURCES_USED:
+                objective = self.get_nb_unary_resources_used_variable()
+            case Objective.NB_RESOURCES_USED:
+                objective = self.get_nb_resources_used_variable()
+            case Objective.RESOURCES_CONSUMPTION:
+                objective = self.get_aggregated_resources_consumptions_variable()
+            case Objective.CUSTOM:
+                # do not define it here. User will do it in overridden `init_model()`.
+                ...
+            case _:
+                raise NotImplementedError()
+        if objective is not None:
+            self.cp_model.minimize(objective)
+
+    def get_task_unary_resource_interval(
+        self, task: Task, unary_resource: UnaryResource
+    ) -> IntervalVar:
+        return self.allocation_intervals[task][unary_resource]
+
+    def get_task_unary_resource_is_present_variable(
+        self, task: Task, unary_resource: UnaryResource
+    ) -> LinearExprT:
+        """Return a 0-1 variable/expression telling if the unary_resource is used for the task.
+
+        NB: sometimes the given resource is never to be used by a task and the variable has not been created.
+        The convention is to return 0 in that case.
+
+        """
+        try:
+            return self.allocation_is_present[task][unary_resource]
+        except KeyError:
+            return 0
+
+    def get_task_start_or_end_variable(
+        self, task: Task, start_or_end: StartOrEnd
+    ) -> LinearExprT:
+        return self.start_or_end_variables[task, start_or_end]
+
+    def get_task_mode_is_present_variable(self, task: Task, mode: int) -> LinearExprT:
+        return self.modes_is_present[task][mode]
+
+    def get_task_mode_interval(self, task: Task, mode: int) -> IntervalVar:
+        """Get the interval variable corresponding to given task and mode."""
+        return self.modes_intervals[task][mode]
+
+    def retrieve_tasks_variables(
+        self, cpsolvercb: CpSolverSolutionCallback
+    ) -> TemporarySolution[Task, UnaryResource]:
+        """Construct each task variable from the cpsat solver internal solution.
+
+        It will be called each time the cpsat solver find a new solution.
+        At that point, value of internal variables are accessible via `cpsolvercb.Value(VARIABLE_NAME)`.
+
+        This method is called in `self.retrieve_solution()` before `self.convert_task_variables_to_solution()`.
+        Override it if you need additional information to be stored
+        (either in res.metadata or res.task_variables[task].info).
+
+        Args:
+            cpsolvercb: the ortools callback called when the cpsat solver finds a new solution.
+
+        Returns:
+            the task variables for the intermediate solution
+
+        """
+        task_variables = {}
+        for task in self.problem.tasks_list:
+            start = cpsolvercb.Value(
+                self.start_or_end_variables[task, StartOrEnd.START]
+            )
+            end = cpsolvercb.Value(self.start_or_end_variables[task, StartOrEnd.END])
+            modes = self.problem.get_task_modes(task)
+            if len(modes) == 1:
+                mode = next(iter(modes))
+            else:
+                for mode in modes:
+                    if cpsolvercb.Value(self.modes_is_present[task][mode]):
+                        break
+            allocated = [
+                unary_resource
+                for unary_resource, is_allocated_var in self.allocation_is_present[
+                    task
+                ].items()
+                if cpsolvercb.Value(is_allocated_var)
+            ]
+            task_variables[task] = TaskVariable(
+                start=start, end=end, mode=mode, allocated=allocated
+            )
+        return TemporarySolution(task_variables=task_variables)
+
+    def retrieve_solution(self, cpsolvercb: CpSolverSolutionCallback) -> Solution:
+        # construct generic tasks variables
+        temp_sol = self.retrieve_tasks_variables(cpsolvercb=cpsolvercb)
+        # convert to specific solution type
+        return self.convert_task_variables_to_solution(temp_sol=temp_sol)
+
+    def set_warm_start(self, solution: Solution) -> None:
+        solution: GenericSchedulingSolution[
+            Task, UnaryResource, CumulativeResource, NonRenewableResource
+        ]
+        # warm start cp_model
+        self.cp_model.clear_hints()
+        for task in self.problem.tasks_list:
+            self.cp_model.add_hint(
+                self.start_or_end_variables[task, StartOrEnd.START],
+                solution.get_start_time(task),
+            )
+            self.cp_model.add_hint(
+                self.start_or_end_variables[task, StartOrEnd.END],
+                solution.get_end_time(task),
+            )
+            modes = self.problem.get_task_modes(task)
+            if len(modes) > 1:
+                hinted_mode = solution.get_mode(task)
+                for mode in modes:
+                    self.cp_model.add_hint(
+                        self.modes_is_present[task][mode], mode == hinted_mode
+                    )
+                if self.needs_duration_variables:
+                    self.cp_model.add_hint(
+                        self.duration_variables[task],
+                        self.problem.get_task_mode_duration(
+                            task=task, mode=hinted_mode
+                        ),
+                    )
+            for unary_resource, is_allocated_var in self.allocation_is_present[
+                task
+            ].items():
+                self.cp_model.add_hint(
+                    is_allocated_var,
+                    solution.is_allocated(task=task, unary_resource=unary_resource),
+                )
+
+    @abstractmethod
+    def convert_task_variables_to_solution(
+        self, temp_sol: TemporarySolution[Task, UnaryResource]
+    ) -> GenericSchedulingSolution[
+        Task, UnaryResource, CumulativeResource, NonRenewableResource
+    ]:
+        """Convert solution from autosolver format into do format.
+
+        To be used in `self.retrieve_solution()`.
+
+        Args:
+            temp_sol:
+
+        Returns:
+
+        """
+        ...
+
+
+class SinglemodeGenericSchedulingAutoCpSatSolver(
+    GenericSchedulingAutoCpSatSolver[
+        Task, UnaryResource, CumulativeResource, NonRenewableResource
+    ],
+    SinglemodeSchedulingCpSatSolver[Task],
+):
+    """Subclass of GenericSchedulingAutoCpSatSolver for single mode problems.
+
+    Give access to task intervals without dealing with modes.
+
+    """
+
+    problem: SinglemodeProblem[Task]
+
+    def get_task_interval(self, task: Task) -> IntervalVar:
+        """Task interval with fixed duration, single mode."""
+        return self.get_task_mode_interval(task=task, mode=self.problem.default_mode)

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto.py
@@ -428,7 +428,7 @@ class GenericSchedulingAutoCpSatSolver(
             for resource in self.problem.cumulative_resources_list:
 
                 def conso_fn(task: Task, mode: int) -> int:
-                    return self.problem.get_renewable_resource_consumption(
+                    return self.problem.get_cumulative_resource_consumption(
                         resource=resource, task=task, mode=mode
                     )
 
@@ -497,7 +497,7 @@ class GenericSchedulingAutoCpSatSolver(
                         for task in self.problem.tasks_list
                         for mode in self.problem.get_task_modes(task=task)
                         if (
-                            conso := self.problem.get_renewable_resource_consumption(
+                            conso := self.problem.get_cumulative_resource_consumption(
                                 resource=resource, task=task, mode=mode
                             )
                         )
@@ -527,12 +527,12 @@ class GenericSchedulingAutoCpSatSolver(
                         conso_var = 0
                 else:
                     # disjunctive resource, no need to use the interval variables
-                    # (no overlap constraint already handled by `create_renewable_resources_constraint()`
+                    # (no overlap constraint already handled by `create_calendar_resources_constraint()`
                     list_is_present_variables = [
                         self.get_task_mode_is_present_variable(task=task, mode=mode)
                         for task in self.problem.tasks_list
                         for mode in self.problem.get_task_modes(task=task)
-                        if self.problem.get_renewable_resource_consumption(
+                        if self.problem.get_cumulative_resource_consumption(
                             resource=resource, task=task, mode=mode
                         )
                         > 0
@@ -563,12 +563,12 @@ class GenericSchedulingAutoCpSatSolver(
 
     def check_resources_lists(self):
         resources_list = (
-            self.problem.renewable_resources_list
+            self.problem.calendar_resources_list
             + self.problem.non_renewable_resources_list
         )
         assert len(resources_list) == len(set(resources_list)), (
             "There are duplicates in resources list, "
-            "potentially because renewable and non-renewable resources intersect."
+            "potentially because calendar and non-renewable resources intersect."
         )
 
     def get_nb_resources_used_variable(self) -> Any:
@@ -602,11 +602,11 @@ class GenericSchedulingAutoCpSatSolver(
         for resource in self.problem.non_renewable_resources_list:
             self.create_non_renewable_resources_constraint(resource=resource)
         # cumulative + unary resources calendar
-        for resource in self.problem.renewable_resources_list:
+        for resource in self.problem.calendar_resources_list:
             if not self.problem.is_cumulative_resource(
                 resource
             ) or self.include_constraint_on_cumulative_resource(resource=resource):
-                self.create_renewable_resources_constraint(resource=resource)
+                self.create_calendar_resources_constraint(resource=resource)
         # precedence
         self.create_precedence_constraints()
         # at most or exactly one resource allocated per task?

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/calendar_resource.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/calendar_resource.py
@@ -8,8 +8,8 @@ from typing import Generic
 from ortools.sat.python.cp_model import IntervalVar
 
 from discrete_optimization.generic_tasks_tools.base import Task
-from discrete_optimization.generic_tasks_tools.renewable_resource import (
-    RenewableResourceProblem,
+from discrete_optimization.generic_tasks_tools.calendar_resource import (
+    CalendarResourceProblem,
     Resource,
 )
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.scheduling import (
@@ -17,13 +17,11 @@ from discrete_optimization.generic_tasks_tools.solvers.cpsat.scheduling import (
 )
 
 
-class RenewableResourceCpSatSolver(
-    SchedulingCpSatSolver[Task], Generic[Task, Resource]
-):
-    problem: RenewableResourceProblem[Task, Resource]
+class CalendarResourceCpSatSolver(SchedulingCpSatSolver[Task], Generic[Task, Resource]):
+    problem: CalendarResourceProblem[Task, Resource]
 
-    def create_renewable_resources_constraint(self, resource: Resource):
-        """Add the constraint for renewable resources to the cpsat model.
+    def create_calendar_resources_constraint(self, resource: Resource):
+        """Add the constraint for renewable resources with an availability calendar to the cpsat model.
 
         Constraint ensuring that the total demand on the given resource stay below its capacity.
 

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/cumulative_resource.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/cumulative_resource.py
@@ -8,9 +8,11 @@ from ortools.sat.python.cp_model import IntervalVar
 
 from discrete_optimization.generic_tasks_tools.base import Task
 from discrete_optimization.generic_tasks_tools.cumulative_resource import (
+    CumulativeResource,
     CumulativeResourceProblem,
+    OtherRenewableResource,
+    Resource,
 )
-from discrete_optimization.generic_tasks_tools.renewable_resource import Resource
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.multimode_scheduling import (
     MultimodeSchedulingCpSatSolver,
 )
@@ -22,11 +24,11 @@ from discrete_optimization.generic_tasks_tools.solvers.cpsat.renewable_resource 
 class CumulativeResourceSchedulingCpSatSolver(
     RenewableResourceCpSatSolver[Task, Resource],
     MultimodeSchedulingCpSatSolver[Task],
-    Generic[Task, Resource],
+    Generic[Task, CumulativeResource, OtherRenewableResource],
 ):
     """Base class for cpsat solvers dealing with scheduling problems handling cumulative resources."""
 
-    problem: CumulativeResourceProblem[Task, Resource]
+    problem: CumulativeResourceProblem[Task, CumulativeResource, OtherRenewableResource]
 
     def get_resource_consumption_intervals(
         self, resource: Resource

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/cumulative_resource.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/cumulative_resource.py
@@ -10,25 +10,25 @@ from discrete_optimization.generic_tasks_tools.base import Task
 from discrete_optimization.generic_tasks_tools.cumulative_resource import (
     CumulativeResource,
     CumulativeResourceProblem,
-    OtherRenewableResource,
+    OtherCalendarResource,
     Resource,
+)
+from discrete_optimization.generic_tasks_tools.solvers.cpsat.calendar_resource import (
+    CalendarResourceCpSatSolver,
 )
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.multimode_scheduling import (
     MultimodeSchedulingCpSatSolver,
 )
-from discrete_optimization.generic_tasks_tools.solvers.cpsat.renewable_resource import (
-    RenewableResourceCpSatSolver,
-)
 
 
 class CumulativeResourceSchedulingCpSatSolver(
-    RenewableResourceCpSatSolver[Task, Resource],
+    CalendarResourceCpSatSolver[Task, Resource],
     MultimodeSchedulingCpSatSolver[Task],
-    Generic[Task, CumulativeResource, OtherRenewableResource],
+    Generic[Task, CumulativeResource, OtherCalendarResource],
 ):
     """Base class for cpsat solvers dealing with scheduling problems handling cumulative resources."""
 
-    problem: CumulativeResourceProblem[Task, CumulativeResource, OtherRenewableResource]
+    problem: CumulativeResourceProblem[Task, CumulativeResource, OtherCalendarResource]
 
     def get_resource_consumption_intervals(
         self, resource: Resource
@@ -37,7 +37,7 @@ class CumulativeResourceSchedulingCpSatSolver(
             return [
                 (
                     self.get_task_mode_interval(task=task, mode=mode),
-                    self.problem.get_renewable_resource_consumption(
+                    self.problem.get_cumulative_resource_consumption(
                         resource=resource, task=task, mode=mode
                     ),
                 )

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/generic_scheduling.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/generic_scheduling.py
@@ -67,7 +67,7 @@ class GenericSchedulingCpSatSolver(
                     1,
                 )
                 for task in tasks
-                if self.problem.is_compatible_task_unary_resource(
+                if self.is_compatible_task_unary_resource(
                     task=task, unary_resource=resource
                 )
             ]

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/generic_scheduling.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/generic_scheduling.py
@@ -8,12 +8,12 @@ from typing import Generic
 from ortools.sat.python.cp_model import IntervalVar
 
 from discrete_optimization.generic_tasks_tools.allocation import UnaryResource
-from discrete_optimization.generic_tasks_tools.allocation_scheduling import (
-    AllocationSchedulingProblem,
+from discrete_optimization.generic_tasks_tools.base import Task
+from discrete_optimization.generic_tasks_tools.generic_scheduling import (
     CumulativeResource,
+    GenericSchedulingProblem,
     Resource,
 )
-from discrete_optimization.generic_tasks_tools.base import Task
 from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
     NonRenewableResource,
 )
@@ -31,14 +31,26 @@ from discrete_optimization.generic_tasks_tools.solvers.cpsat.precedence_scheduli
 )
 
 
-class AllocationSchedulingCpSatSolver(
+class GenericSchedulingCpSatSolver(
     CumulativeResourceSchedulingCpSatSolver[Task, Resource],
     NonRenewableCpSatSolver[Task, NonRenewableResource],
     AllocationCpSatSolver[Task, UnaryResource],
     PrecedenceSchedulingCpSatSolver[Task],
     Generic[Task, UnaryResource, CumulativeResource, NonRenewableResource],
 ):
-    problem: AllocationSchedulingProblem[
+    """Mixin for cpsat solver dealing with sheduling + allocation problems.
+
+    Has access to helping methods to create constraints for
+    - precedence
+    - renewable resource with calendar (unary resource to allocate, or cumulative resource)
+    - non-renewable resource capacity
+
+    For a more all-in-one version actually creating variables, constraints and objectives,
+    see `GenericSchedulingAutoCpSatSolver`.
+
+    """
+
+    problem: GenericSchedulingProblem[
         Task, UnaryResource, CumulativeResource, NonRenewableResource
     ]
 

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/generic_scheduling.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/generic_scheduling.py
@@ -32,7 +32,7 @@ from discrete_optimization.generic_tasks_tools.solvers.cpsat.precedence_scheduli
 
 
 class GenericSchedulingCpSatSolver(
-    CumulativeResourceSchedulingCpSatSolver[Task, Resource],
+    CumulativeResourceSchedulingCpSatSolver[Task, CumulativeResource, UnaryResource],
     NonRenewableCpSatSolver[Task, NonRenewableResource],
     AllocationCpSatSolver[Task, UnaryResource],
     PrecedenceSchedulingCpSatSolver[Task],

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/multimode_scheduling.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/multimode_scheduling.py
@@ -10,9 +10,11 @@ from ortools.sat.python.cp_model import IntervalVar
 from discrete_optimization.generic_tasks_tools.base import Task
 from discrete_optimization.generic_tasks_tools.multimode_scheduling import (
     MultimodeSchedulingProblem,
+    SinglemodeSchedulingProblem,
 )
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.multimode import (
     MultimodeCpSatSolver,
+    SinglemodeCpSatSolver,
 )
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.scheduling import (
     SchedulingCpSatSolver,
@@ -22,17 +24,7 @@ from discrete_optimization.generic_tasks_tools.solvers.cpsat.scheduling import (
 class MultimodeSchedulingCpSatSolver(
     SchedulingCpSatSolver[Task], MultimodeCpSatSolver[Task], Generic[Task]
 ):
-    """Base class for cpsat solvers dealing with scheduling problems whose tasks durations depend only on mode.
-
-    Automatically managed creation of some variables
-    - start
-    - end
-    - task-mode choice + only one to chosen constraint
-    - duration
-    - task intervals (constraint duration = end - start)
-    - task-mode opt intervals
-
-    """
+    """Base class for cpsat solvers dealing with scheduling problems whose tasks durations depend only on mode."""
 
     problem: MultimodeSchedulingProblem[Task]
 
@@ -40,3 +32,19 @@ class MultimodeSchedulingCpSatSolver(
     def get_task_mode_interval(self, task: Task, mode: int) -> IntervalVar:
         """Get the interval variable corresponding to given task and mode."""
         ...
+
+
+class SinglemodeSchedulingCpSatSolver(
+    MultimodeSchedulingCpSatSolver[Task], SinglemodeCpSatSolver[Task]
+):
+    """Base class for cpsat solvers dealing with single mode scheduling problems with fixed tasks durations."""
+
+    problem: SinglemodeSchedulingProblem[Task]
+
+    @abstractmethod
+    def get_task_interval(self, task: Task) -> IntervalVar:
+        """Get the interval variable corresponding to given task."""
+        ...
+
+    def get_task_mode_interval(self, task: Task, mode: int) -> IntervalVar:
+        return self.get_task_interval(task=task)

--- a/src/discrete_optimization/generic_tasks_tools/solvers/lns_cp/constraint_extractor.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/lns_cp/constraint_extractor.py
@@ -10,6 +10,7 @@ from discrete_optimization.generic_tasks_tools.allocation import (
     AllocationCpSolver,
     AllocationProblem,
     AllocationSolution,
+    WithoutAllocationProblem,
 )
 from discrete_optimization.generic_tasks_tools.base import (
     Task,
@@ -733,7 +734,9 @@ def build_default_constraint_extractor(
                 fix_secondary_tasks_modes=params_constraint_extractor.fix_secondary_tasks_allocation,
             )
         )
-    if isinstance(problem, AllocationProblem):
+    if isinstance(problem, AllocationProblem) and not isinstance(
+        problem, WithoutAllocationProblem
+    ):
         if params_constraint_extractor.allocation_subtasks:
             extractors.append(
                 SubtasksAllocationConstraintExtractor(

--- a/src/discrete_optimization/generic_tasks_tools/solvers/lns_cp/constraint_handler.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/lns_cp/constraint_handler.py
@@ -8,6 +8,7 @@ from discrete_optimization.generic_tasks_tools.allocation import (
     AllocationCpSolver,
     AllocationProblem,
     AllocationSolution,
+    WithoutAllocationProblem,
 )
 from discrete_optimization.generic_tasks_tools.base import (
     Task,
@@ -104,8 +105,9 @@ class TasksConstraintHandler(ConstraintHandler, Generic[Task]):
             raise ValueError(
                 f"{self.objective_subproblem} objective possible only for a scheduling problem."
             )
-        if self.objective_subproblem in ALLOCATION_OBJECTIVES and not isinstance(
-            problem, AllocationProblem
+        if self.objective_subproblem in ALLOCATION_OBJECTIVES and (
+            not isinstance(problem, AllocationProblem)
+            or isinstance(problem, WithoutAllocationProblem)
         ):
             raise ValueError(
                 f"{self.objective_subproblem} objective possible only for an allocation problem."

--- a/src/discrete_optimization/generic_tasks_tools/solvers/lns_cp/neighbor_tools.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/lns_cp/neighbor_tools.py
@@ -18,6 +18,7 @@ from discrete_optimization.generic_tasks_tools.base import (
 )
 from discrete_optimization.generic_tasks_tools.precedence import (
     PrecedenceProblem,
+    WithoutPrecedenceProblem,
 )
 from discrete_optimization.generic_tasks_tools.scheduling import (
     SchedulingProblem,
@@ -333,8 +334,10 @@ class NeighborRandomAndNeighborGraph(NeighborBuilder[Task]):
 def build_default_neighbor_builder(
     problem: TasksProblem[Task],
 ) -> NeighborBuilder[Task]:
-    if isinstance(problem, PrecedenceProblem) and isinstance(
-        problem, SchedulingProblem
+    if (
+        isinstance(problem, PrecedenceProblem)
+        and not isinstance(problem, WithoutPrecedenceProblem)
+        and isinstance(problem, SchedulingProblem)
     ):
         return NeighborBuilderMix(
             list_neighbor=[

--- a/src/discrete_optimization/jsp/problem.py
+++ b/src/discrete_optimization/jsp/problem.py
@@ -5,9 +5,32 @@
 #  here https://github.com/erachelson/seq_dec_mak/blob/main/scheduling_newcourse/correction/nb2_jobshopsolver.py
 from __future__ import annotations
 
-from discrete_optimization.generic_tasks_tools.precedence_scheduling import (
-    PrecedenceSchedulingProblem,
-    PrecedenceSchedulingSolution,
+from discrete_optimization.generic_tasks_tools.allocation import (
+    NoUnaryResource,
+    WithoutAllocationProblem,
+    WithoutAllocationSolution,
+)
+from discrete_optimization.generic_tasks_tools.cumulative_resource import (
+    NoCumulativeResource,
+    WithoutCumulativeResourceProblem,
+    WithoutCumulativeResourceSolution,
+)
+from discrete_optimization.generic_tasks_tools.generic_scheduling import (
+    GenericSchedulingProblem,
+    GenericSchedulingSolution,
+)
+from discrete_optimization.generic_tasks_tools.multimode_scheduling import (
+    SinglemodeSchedulingProblem,
+    SinglemodeSchedulingSolution,
+)
+from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
+    NoNonRenewableResource,
+    WithoutNonRenewableResourceProblem,
+    WithoutNonRenewableResourceSolution,
+)
+from discrete_optimization.generic_tasks_tools.renewable_resource import (
+    WithoutRenewableResourceProblem,
+    WithoutRenewableResourceSolution,
 )
 from discrete_optimization.generic_tools.do_problem import (
     ModeOptim,
@@ -22,7 +45,16 @@ Task = tuple[int, int]
 """Task representation: (job index, subjob index)."""
 
 
-class JobShopSolution(PrecedenceSchedulingSolution[Task]):
+class JobShopSolution(
+    GenericSchedulingSolution[
+        Task, NoUnaryResource, NoCumulativeResource, NoNonRenewableResource
+    ],
+    WithoutCumulativeResourceSolution[Task, NoUnaryResource],
+    WithoutNonRenewableResourceSolution[Task],
+    WithoutAllocationSolution[Task],
+    WithoutRenewableResourceSolution[Task],
+    SinglemodeSchedulingSolution[Task],
+):
     problem: JobShopProblem
 
     def __init__(self, problem: JobShopProblem, schedule: list[list[tuple[int, int]]]):
@@ -55,7 +87,16 @@ class Subjob:
         self.processing_time = processing_time
 
 
-class JobShopProblem(PrecedenceSchedulingProblem[Task]):
+class JobShopProblem(
+    GenericSchedulingProblem[
+        Task, NoUnaryResource, NoCumulativeResource, NoNonRenewableResource
+    ],
+    WithoutCumulativeResourceProblem[Task, NoUnaryResource],
+    WithoutNonRenewableResourceProblem[Task],
+    WithoutAllocationProblem[Task],
+    WithoutRenewableResourceProblem[Task],
+    SinglemodeSchedulingProblem[Task],
+):
     n_jobs: int
     n_machines: int
     list_jobs: list[list[Subjob]]
@@ -91,6 +132,10 @@ class JobShopProblem(PrecedenceSchedulingProblem[Task]):
     @property
     def tasks_list(self) -> list[Task]:
         return [(j, k) for j, job in enumerate(self.list_jobs) for k in range(len(job))]
+
+    def get_task_duration(self, task: Task) -> int:
+        j, k = task
+        return self.list_jobs[j][k].processing_time
 
     def get_precedence_constraints(self) -> dict[Task, list[Task]]:
         return {

--- a/src/discrete_optimization/jsp/problem.py
+++ b/src/discrete_optimization/jsp/problem.py
@@ -10,6 +10,10 @@ from discrete_optimization.generic_tasks_tools.allocation import (
     WithoutAllocationProblem,
     WithoutAllocationSolution,
 )
+from discrete_optimization.generic_tasks_tools.calendar_resource import (
+    WithoutCalendarResourceProblem,
+    WithoutCalendarResourceSolution,
+)
 from discrete_optimization.generic_tasks_tools.cumulative_resource import (
     NoCumulativeResource,
     WithoutCumulativeResourceProblem,
@@ -27,10 +31,6 @@ from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
     NoNonRenewableResource,
     WithoutNonRenewableResourceProblem,
     WithoutNonRenewableResourceSolution,
-)
-from discrete_optimization.generic_tasks_tools.renewable_resource import (
-    WithoutRenewableResourceProblem,
-    WithoutRenewableResourceSolution,
 )
 from discrete_optimization.generic_tools.do_problem import (
     ModeOptim,
@@ -52,7 +52,7 @@ class JobShopSolution(
     WithoutCumulativeResourceSolution[Task, NoUnaryResource],
     WithoutNonRenewableResourceSolution[Task],
     WithoutAllocationSolution[Task],
-    WithoutRenewableResourceSolution[Task],
+    WithoutCalendarResourceSolution[Task],
     SinglemodeSchedulingSolution[Task],
 ):
     problem: JobShopProblem
@@ -94,7 +94,7 @@ class JobShopProblem(
     WithoutCumulativeResourceProblem[Task, NoUnaryResource],
     WithoutNonRenewableResourceProblem[Task],
     WithoutAllocationProblem[Task],
-    WithoutRenewableResourceProblem[Task],
+    WithoutCalendarResourceProblem[Task],
     SinglemodeSchedulingProblem[Task],
 ):
     n_jobs: int

--- a/src/discrete_optimization/jsp/solvers/cpsat_auto.py
+++ b/src/discrete_optimization/jsp/solvers/cpsat_auto.py
@@ -1,0 +1,64 @@
+#  Copyright (c) 2024 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+#  Adaptation of
+#  https://github.com/erachelson/seq_dec_mak/blob/main/scheduling_newcourse/correction/nb2_jobshopsolver.py
+import logging
+from typing import Any
+
+from discrete_optimization.generic_tasks_tools.allocation import (
+    NoUnaryResource,
+    UnaryResource,
+)
+from discrete_optimization.generic_tasks_tools.cumulative_resource import (
+    NoCumulativeResource,
+)
+from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
+    NoNonRenewableResource,
+)
+from discrete_optimization.generic_tasks_tools.solvers.cpsat.auto import (
+    SinglemodeGenericSchedulingAutoCpSatSolver,
+    TemporarySolution,
+)
+from discrete_optimization.jsp.problem import JobShopProblem, JobShopSolution, Task
+
+logger = logging.getLogger(__name__)
+
+
+class CpSatAutoJspSolver(
+    SinglemodeGenericSchedulingAutoCpSatSolver[
+        Task, NoUnaryResource, NoCumulativeResource, NoNonRenewableResource
+    ],
+):
+    problem: JobShopProblem
+
+    def get_makespan_upper_bound(self) -> int:
+        return self._max_time
+
+    def init_model(self, **kwargs: Any) -> None:
+        # dummy value, todo : compute a better bound
+        max_time = kwargs.get(
+            "max_time",
+            self.problem.get_makespan_upper_bound(),
+        )
+        self._max_time = max_time  # will be used by the makespan variable
+
+        super().init_model(**kwargs)
+
+        # No overlap task on the same machine.
+        for machine, tasks in self.problem.job_per_machines.items():
+            self.cp_model.add_no_overlap(
+                self.get_task_interval(task=task) for task in tasks
+            )
+
+    def convert_task_variables_to_solution(
+        self, temp_sol: TemporarySolution[Task, UnaryResource]
+    ) -> JobShopSolution:
+        schedule = [
+            [
+                ((task_var := temp_sol.task_variables[j, k]).start, task_var.end)
+                for k, sub_job in enumerate(job)
+            ]
+            for j, job in enumerate(self.problem.list_jobs)
+        ]
+        return JobShopSolution(problem=self.problem, schedule=schedule)

--- a/src/discrete_optimization/rcpsp/problem.py
+++ b/src/discrete_optimization/rcpsp/problem.py
@@ -17,17 +17,13 @@ from discrete_optimization.generic_rcpsp_tools.attribute_type import (
     ListIntegerRcpsp,
     PermutationRcpsp,
 )
-from discrete_optimization.generic_tasks_tools.cumulative_resource import (
-    CumulativeResourceProblem,
+from discrete_optimization.generic_tasks_tools.allocation import (
+    NoUnaryResource,
+    WithoutAllocationProblem,
 )
-from discrete_optimization.generic_tasks_tools.multimode_scheduling import (
-    MultimodeSchedulingProblem,
-)
-from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
-    NonRenewableResourceProblem,
-)
-from discrete_optimization.generic_tasks_tools.precedence_scheduling import (
-    PrecedenceSchedulingProblem,
+from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
+from discrete_optimization.generic_tasks_tools.generic_scheduling import (
+    GenericSchedulingProblem,
 )
 from discrete_optimization.generic_tasks_tools.renewable_resource import (
     convert_calendar_to_availability_intervals,
@@ -49,6 +45,7 @@ from discrete_optimization.rcpsp.fast_function import (
     sgs_fast_partial_schedule_incomplete_permutation_tasks,
 )
 from discrete_optimization.rcpsp.solution import (
+    CumulativeResource,
     NonRenewableResource,
     RcpspSolution,
     Resource,
@@ -58,7 +55,11 @@ from discrete_optimization.rcpsp.special_constraints import (
     PairModeConstraint,
     SpecialConstraintsDescription,
 )
-from discrete_optimization.rcpsp.utils import intersect
+from discrete_optimization.rcpsp.utils import (
+    get_end_bounds_from_additional_constraint,
+    get_start_bounds_from_additional_constraint,
+    intersect,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -69,10 +70,10 @@ class ScheduleGenerationScheme(Enum):
 
 
 class RcpspProblem(
-    PrecedenceSchedulingProblem[Task],
-    CumulativeResourceProblem[Task, Resource],
-    NonRenewableResourceProblem[Task, NonRenewableResource],
-    MultimodeSchedulingProblem[Task],
+    GenericSchedulingProblem[
+        Task, NoUnaryResource, CumulativeResource, NonRenewableResource
+    ],
+    WithoutAllocationProblem[Task],
 ):
     """Main class for RCPSP problem.
 
@@ -364,6 +365,14 @@ class RcpspProblem(
     def non_renewable_resources_list(self) -> list[NonRenewableResource]:
         return self.non_renewable_resources
 
+    @property
+    def cumulative_resources_list(self) -> list[CumulativeResource]:
+        return [
+            resource
+            for resource in self.resources_list
+            if resource not in self.non_renewable_resources
+        ]
+
     def get_non_renewable_resource_capacity(
         self, resource: NonRenewableResource
     ) -> int:
@@ -378,14 +387,6 @@ class RcpspProblem(
     ) -> int:
         mode_detail = self.mode_details[task][mode]
         return mode_detail.get(resource, 0)
-
-    @property
-    def renewable_resources_list(self) -> list[Resource]:
-        return [
-            res
-            for res in self.resources_list
-            if res not in self.non_renewable_resources
-        ]
 
     @cache
     def get_resource_availabilities(
@@ -404,9 +405,6 @@ class RcpspProblem(
             mode_detail = self.mode_details[task][mode]
             return mode_detail.get(resource, 0)
 
-    def is_cumulative_resource(self, resource: Resource) -> bool:
-        return resource in self.resources_list
-
     def get_task_mode_duration(self, task: Task, mode: int) -> int:
         return self.mode_details[task][mode]["duration"]
 
@@ -421,6 +419,34 @@ class RcpspProblem(
 
     def get_makespan_upper_bound(self) -> int:
         return self.horizon
+
+    def get_task_start_or_end_lower_bound(
+        self, task: Task, start_or_end: StartOrEnd
+    ) -> int:
+        match start_or_end:
+            case StartOrEnd.START:
+                lb, ub = get_start_bounds_from_additional_constraint(
+                    rcpsp_problem=self, activity=task
+                )
+            case _:
+                lb, ub = get_end_bounds_from_additional_constraint(
+                    rcpsp_problem=self, activity=task
+                )
+        return lb
+
+    def get_task_start_or_end_upper_bound(
+        self, task: Task, start_or_end: StartOrEnd
+    ) -> int:
+        match start_or_end:
+            case StartOrEnd.START:
+                lb, ub = get_start_bounds_from_additional_constraint(
+                    rcpsp_problem=self, activity=task
+                )
+            case _:
+                lb, ub = get_end_bounds_from_additional_constraint(
+                    rcpsp_problem=self, activity=task
+                )
+        return ub
 
     def update_functions(self) -> None:
         (

--- a/src/discrete_optimization/rcpsp/problem.py
+++ b/src/discrete_optimization/rcpsp/problem.py
@@ -21,12 +21,12 @@ from discrete_optimization.generic_tasks_tools.allocation import (
     NoUnaryResource,
     WithoutAllocationProblem,
 )
+from discrete_optimization.generic_tasks_tools.calendar_resource import (
+    convert_calendar_to_availability_intervals,
+)
 from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
 from discrete_optimization.generic_tasks_tools.generic_scheduling import (
     GenericSchedulingProblem,
-)
-from discrete_optimization.generic_tasks_tools.renewable_resource import (
-    convert_calendar_to_availability_intervals,
 )
 from discrete_optimization.generic_tools.do_problem import (
     ModeOptim,
@@ -396,7 +396,7 @@ class RcpspProblem(
             calendar=self.resources[resource], horizon=self.horizon
         )
 
-    def get_renewable_resource_consumption(
+    def get_cumulative_resource_consumption(
         self, resource: Resource, task: Task, mode: int
     ) -> int:
         if not self.is_cumulative_resource(resource):
@@ -583,7 +583,7 @@ class RcpspProblem(
                 return False
 
         # Check for cumumative resource violation
-        if not variable.check_all_renewable_resource_capacity_constraints():
+        if not variable.check_all_calendar_resource_capacity_constraints():
             return False
 
         # Check for non-renewable resource violation

--- a/src/discrete_optimization/rcpsp/solution.py
+++ b/src/discrete_optimization/rcpsp/solution.py
@@ -13,17 +13,12 @@ from typing import TYPE_CHECKING, Any, Optional
 import numpy as np
 from numpy import typing as npt
 
-from discrete_optimization.generic_tasks_tools.cumulative_resource import (
-    CumulativeResourceSolution,
+from discrete_optimization.generic_tasks_tools.allocation import (
+    NoUnaryResource,
+    WithoutAllocationSolution,
 )
-from discrete_optimization.generic_tasks_tools.multimode_scheduling import (
-    MultimodeSchedulingSolution,
-)
-from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
-    NonRenewableResourceSolution,
-)
-from discrete_optimization.generic_tasks_tools.precedence_scheduling import (
-    PrecedenceSchedulingSolution,
+from discrete_optimization.generic_tasks_tools.generic_scheduling import (
+    GenericSchedulingSolution,
 )
 from discrete_optimization.generic_tools.do_problem import RobustProblem
 
@@ -33,6 +28,7 @@ if TYPE_CHECKING:  # avoid circular imports due to annotations
 Task = Hashable
 Resource = str
 NonRenewableResource = str
+CumulativeResource = Resource
 
 
 class TaskDetails:
@@ -42,10 +38,10 @@ class TaskDetails:
 
 
 class RcpspSolution(
-    PrecedenceSchedulingSolution[Task],
-    CumulativeResourceSolution[Task, Resource],
-    NonRenewableResourceSolution[Task, NonRenewableResource],
-    MultimodeSchedulingSolution[Task],
+    GenericSchedulingSolution[
+        Task, NoUnaryResource, CumulativeResource, NonRenewableResource
+    ],
+    WithoutAllocationSolution[Task],
 ):
     """Solution to RcpspProblem problems.
 

--- a/src/discrete_optimization/rcpsp/solvers/cpsat.py
+++ b/src/discrete_optimization/rcpsp/solvers/cpsat.py
@@ -19,6 +19,7 @@ from ortools.sat.python.cp_model import (
     ObjLinearExprT,
 )
 
+from discrete_optimization.generic_tasks_tools.allocation import NoUnaryResource
 from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.cumulative_resource import (
     CumulativeResourceSchedulingCpSatSolver,
@@ -40,10 +41,12 @@ from discrete_optimization.generic_tools.result_storage.result_storage import (
 from discrete_optimization.rcpsp.problem import (
     RcpspProblem,
     RcpspSolution,
-    Resource,
     Task,
 )
-from discrete_optimization.rcpsp.solution import NonRenewableResource
+from discrete_optimization.rcpsp.solution import (
+    CumulativeResource,
+    NonRenewableResource,
+)
 from discrete_optimization.rcpsp.solvers import RcpspSolver
 from discrete_optimization.rcpsp.special_constraints import PairModeConstraint
 from discrete_optimization.rcpsp.utils import (
@@ -56,7 +59,7 @@ logger = logging.getLogger(__name__)
 
 class CpSatRcpspSolver(
     PrecedenceSchedulingCpSatSolver[Task],
-    CumulativeResourceSchedulingCpSatSolver[Task, Resource],
+    CumulativeResourceSchedulingCpSatSolver[Task, CumulativeResource, NoUnaryResource],
     NonRenewableCpSatSolver[Task, NonRenewableResource],
     RcpspSolver,
     WarmstartMixin,

--- a/src/discrete_optimization/rcpsp/solvers/cpsat.py
+++ b/src/discrete_optimization/rcpsp/solvers/cpsat.py
@@ -151,7 +151,7 @@ class CpSatRcpspSolver(
         if resource in self.problem.non_renewable_resources:
             self.create_non_renewable_resources_constraint(resource=resource)
         else:
-            self.create_renewable_resources_constraint(resource=resource)
+            self.create_calendar_resources_constraint(resource=resource)
 
     def create_mode_pair_constraint(
         self,
@@ -385,10 +385,10 @@ class CpSatResourceRcpspSolver(CpSatRcpspSolver):
                     resource=resource, task=task, mode=mode
                 )
         else:
-            self.create_renewable_resources_constraint(resource=resource)
+            self.create_calendar_resources_constraint(resource=resource)
 
             def get_resource_consumption(task: Task, mode: int) -> int:
-                return self.problem.get_renewable_resource_consumption(
+                return self.problem.get_cumulative_resource_consumption(
                     resource=resource, task=task, mode=mode
                 )
 
@@ -566,7 +566,7 @@ class CpSatCumulativeResourceRcpspSolver(CpSatRcpspSolver):
                     <= resource_capacity_var[resource]
                 )
         else:
-            self.create_renewable_resources_constraint(resource=resource)
+            self.create_calendar_resources_constraint(resource=resource)
             if len(task_modes_consuming) == 0:
                 # when empty, the constraints don't work !
                 return

--- a/src/discrete_optimization/rcpsp/solvers/cpsat_auto.py
+++ b/src/discrete_optimization/rcpsp/solvers/cpsat_auto.py
@@ -1,0 +1,476 @@
+#  Copyright (c) 2024 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+#  Native ortools-cpsat implementation for multimode rcpsp with resource calendar.
+#  Note : Model could most likely be improved with
+#  https://github.com/google/or-tools/blob/stable/examples/python/rcpsp_sat.py
+import logging
+from collections.abc import Iterable
+from typing import Any
+
+from ortools.sat.python.cp_model import (
+    Constraint,
+    CpSolverSolutionCallback,
+    ObjLinearExprT,
+)
+
+from discrete_optimization.generic_tasks_tools.allocation import (
+    NoUnaryResource,
+    UnaryResource,
+)
+from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
+from discrete_optimization.generic_tasks_tools.solvers.cpsat.auto import (
+    GenericSchedulingAutoCpSatSolver,
+    Objective,
+    TemporarySolution,
+)
+from discrete_optimization.generic_tools.result_storage.result_storage import (
+    ResultStorage,
+)
+from discrete_optimization.rcpsp.problem import (
+    RcpspProblem,
+    RcpspSolution,
+    Task,
+)
+from discrete_optimization.rcpsp.solution import (
+    CumulativeResource,
+    NonRenewableResource,
+)
+from discrete_optimization.rcpsp.solvers import RcpspSolver
+
+logger = logging.getLogger(__name__)
+
+
+class CpSatAutoRcpspSolver(
+    GenericSchedulingAutoCpSatSolver[
+        Task, NoUnaryResource, CumulativeResource, NonRenewableResource
+    ],
+    RcpspSolver,
+):
+    problem: RcpspProblem
+    variables: dict[str, Any]
+
+    def create_mode_pair_constraint(self):
+        pair_mode_constraint = self.problem.special_constraints.pair_mode_constraint
+        if pair_mode_constraint is None:
+            return
+
+        if pair_mode_constraint.allowed_mode_assignment is not None:
+            for task1, task2 in pair_mode_constraint.allowed_mode_assignment:
+                pairs_allowed = pair_mode_constraint.allowed_mode_assignment[
+                    (task1, task2)
+                ]
+                all_modes_task1 = set([x[0] for x in pairs_allowed])
+                all_modes_task2 = set([x[1] for x in pairs_allowed])
+                for mode in self.problem.get_task_modes(task1):
+                    if mode not in all_modes_task1:
+                        self.cp_model.add(
+                            self.get_task_mode_is_present_variable(
+                                task=task1, mode=mode
+                            )
+                            == 0
+                        )
+                for mode in self.problem.get_task_modes(task2):
+                    if mode not in all_modes_task2:
+                        self.cp_model.add(
+                            self.get_task_mode_is_present_variable(
+                                task=task2, mode=mode
+                            )
+                            == 0
+                        )
+
+                for mode1, mode2 in pairs_allowed:
+                    self.cp_model.add_allowed_assignments(
+                        [
+                            self.get_task_mode_is_present_variable(
+                                task=task1, mode=mode1
+                            ),
+                            self.get_task_mode_is_present_variable(
+                                task=task2, mode=mode2
+                            ),
+                        ],
+                        [(1, 1), (0, 0)],
+                    )
+            return
+        else:
+            score_task = {}
+            task_mode_score = pair_mode_constraint.score_mode
+            for task in set([x[0] for x in task_mode_score]):
+                min_score = min(
+                    task_mode_score[task, mode]
+                    for mode in self.problem.get_task_modes(task)
+                )
+                max_score = max(
+                    task_mode_score[task, mode]
+                    for mode in self.problem.get_task_modes(task)
+                )
+                score_task[task] = self.cp_model.new_int_var(
+                    lb=min_score, ub=max_score, name=f"score_{task}"
+                )
+                self.cp_model.add(
+                    score_task[task]
+                    == sum(
+                        [
+                            task_mode_score[task, mode]
+                            * self.get_task_mode_is_present_variable(
+                                task=task, mode=mode
+                            )
+                            for mode in self.problem.get_task_modes(task)
+                        ]
+                    )
+                )
+            for task1, task2 in pair_mode_constraint.same_score_mode:
+                # way 1
+                self.cp_model.add(score_task[task1] == score_task[task2])
+
+    def add_special_temporal_constraints(
+        self,
+    ):
+        """Add special temporal constraints to the CP model."""
+        model = self.cp_model
+        # start_to_start_min_time_lag: start(t1) + offset <= start(t2) where offset >= 0 (minimum time lag)
+        for (
+            t1,
+            t2,
+            offset,
+        ) in self.problem.special_constraints.start_to_start_min_time_lag:
+            model.add(
+                self.get_task_start_or_end_variable(
+                    task=t1, start_or_end=StartOrEnd.START
+                )
+                + offset
+                <= self.get_task_start_or_end_variable(
+                    task=t2, start_or_end=StartOrEnd.START
+                )
+            )
+
+        # start_to_start_max_time_lag: start(t2) <= start(t1) + offset where offset >= 0 (maximum time lag)
+        for (
+            t1,
+            t2,
+            offset,
+        ) in self.problem.special_constraints.start_to_start_max_time_lag:
+            model.add(
+                self.get_task_start_or_end_variable(
+                    task=t2, start_or_end=StartOrEnd.START
+                )
+                <= self.get_task_start_or_end_variable(
+                    task=t1, start_or_end=StartOrEnd.START
+                )
+                + offset
+            )
+
+        # start_together: start(t1) == start(t2)
+        for t1, t2 in self.problem.special_constraints.start_together:
+            model.add(
+                self.get_task_start_or_end_variable(
+                    task=t1, start_or_end=StartOrEnd.START
+                )
+                == self.get_task_start_or_end_variable(
+                    task=t2, start_or_end=StartOrEnd.START
+                )
+            )
+
+        # start_at_end: end(t1) == start(t2)
+        for t1, t2 in self.problem.special_constraints.start_at_end:
+            model.add(
+                self.get_task_start_or_end_variable(
+                    task=t1, start_or_end=StartOrEnd.END
+                )
+                == self.get_task_start_or_end_variable(
+                    task=t2, start_or_end=StartOrEnd.START
+                )
+            )
+
+        # start_at_end_plus_offset: end(t1) + offset <= start(t2)
+        for t1, t2, offset in self.problem.special_constraints.start_at_end_plus_offset:
+            model.add(
+                self.get_task_start_or_end_variable(
+                    task=t1, start_or_end=StartOrEnd.END
+                )
+                + offset
+                <= self.get_task_start_or_end_variable(
+                    task=t2, start_or_end=StartOrEnd.START
+                )
+            )
+
+        # disjunctive_tasks: tasks cannot overlap (pairwise)
+        # Either end(t1) <= start(t2) OR end(t2) <= start(t1)
+        for t1, t2 in self.problem.special_constraints.disjunctive_tasks:
+            b = model.new_bool_var(f"disjunctive_{t1}_{t2}")
+            model.add(
+                self.get_task_start_or_end_variable(
+                    task=t1, start_or_end=StartOrEnd.END
+                )
+                <= self.get_task_start_or_end_variable(
+                    task=t2, start_or_end=StartOrEnd.START
+                )
+            ).only_enforce_if(b)
+            model.add(
+                self.get_task_start_or_end_variable(
+                    task=t2, start_or_end=StartOrEnd.END
+                )
+                <= self.get_task_start_or_end_variable(
+                    task=t1, start_or_end=StartOrEnd.START
+                )
+            ).only_enforce_if(~b)
+
+    def init_model(self, **kwargs):
+        """Init CP model."""
+        include_special_constraints = kwargs.get(
+            "include_special_constraints", self.problem.includes_special_constraint()
+        )
+        super().init_model(**kwargs)
+        if include_special_constraints:
+            self.create_mode_pair_constraint()
+            self.add_special_temporal_constraints()
+
+    def get_global_makespan_variable(self) -> Any:
+        self.remove_constraints_on_objective()
+        return self.get_task_start_or_end_variable(
+            task=self.problem.sink_task, start_or_end=StartOrEnd.END
+        )
+
+    def convert_task_variables_to_solution(
+        self, temp_sol: TemporarySolution[Task, UnaryResource]
+    ) -> RcpspSolution:
+        schedule = {}
+        modes_dict = {}
+        for task, task_variable in temp_sol.task_variables.items():
+            schedule[task] = {
+                "start_time": task_variable.start,
+                "end_time": task_variable.end,
+            }
+            modes_dict[task] = task_variable.mode
+        return RcpspSolution(
+            problem=self.problem,
+            rcpsp_schedule=schedule,
+            rcpsp_modes=[modes_dict[t] for t in self.problem.tasks_list_non_dummy],
+        )
+
+
+class CpSatAutoResourceRcpspSolver(CpSatAutoRcpspSolver):
+    """
+    Specific solver to minimize the minimum resource amount needed to accomplish the scheduling problem.
+    In this version we don't sum up the resource at a given time, and it suits/makes sense mostly
+    for disjunctive resource (machines)
+    """
+
+    objective = (
+        Objective.CUSTOM
+    )  # custom objective (linear combination of makespan and nb_used_resources)
+
+    def init_model(self, **kwargs):
+        weight_on_makespan = kwargs.get("weight_on_makespan", 1)
+        weight_on_used_resource = kwargs.get("weight_on_used_resource", 10000)
+        super().init_model(**kwargs)
+
+        nb_used_resources_var = self.get_nb_resources_used_variable()
+        makespan_var = self.get_global_makespan_variable()
+
+        self.cp_model.minimize(
+            weight_on_used_resource * nb_used_resources_var
+            + weight_on_makespan * makespan_var
+        )
+
+    def _internal_objective(self, obj: str) -> ObjLinearExprT:
+        if obj == "makespan":
+            return self.get_global_makespan_variable()
+        elif obj == "used_resource":
+            return self.get_nb_resources_used_variable()
+        else:
+            raise ValueError(f"Unknown objective '{obj}'.")
+
+    def set_lexico_objective(self, obj: str) -> None:
+        """Update internal model objective.
+
+        Args:
+            obj: a string representing the desired objective.
+                Should be one of "makespan" or "used_resource".
+
+        Returns:
+
+        """
+        self.cp_model.minimize(self._internal_objective(obj))
+
+    def add_lexico_constraint(self, obj: str, value: float) -> Iterable[Constraint]:
+        """
+
+        Args:
+            obj: a string representing the desired objective.
+                Should be one of `self.problem.get_objective_names()`.
+            value: the limiting value.
+                If the optimization direction is maximizing, this is a lower bound,
+                else this is an upper bound.
+
+        Returns:
+            the created constraints.
+
+        """
+        return [self.cp_model.add(self._internal_objective(obj) <= int(value))]
+
+    @staticmethod
+    def implements_lexico_api() -> bool:
+        return True
+
+    def retrieve_tasks_variables(
+        self, cpsolvercb: CpSolverSolutionCallback
+    ) -> TemporarySolution[Task, UnaryResource]:
+        """Construct each task variable from the cpsat solver internal solution.
+
+        It will be called each time the cpsat solver find a new solution.
+        At that point, value of internal variables are accessible via `cpsolvercb.value(VARIABLE_NAME)`.
+
+        We override the method from generic auto solver to add the internal objective value.
+
+        Args:
+            cpsolvercb: the ortools callback called when the cpsat solver finds a new solution.
+
+        Returns:
+            the task variables for the intermediate solution
+
+        """
+        temp_sol = super().retrieve_tasks_variables(cpsolvercb)
+
+        temp_sol.metadata.update(
+            {
+                obj: cpsolvercb.value(self._internal_objective(obj))
+                for obj in self.get_lexico_objectives_available()
+            }
+        )
+
+        return temp_sol
+
+    def convert_task_variables_to_solution(
+        self, temp_sol: TemporarySolution[Task, UnaryResource]
+    ) -> RcpspSolution:
+        """Convert temporary solution to rcpsp format.
+
+        Add internal objectives.
+
+        """
+        sol = super().convert_task_variables_to_solution(temp_sol=temp_sol)
+        sol._internal_objectives = temp_sol.metadata
+        return sol
+
+    def get_lexico_objectives_available(self) -> list[str]:
+        return ["makespan", "used_resource"]
+
+    def get_lexico_objective_value(self, obj: str, res: ResultStorage) -> float:
+        values = [sol._internal_objectives[obj] for sol, fit in res.list_solution_fits]
+        return min(values)
+
+
+class CpSatAutoCumulativeResourceRcpspSolver(CpSatAutoRcpspSolver):
+    """
+    Specific solver to minimize the minimum resource amount needed to accomplish the scheduling problem.
+    In this version we sum up the resource for each given time to do the resource optimisation.
+    """
+
+    objective = (
+        Objective.CUSTOM
+    )  # custom objective (linear combination of makespan and nb_used_resources)
+
+    def init_model(self, **kwargs):
+        kwargs = self.complete_with_default_hyperparameters(kwargs)
+        weight_on_makespan = kwargs.get("weight_on_makespan", 1)
+        weight_on_used_resource = kwargs.get("weight_on_used_resource", 10000)
+
+        super().init_model(**kwargs)
+
+        resources_consumption_var = (
+            self.get_aggregated_resources_consumptions_variable()
+        )
+        makespan_var = self.get_global_makespan_variable()
+
+        self.cp_model.minimize(
+            weight_on_used_resource * resources_consumption_var
+            + weight_on_makespan * makespan_var
+        )
+
+    def _internal_objective(self, obj: str) -> ObjLinearExprT:
+        if obj == "makespan":
+            return self.get_global_makespan_variable()
+        elif obj == "used_resource":
+            return self.get_aggregated_resources_consumptions_variable()
+        else:
+            raise ValueError(f"Unknown objective '{obj}'.")
+
+    def set_lexico_objective(self, obj: str) -> None:
+        """Update internal model objective.
+
+        Args:
+            obj: a string representing the desired objective.
+                Should be one of "makespan" or "used_resource".
+
+        Returns:
+
+        """
+        self.cp_model.minimize(self._internal_objective(obj))
+
+    def add_lexico_constraint(self, obj: str, value: float) -> Iterable[Constraint]:
+        """
+
+        Args:
+            obj: a string representing the desired objective.
+                Should be one of "makespan" or "used_resource".
+            value: the limiting value.
+                If the optimization direction is maximizing, this is a lower bound,
+                else this is an upper bound.
+
+        Returns:
+            the created constraints.
+
+        """
+        return [self.cp_model.add(self._internal_objective(obj) <= int(value))]
+
+    @staticmethod
+    def implements_lexico_api() -> bool:
+        return True
+
+    def retrieve_tasks_variables(
+        self, cpsolvercb: CpSolverSolutionCallback
+    ) -> TemporarySolution[Task, UnaryResource]:
+        """Construct each task variable from the cpsat solver internal solution.
+
+        It will be called each time the cpsat solver find a new solution.
+        At that point, value of internal variables are accessible via `cpsolvercb.value(VARIABLE_NAME)`.
+
+        We override the method from generic auto solver to add the internal objective value.
+
+        Args:
+            cpsolvercb: the ortools callback called when the cpsat solver finds a new solution.
+
+        Returns:
+            the task variables for the intermediate solution
+
+        """
+        temp_sol = super().retrieve_tasks_variables(cpsolvercb)
+
+        temp_sol.metadata.update(
+            {
+                obj: cpsolvercb.value(self._internal_objective(obj))
+                for obj in self.get_lexico_objectives_available()
+            }
+        )
+
+        return temp_sol
+
+    def convert_task_variables_to_solution(
+        self, temp_sol: TemporarySolution[Task, UnaryResource]
+    ) -> RcpspSolution:
+        """Convert temporary solution to rcpsp format.
+
+        Add internal objectives.
+
+        """
+        sol = super().convert_task_variables_to_solution(temp_sol=temp_sol)
+        sol._internal_objectives = temp_sol.metadata
+        return sol
+
+    def get_lexico_objectives_available(self) -> list[str]:
+        return ["makespan", "used_resource"]
+
+    def get_lexico_objective_value(self, obj: str, res: ResultStorage) -> float:
+        values = [sol._internal_objectives[obj] for sol, fit in res.list_solution_fits]
+        return min(values)

--- a/src/discrete_optimization/rcpsp/utils.py
+++ b/src/discrete_optimization/rcpsp/utils.py
@@ -587,23 +587,23 @@ def get_start_bounds_from_additional_constraint(
                 if ubs is not None:
                     ub = ubs
             if activity in rcpsp_problem.special_constraints.end_times_window:
-                lbs, ubs = rcpsp_problem.special_constraints.end_times_window[activity]
-                if lbs is not None:
+                lbe, ube = rcpsp_problem.special_constraints.end_times_window[activity]
+                if lbe is not None:
                     max_duration = max(
                         [
                             rcpsp_problem.mode_details[activity][m]["duration"]
                             for m in rcpsp_problem.mode_details[activity]
                         ]
                     )
-                    lb = max(lb, lbs - max_duration)
-                if ubs is not None:
+                    lb = max(lb, lbe - max_duration)
+                if ube is not None:
                     min_duration = min(
                         [
                             rcpsp_problem.mode_details[activity][m]["duration"]
                             for m in rcpsp_problem.mode_details[activity]
                         ]
                     )
-                    ub = min(ub, ubs - min_duration)
+                    ub = min(ub, ube - min_duration)
     if ub < 0:
         logger.debug(f"ub<0, {ub}")
     return int(lb), int(ub)
@@ -624,11 +624,11 @@ def get_end_bounds_from_additional_constraint(
             lb = ub = rcpsp_problem.special_constraints.end_times[activity]
         else:
             if activity in rcpsp_problem.special_constraints.end_times_window:
-                lbs, ubs = rcpsp_problem.special_constraints.end_times_window[activity]
-                if lbs is not None:
-                    lb = lbs
-                if ubs is not None:
-                    ub = ubs
+                lbe, ube = rcpsp_problem.special_constraints.end_times_window[activity]
+                if lbe is not None:
+                    lb = lbe
+                if ube is not None:
+                    ub = ube
             if activity in rcpsp_problem.special_constraints.start_times_window:
                 lbs, ubs = rcpsp_problem.special_constraints.start_times_window[
                     activity

--- a/src/discrete_optimization/rcpsp_multiskill/problem.py
+++ b/src/discrete_optimization/rcpsp_multiskill/problem.py
@@ -112,6 +112,7 @@ UnaryResource = Hashable
 CumulativeResource = str
 Resource = Union[CumulativeResource, UnaryResource]
 NonRenewableResource = str
+Skill = str
 
 
 class MultiskillRcpspSolution(
@@ -2372,6 +2373,7 @@ class MultiskillRcpspProblem(
             for s in self.skills_set
         }
         self.compatibility_task_employee: dict[Task, dict[UnaryResource, bool]] = {}
+        self.skills_of_task: dict[Task, set[Skill]] = {}
         for task in self.tasks_list:
             self.compatibility_task_employee[task] = {}
             skills_of_task = set()
@@ -2384,6 +2386,7 @@ class MultiskillRcpspProblem(
                     self.compatibility_task_employee[task][employee] = True
                 else:
                     self.compatibility_task_employee[task][employee] = False
+            self.skills_of_task[task] = skills_of_task
 
     def get_precedence_constraints(self) -> dict[Task, list[Task]]:
         return self.successors

--- a/src/discrete_optimization/rcpsp_multiskill/problem.py
+++ b/src/discrete_optimization/rcpsp_multiskill/problem.py
@@ -20,9 +20,9 @@ from discrete_optimization.generic_rcpsp_tools.attribute_type import (
     ListIntegerRcpsp,
     PermutationRcpsp,
 )
-from discrete_optimization.generic_tasks_tools.allocation_scheduling import (
-    AllocationSchedulingProblem,
-    AllocationSchedulingSolution,
+from discrete_optimization.generic_tasks_tools.generic_scheduling import (
+    GenericSchedulingProblem,
+    GenericSchedulingSolution,
 )
 from discrete_optimization.generic_tasks_tools.renewable_resource import (
     convert_calendar_to_availability_intervals,
@@ -115,7 +115,7 @@ NonRenewableResource = str
 
 
 class MultiskillRcpspSolution(
-    AllocationSchedulingSolution[
+    GenericSchedulingSolution[
         Task, UnaryResource, CumulativeResource, NonRenewableResource
     ],
 ):
@@ -1983,7 +1983,7 @@ def intersect(i1, i2):
 
 
 class MultiskillRcpspProblem(
-    AllocationSchedulingProblem[
+    GenericSchedulingProblem[
         Task, UnaryResource, CumulativeResource, NonRenewableResource
     ],
 ):

--- a/src/discrete_optimization/rcpsp_multiskill/problem.py
+++ b/src/discrete_optimization/rcpsp_multiskill/problem.py
@@ -20,13 +20,13 @@ from discrete_optimization.generic_rcpsp_tools.attribute_type import (
     ListIntegerRcpsp,
     PermutationRcpsp,
 )
+from discrete_optimization.generic_tasks_tools.calendar_resource import (
+    convert_calendar_to_availability_intervals,
+    merge_resources_calendars,
+)
 from discrete_optimization.generic_tasks_tools.generic_scheduling import (
     GenericSchedulingProblem,
     GenericSchedulingSolution,
-)
-from discrete_optimization.generic_tasks_tools.renewable_resource import (
-    convert_calendar_to_availability_intervals,
-    merge_resources_calendars,
 )
 from discrete_optimization.generic_tools.do_problem import (
     ModeOptim,
@@ -2263,7 +2263,7 @@ class MultiskillRcpspProblem(
             + [NB_EMPLOYEES_LB]
         )
 
-    def get_renewable_resource_consumption(
+    def get_cumulative_resource_consumption(
         self, resource: CumulativeResource, task: Task, mode: int
     ) -> int:
         """Get resource consumption of the task in the given mode
@@ -2574,7 +2574,7 @@ class MultiskillRcpspProblem(
 
         # Check for renewable resources capacity violations
         # include employees and cumulative resources
-        if not rcpsp_sol.check_all_renewable_resource_capacity_constraints():
+        if not rcpsp_sol.check_all_calendar_resource_capacity_constraints():
             return False
 
         # Check for non-renewable resource violation

--- a/src/discrete_optimization/rcpsp_multiskill/solvers/cpsat.py
+++ b/src/discrete_optimization/rcpsp_multiskill/solvers/cpsat.py
@@ -14,8 +14,8 @@ from ortools.sat.python.cp_model import (
 )
 
 from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
-from discrete_optimization.generic_tasks_tools.solvers.cpsat.allocation_scheduling import (
-    AllocationSchedulingCpSatSolver,
+from discrete_optimization.generic_tasks_tools.solvers.cpsat.generic_scheduling import (
+    GenericSchedulingCpSatSolver,
 )
 from discrete_optimization.generic_tools.do_problem import Problem, Solution
 from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 
 
 class CpSatMultiskillRcpspSolver(
-    AllocationSchedulingCpSatSolver[
+    GenericSchedulingCpSatSolver[
         Task, UnaryResource, CumulativeResource, NonRenewableResource
     ],
 ):

--- a/src/discrete_optimization/rcpsp_multiskill/solvers/cpsat.py
+++ b/src/discrete_optimization/rcpsp_multiskill/solvers/cpsat.py
@@ -504,18 +504,18 @@ class CpSatMultiskillRcpspSolver(
             if r in self.problem.non_renewable_resources:
                 self.create_non_renewable_resources_constraint(r)
             else:
-                self.create_renewable_resources_constraint(r)
+                self.create_calendar_resources_constraint(r)
 
     def create_disjunctive_worker(self):
         for worker in self.problem.employees:
-            self.create_renewable_resources_constraint(worker)
+            self.create_calendar_resources_constraint(worker)
 
     def constraint_redundant_cumulative_skills(self):
         for skill in self.problem.skills_set:
-            self.create_renewable_resources_constraint(skill)
+            self.create_calendar_resources_constraint(skill)
 
     def constraint_redundant_cumulative_worker(self):
-        self.create_renewable_resources_constraint(NB_EMPLOYEES_LB)
+        self.create_calendar_resources_constraint(NB_EMPLOYEES_LB)
 
     def constraint_mode(self):
         for task in self.variables["mode_variable"]["is_present"]:

--- a/src/discrete_optimization/rcpsp_multiskill/solvers/cpsat.py
+++ b/src/discrete_optimization/rcpsp_multiskill/solvers/cpsat.py
@@ -63,6 +63,24 @@ class CpSatMultiskillRcpspSolver(
     ) -> IntervalVar:
         return self.variables["worker_variable"]["opt_intervals"][task][unary_resource]
 
+    def is_compatible_task_unary_resource(
+        self, task: Task, unary_resource: UnaryResource
+    ) -> bool:
+        if len(self.problem.skills_of_task[task]) == 0:
+            # never allocate an employee to a task not needing a skill
+            return False
+        elif self._one_worker_per_task:
+            return any(
+                all(
+                    self.problem.employees[unary_resource].get_skill_level(s)
+                    >= self.problem.mode_details[task][mode].get(s, 0)
+                    for s in self.problem.skills_of_task[task]
+                )
+                for mode in self.problem.mode_details[task]
+            )
+        else:
+            return super().is_compatible_task_unary_resource(task, unary_resource)
+
     def get_task_mode_interval(self, task: Task, mode: int) -> IntervalVar:
         if not self.problem.is_multimode or len(self.problem.get_task_modes(task)) == 1:
             return self.variables["base_variable"]["intervals"][task]
@@ -117,6 +135,9 @@ class CpSatMultiskillRcpspSolver(
         one_skill_per_task = args.get("one_skill_per_task", False)
         redundant_skill_cumulative = args["redundant_skill_cumulative"]
         redundant_worker_cumulative = args["redundant_worker_cumulative"]
+        # store one_worker_per_task to use in `is_compatible_task_unary_resource`
+        self._one_worker_per_task = one_worker_per_task
+
         super().init_model(**args)
         self.variables = {}
         self.create_base_variable()
@@ -233,9 +254,12 @@ class CpSatMultiskillRcpspSolver(
                         )
                         for mode in self.problem.mode_details[task]
                     )
-                ) or any(
-                    worker in self.problem.employees_per_skill[s]
-                    for s in skills_of_task
+                ) or (
+                    not one_worker_per_task
+                    and any(
+                        worker in self.problem.employees_per_skill[s]
+                        for s in skills_of_task
+                    )
                 ):
                     skills_used_var[task][worker] = {}
                     is_present_var[task][worker] = self.cp_model.NewBoolVar(

--- a/src/discrete_optimization/rcpsp_multiskill/solvers/cpsat_auto.py
+++ b/src/discrete_optimization/rcpsp_multiskill/solvers/cpsat_auto.py
@@ -1,0 +1,397 @@
+#  Copyright (c) 2024 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+import logging
+from typing import Any
+
+from ortools.sat.python.cp_model import (
+    CpSolverSolutionCallback,
+    Domain,
+)
+
+from discrete_optimization.generic_tasks_tools.solvers.cpsat.auto import (
+    GenericSchedulingAutoCpSatSolver,
+    TemporarySolution,
+)
+from discrete_optimization.generic_tools.do_problem import Solution
+from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
+    CategoricalHyperparameter,
+)
+from discrete_optimization.rcpsp_multiskill.problem import (
+    NB_EMPLOYEES_LB,
+    CumulativeResource,
+    MultiskillRcpspProblem,
+    MultiskillRcpspSolution,
+    NonRenewableResource,
+    Task,
+    UnaryResource,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class CpSatAutoMultiskillRcpspSolver(
+    GenericSchedulingAutoCpSatSolver[
+        Task, UnaryResource, CumulativeResource, NonRenewableResource
+    ],
+):
+    hyperparameters = [
+        CategoricalHyperparameter(
+            name="redundant_skill_cumulative", choices=[True, False], default=True
+        ),
+        CategoricalHyperparameter(
+            name="redundant_worker_cumulative", choices=[True, False], default=True
+        ),
+    ]
+    problem: MultiskillRcpspProblem
+
+    def convert_task_variables_to_solution(
+        self, temp_sol: TemporarySolution[Task, UnaryResource]
+    ) -> Solution:
+        """Convert solution from autosolver format into do format.
+
+        To be used in `self.retrieve_solution()`.
+
+        Args:
+            temp_sol:
+
+        Returns:
+
+        """
+        modes_dict = {}
+        schedule = {}
+        employee_usage = {}
+        for task, task_variable in temp_sol.task_variables.items():
+            schedule[task] = {
+                "start_time": task_variable.start,
+                "end_time": task_variable.end,
+            }
+            modes_dict[task] = task_variable.mode
+            employee_usage[task] = {
+                worker: contrib
+                for worker, contrib in task_variable.info["contrib"].items()
+                if len(contrib) > 0
+            }
+        sol = MultiskillRcpspSolution(
+            problem=self.problem,
+            schedule=schedule,
+            modes=modes_dict,
+            employee_usage=employee_usage,
+        )
+        sol._internal_obj = temp_sol.metadata
+        return sol
+
+    def retrieve_tasks_variables(
+        self, cpsolvercb: CpSolverSolutionCallback
+    ) -> TemporarySolution[Task, UnaryResource]:
+        """Construct each task variable from the cpsat solver internal solution.
+
+        It will be called each time the cpsat solver find a new solution.
+        At that point, value of internal variables are accessible via `cpsolvercb.value(VARIABLE_NAME)`.
+
+        We override the method from generic auto solver to add the worker skills contribution
+        and internal objective value.
+
+        Args:
+            cpsolvercb: the ortools callback called when the cpsat solver finds a new solution.
+
+        Returns:
+            the task variables for the intermediate solution
+
+        """
+        temp_sol = super().retrieve_tasks_variables(cpsolvercb)
+
+        # worker skills contribution per task
+        for task, task_variable in temp_sol.task_variables.items():
+            task_variable.info["contrib"] = {}
+            for worker in task_variable.allocated:
+                try:
+                    skills_used_vars = self.skills_used_per_worker[task][worker]
+                except KeyError:
+                    contrib = set()
+                else:
+                    contrib = {
+                        s
+                        for s, used_var in skills_used_vars.items()
+                        if cpsolvercb.value(used_var)
+                    }
+                task_variable.info["contrib"][worker] = contrib
+
+        # internal objective
+        temp_sol.metadata["makespan"] = cpsolvercb.value(
+            self.get_global_makespan_variable()
+        )
+
+        return temp_sol
+
+    def include_constraint_on_cumulative_resource(
+        self, resource: CumulativeResource
+    ) -> bool:
+        """Whether the cp model should take into account the constraint on the given cumulative resource.
+
+        The constraints on skills as cumulative resources and on number of employees are to be added
+        according to `redundant_skill_cumulative` and `redundant_worker_cumulative` hyperparameters.
+
+        Args:
+            resource:
+
+        Returns:
+
+        """
+        if resource in self.problem.skills_set:
+            return self._redundant_skill_cumulative
+        elif resource == NB_EMPLOYEES_LB:
+            return self._redundant_worker_cumulative
+        else:
+            return super().include_constraint_on_cumulative_resource(resource)
+
+    def is_compatible_task_unary_resource(
+        self, task: Task, unary_resource: UnaryResource
+    ) -> bool:
+        if len(self.problem.skills_of_task[task]) == 0:
+            # never allocate an employee to a task not needing a skill
+            return False
+        elif self._one_worker_per_task:
+            return any(
+                all(
+                    self.problem.employees[unary_resource].get_skill_level(s)
+                    >= self.problem.mode_details[task][mode].get(s, 0)
+                    for s in self.problem.skills_of_task[task]
+                )
+                for mode in self.problem.mode_details[task]
+            )
+        else:
+            return super().is_compatible_task_unary_resource(task, unary_resource)
+
+    def init_model(self, **kwargs: Any) -> None:
+        if self.problem.is_preemptive():
+            raise NotImplementedError()
+
+        kwargs = self.complete_with_default_hyperparameters(kwargs)
+
+        # redundant renewable resources to consider
+        self._redundant_skill_cumulative = kwargs["redundant_skill_cumulative"]
+        self._redundant_worker_cumulative = kwargs["redundant_worker_cumulative"]
+
+        # additional constraints (subproblem)
+        self._one_worker_per_task = kwargs.get("one_worker_per_task", False)
+        self._one_skill_per_task = kwargs.get("one_skill_per_task", False)
+        self.at_most_one_unary_resource_per_task = self._one_worker_per_task
+
+        self._exact_skill = kwargs.get("exact_skill", False)
+        self._slack_skill = kwargs.get("slack_skill", False)
+
+        super().init_model(**kwargs)
+
+        self.create_skills_used_per_worker()
+        self.create_skills_per_task_variables()
+        self.create_skills_constraint_worker()
+        self.create_skills_constraints_v2()
+        # self.create_workload_variables()  # not used for now
+
+    def create_skills_used_per_worker(self):
+        one_skill_per_task = self._one_skill_per_task
+        skills_used_var = {}
+        for task in self.problem.tasks_list:
+            skills_of_task = self.problem.skills_of_task[task]
+            if len(skills_of_task) == 0:
+                # no need of employees
+                continue
+            skills_used_var[task] = {}
+            for worker in self.problem.employees:
+                if self.is_compatible_task_unary_resource(
+                    task=task, unary_resource=worker
+                ):
+                    skills_used_var[task][worker] = {}
+                    skills_of_worker = self.problem.employees[
+                        worker
+                    ].get_non_zero_skills()
+                    for s in skills_of_task:
+                        if s in skills_of_worker:
+                            if not one_skill_per_task or len(skills_of_worker) == 1:
+                                skills_used_var[task][worker][s] = (
+                                    self.allocation_is_present[task][worker]
+                                )
+                            else:
+                                skills_used_var[task][worker][s] = (
+                                    self.cp_model.new_bool_var(
+                                        name=f"skill_{task}_{worker}_{s}"
+                                    )
+                                )
+                    for s in skills_used_var[task][worker]:
+                        self.cp_model.add(
+                            skills_used_var[task][worker][s]
+                            <= self.allocation_is_present[task][worker]
+                        )
+                    self.cp_model.add_bool_or(
+                        [
+                            skills_used_var[task][worker][s]
+                            for s in skills_used_var[task][worker]
+                        ]
+                    ).only_enforce_if(self.allocation_is_present[task][worker])
+                    if one_skill_per_task:
+                        if len(skills_used_var[task][worker]) >= 1:
+                            self.cp_model.add_at_most_one(
+                                [
+                                    skills_used_var[task][worker][s]
+                                    for s in skills_used_var[task][worker]
+                                ]
+                            )
+
+        self.skills_used_per_worker = skills_used_var
+
+    def create_skills_per_task_variables(self):
+        skills_var = {}
+        for task in self.problem.tasks_list:
+            skills_var[task] = {}
+            for s in self.problem.skills_of_task[task]:
+                possible_values = [
+                    self.problem.mode_details[task][mode].get(s, 0)
+                    for mode in self.problem.mode_details[task]
+                ]
+                skills_var[task][s] = self.cp_model.new_int_var_from_domain(
+                    domain=Domain.from_values(possible_values),
+                    name=f"skills_{task}_{s}",
+                )
+                for mode, is_present_mode in self.modes_is_present[task].items():
+                    val = self.problem.mode_details[task][mode].get(s, 0)
+                    self.cp_model.add(skills_var[task][s] == val).OnlyEnforceIf(
+                        is_present_mode
+                    )
+        self.skills_per_task = skills_var
+
+    def create_workload_variables(self):
+        workload = {}
+        for emp in self.problem.employees:
+            workload[emp] = sum(
+                [
+                    # NB: we use duration of mode 1 instead of actual duration variable to avoid quadratic constraint
+                    # (impossible in cpsat)
+                    # the constraint is correct in single mode
+                    self.problem.get_task_mode_duration(task=task, mode=1)
+                    * is_present_task_worker[emp]
+                    for task, is_present_task_worker in self.allocation_is_present.items()
+                    if emp in is_present_task_worker
+                ]
+            )
+        max_workload = self.cp_model.new_int_var(
+            lb=0, ub=self.problem.horizon, name=f"max_workload"
+        )
+        min_workload = self.cp_model.new_int_var(
+            lb=0, ub=self.problem.horizon, name=f"min_workload"
+        )
+        self.cp_model.add_max_equality(
+            max_workload, [workload[emp] for emp in workload]
+        )
+        self.cp_model.add_min_equality(
+            min_workload, [workload[emp] for emp in workload]
+        )
+        self.max_workload_var = max_workload
+        self.min_workload_var = min_workload
+
+    def create_skills_constraint_worker(self):
+        exact_skill = self._exact_skill
+        slack_skill = self._slack_skill
+        if slack_skill:
+            slack_skill_dict = {}
+        for task in self.skills_per_task:
+            if slack_skill:
+                slack_skill_dict[task] = {}
+            for s in self.skills_per_task[task]:
+                if slack_skill:
+                    slack_skill_dict[task][s] = self.cp_model.new_int_var(
+                        lb=0, ub=5, name=f"slack_{task}_{s}"
+                    )
+
+                skill_value_put_on_task = sum(
+                    skill_value * is_present_worker
+                    for worker, is_present_worker in self.allocation_is_present[
+                        task
+                    ].items()
+                    if (
+                        skill_value := self.problem.employees[worker].get_skill_level(s)
+                    )
+                    > 0
+                )
+
+                if exact_skill:
+                    if not slack_skill:
+                        self.cp_model.add(
+                            skill_value_put_on_task == self.skills_per_task[task][s]
+                        )
+                    else:
+                        self.cp_model.add(
+                            skill_value_put_on_task
+                            == self.skills_per_task[task][s] + slack_skill_dict[task][s]
+                        )
+
+                else:
+                    if not slack_skill:
+                        self.cp_model.add(
+                            skill_value_put_on_task >= self.skills_per_task[task][s]
+                        )
+                    else:
+                        self.cp_model.add(
+                            skill_value_put_on_task
+                            >= self.skills_per_task[task][s] + slack_skill_dict[task][s]
+                        )
+        if slack_skill:
+            self.slack_skill_v1_variables = slack_skill_dict
+
+    def create_skills_constraints_v2(self):
+        """
+        using skills_used variable
+        """
+        exact_skill = self._exact_skill
+        slack_skill = self._slack_skill
+        if slack_skill:
+            slack_skill_dict = {}
+        for task in self.skills_per_task:
+            if slack_skill:
+                slack_skill_dict[task] = {}
+            for s in self.skills_per_task[task]:
+                if slack_skill:
+                    slack_skill_dict[task][s] = self.cp_model.new_int_var(
+                        lb=0, ub=5, name=f"slack_{task}_{s}"
+                    )
+                skill_value_put_on_task = sum(
+                    self.problem.employees[worker].get_skill_level(s)
+                    * skills_used_var[s]
+                    for worker, skills_used_var in self.skills_used_per_worker[
+                        task
+                    ].items()
+                    if s in skills_used_var
+                )
+
+                if exact_skill:
+                    if not slack_skill:
+                        self.cp_model.add(
+                            skill_value_put_on_task == self.skills_per_task[task][s]
+                        )
+                    else:
+                        self.cp_model.add(
+                            skill_value_put_on_task
+                            == self.skills_per_task[task][s] + slack_skill_dict[task][s]
+                        )
+
+                else:
+                    if not slack_skill:
+                        self.cp_model.add(
+                            skill_value_put_on_task >= self.skills_per_task[task][s]
+                        )
+                    else:
+                        self.cp_model.add(
+                            skill_value_put_on_task
+                            >= self.skills_per_task[task][s] + slack_skill_dict[task][s]
+                        )
+        if slack_skill:
+            self.slack_skill_v2_variables = slack_skill_dict
+
+    def create_total_cost_variable(self):
+        self.total_cost_var = sum(
+            int(10 * self.problem.employees[worker].salary)
+            * is_allocated
+            * self.duration_variables[task]
+            for task, is_allocated_vars in self.allocation_is_present.items()
+            for worker, is_allocated in is_allocated_vars.items()
+        )

--- a/src/discrete_optimization/rcpsp_multiskill/solvers/cpsat_auto.py
+++ b/src/discrete_optimization/rcpsp_multiskill/solvers/cpsat_auto.py
@@ -169,7 +169,7 @@ class CpSatAutoMultiskillRcpspSolver(
 
         kwargs = self.complete_with_default_hyperparameters(kwargs)
 
-        # redundant renewable resources to consider
+        # redundant cumulative resources to consider
         self._redundant_skill_cumulative = kwargs["redundant_skill_cumulative"]
         self._redundant_worker_cumulative = kwargs["redundant_worker_cumulative"]
 

--- a/src/discrete_optimization/workforce/scheduling/parser.py
+++ b/src/discrete_optimization/workforce/scheduling/parser.py
@@ -85,17 +85,23 @@ def parse_json_to_problem(json_path: str) -> AllocSchedulingProblem:
         calendar_team=d["calendar"],
         tasks_list=d["tasks"],
         tasks_data={
-            t: TasksDescription(duration_task=d["tasks_data"][t]["duration"])
+            t: TasksDescription(duration_task=int(d["tasks_data"][t]["duration"]))
             for t in d["tasks_data"]
         },
         same_allocation=[set(x) for x in d["same_allocation"]],
         precedence_constraints=d["successors"],
         available_team_for_activity=d["compatible_teams"],
-        start_window=d["start_window"],
-        end_window=d["end_window"],
-        original_start=d["original_start"],
-        original_end=d["original_end"],
-        horizon_start_shift=d["horizon_shift"],
+        start_window={
+            task: (lb if lb is None else int(lb), ub if ub is None else int(ub))
+            for task, (lb, ub) in d["start_window"].items()
+        },
+        end_window={
+            task: (lb if lb is None else int(lb), ub if ub is None else int(ub))
+            for task, (lb, ub) in d["end_window"].items()
+        },
+        original_start={task: int(t) for task, t in d["original_start"].items()},
+        original_end={task: int(t) for task, t in d["original_end"].items()},
+        horizon_start_shift=int(d["horizon_shift"]),
         resources_list=[],
         resources_capacity=None,
         horizon=horizon,

--- a/src/discrete_optimization/workforce/scheduling/problem.py
+++ b/src/discrete_optimization/workforce/scheduling/problem.py
@@ -12,9 +12,9 @@ from typing import Optional, Union
 import networkx as nx
 import numpy as np
 
-from discrete_optimization.generic_tasks_tools.allocation_scheduling import (
-    AllocationSchedulingProblem,
-    AllocationSchedulingSolution,
+from discrete_optimization.generic_tasks_tools.generic_scheduling import (
+    GenericSchedulingProblem,
+    GenericSchedulingSolution,
 )
 from discrete_optimization.generic_tasks_tools.multimode import (
     SinglemodeProblem,
@@ -53,7 +53,7 @@ NonRenewableResource = str
 
 
 class AllocSchedulingSolution(
-    AllocationSchedulingSolution[
+    GenericSchedulingSolution[
         Task, UnaryResource, CumulativeResource, NonRenewableResource
     ],
     SinglemodeSolution[Task],
@@ -104,7 +104,7 @@ class TasksDescription:
 
 
 class AllocSchedulingProblem(
-    AllocationSchedulingProblem[
+    GenericSchedulingProblem[
         Task, UnaryResource, CumulativeResource, NonRenewableResource
     ],
     WithoutNonRenewableResourceProblem[Task, NonRenewableResource],

--- a/src/discrete_optimization/workforce/scheduling/problem.py
+++ b/src/discrete_optimization/workforce/scheduling/problem.py
@@ -12,6 +12,9 @@ from typing import Optional, Union
 import networkx as nx
 import numpy as np
 
+from discrete_optimization.generic_tasks_tools.calendar_resource import (
+    convert_calendar_to_availability_intervals,
+)
 from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
 from discrete_optimization.generic_tasks_tools.generic_scheduling import (
     GenericSchedulingProblem,
@@ -27,9 +30,6 @@ from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
     NoNonRenewableResource,
     WithoutNonRenewableResourceProblem,
     WithoutNonRenewableResourceSolution,
-)
-from discrete_optimization.generic_tasks_tools.renewable_resource import (
-    convert_calendar_to_availability_intervals,
 )
 from discrete_optimization.generic_tools.do_problem import (
     ModeOptim,
@@ -176,7 +176,7 @@ class AllocSchedulingProblem(
     def cumulative_resources_list(self) -> list[CumulativeResource]:
         return self.resources_list
 
-    def get_renewable_resource_consumption(
+    def get_cumulative_resource_consumption(
         self, resource: Resource, task: Task, mode: int
     ) -> int:
         if self.is_cumulative_resource(resource):
@@ -566,12 +566,12 @@ def interval_inside(
     return False
 
 
-def satisfy_renewable_resources(
+def satisfy_calendar_resources(
     problem: AllocSchedulingProblem,
     solution: AllocSchedulingSolution,
     partial_solution: bool = False,
 ):
-    """Check constraints related to renewable resources (teams + cumulative resources)
+    """Check constraints related to renewable calendar resources (teams + cumulative resources)
 
     It checks:
     - team availability when allocated to a task
@@ -586,7 +586,7 @@ def satisfy_renewable_resources(
     Returns:
 
     """
-    return solution.check_all_renewable_resource_capacity_constraints()
+    return solution.check_all_calendar_resource_capacity_constraints()
 
 
 def satisfy_calendars(
@@ -649,7 +649,7 @@ def full_satisfy(
         satisfy_available_team,
         satisfy_same_allocation,
         satisfy_time_window,
-        satisfy_renewable_resources,
+        satisfy_calendar_resources,
         # satisfy_calendars,
         # satisfy_overlap_teams,
     ]:

--- a/src/discrete_optimization/workforce/scheduling/problem.py
+++ b/src/discrete_optimization/workforce/scheduling/problem.py
@@ -271,15 +271,13 @@ class AllocSchedulingProblem(
             "nb_not_done": ObjectiveDoc(
                 type=TypeObjective.PENALTY, default_weight=-100000
             ),
-            "nb_teams": ObjectiveDoc(
-                type=TypeObjective.PENALTY, default_weight=-10000.0
-            ),
-            "makespan": ObjectiveDoc(type=TypeObjective.PENALTY, default_weight=-1.0),
+            "nb_teams": ObjectiveDoc(type=TypeObjective.PENALTY, default_weight=-10000),
+            "makespan": ObjectiveDoc(type=TypeObjective.PENALTY, default_weight=-1),
             "workload_dispersion": ObjectiveDoc(
-                type=TypeObjective.PENALTY, default_weight=-1.0
+                type=TypeObjective.PENALTY, default_weight=-1
             ),
             "nb_violations": ObjectiveDoc(
-                type=TypeObjective.PENALTY, default_weight=-100.0
+                type=TypeObjective.PENALTY, default_weight=-100
             ),
         }
         return ObjectiveRegister(
@@ -380,7 +378,7 @@ def evaluate_solution(
         if team not in dur_per_team:
             dur_per_team[team] = 0
         dur_per_team[team] += problem.tasks_data[problem.index_to_task[i]].duration_task
-    makespan = max(solution.schedule[:, 1])
+    makespan = int(max(solution.schedule[:, 1]))
     sat = satisfy_detailed(problem=problem, solution=solution)
     return {
         "nb_teams": len(teams_used),

--- a/src/discrete_optimization/workforce/scheduling/problem.py
+++ b/src/discrete_optimization/workforce/scheduling/problem.py
@@ -12,18 +12,22 @@ from typing import Optional, Union
 import networkx as nx
 import numpy as np
 
+from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
 from discrete_optimization.generic_tasks_tools.generic_scheduling import (
     GenericSchedulingProblem,
     GenericSchedulingSolution,
 )
 from discrete_optimization.generic_tasks_tools.multimode import (
-    SinglemodeProblem,
     SinglemodeSolution,
 )
-from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
-    WithoutNonRenewableResourceProblem,
+from discrete_optimization.generic_tasks_tools.multimode_scheduling import (
+    SinglemodeSchedulingProblem,
 )
-from discrete_optimization.generic_tasks_tools.precedence import PrecedenceProblem
+from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
+    NoNonRenewableResource,
+    WithoutNonRenewableResourceProblem,
+    WithoutNonRenewableResourceSolution,
+)
 from discrete_optimization.generic_tasks_tools.renewable_resource import (
     convert_calendar_to_availability_intervals,
 )
@@ -49,13 +53,13 @@ Task = Hashable
 UnaryResource = Hashable
 CumulativeResource = str
 Resource = Union[UnaryResource, CumulativeResource]
-NonRenewableResource = str
 
 
 class AllocSchedulingSolution(
     GenericSchedulingSolution[
-        Task, UnaryResource, CumulativeResource, NonRenewableResource
+        Task, UnaryResource, CumulativeResource, NoNonRenewableResource
     ],
+    WithoutNonRenewableResourceSolution[Task],
     SinglemodeSolution[Task],
 ):
     problem: AllocSchedulingProblem
@@ -105,11 +109,10 @@ class TasksDescription:
 
 class AllocSchedulingProblem(
     GenericSchedulingProblem[
-        Task, UnaryResource, CumulativeResource, NonRenewableResource
+        Task, UnaryResource, CumulativeResource, NoNonRenewableResource
     ],
-    WithoutNonRenewableResourceProblem[Task, NonRenewableResource],
-    SinglemodeProblem[Task],
-    PrecedenceProblem[Task],
+    WithoutNonRenewableResourceProblem[Task],
+    SinglemodeSchedulingProblem[Task],
 ):
     def __init__(
         self,
@@ -195,8 +198,26 @@ class AllocSchedulingProblem(
                 f"{resource} is neither an actual cumulative resource nor a team."
             )
 
-    def get_task_mode_duration(self, task: Task, mode: int) -> int:
+    def get_task_duration(self, task: Task) -> int:
         return self.tasks_data[task].duration_task
+
+    def get_task_start_or_end_lower_bound(
+        self, task: Task, start_or_end: StartOrEnd
+    ) -> int:
+        match start_or_end:
+            case StartOrEnd.START:
+                return self.get_lb_start_window(task=task)
+            case _:
+                return self.get_lb_end_window(task=task)
+
+    def get_task_start_or_end_upper_bound(
+        self, task: Task, start_or_end: StartOrEnd
+    ) -> int:
+        match start_or_end:
+            case StartOrEnd.START:
+                return self.get_ub_start_window(task=task)
+            case _:
+                return self.get_ub_end_window(task=task)
 
     @property
     def tasks_list(self) -> list[Task]:

--- a/src/discrete_optimization/workforce/scheduling/solvers/cpsat.py
+++ b/src/discrete_optimization/workforce/scheduling/solvers/cpsat.py
@@ -503,19 +503,19 @@ class CPSatAllocSchedulingSolver(
         for obj in objectives:
             if obj == ObjectivesEnum.NB_DONE_AC and optional_activities:
                 objs.append(self.variables["objectives"][ObjectivesEnum.NB_DONE_AC])
-                weights.append(100000.0)
+                weights.append(100000)
             elif obj == ObjectivesEnum.NB_TEAMS:
                 objs.append(self.variables["objectives"][ObjectivesEnum.NB_TEAMS])
-                weights.append(10000.0)
+                weights.append(10000)
             elif obj == ObjectivesEnum.MIN_WORKLOAD:
                 objs.append(self.variables["objectives"][ObjectivesEnum.MIN_WORKLOAD])
-                weights.append(1.0)
+                weights.append(1)
             elif obj == ObjectivesEnum.DISPERSION:
                 objs.append(self.variables["objectives"][ObjectivesEnum.DISPERSION])
-                weights.append(1.0)
+                weights.append(1)
             elif obj == ObjectivesEnum.MAKESPAN:
                 objs.append(self.variables["objectives"][ObjectivesEnum.MAKESPAN])
-                weights.append(1.0)
+                weights.append(1)
             elif obj == ObjectivesEnum.DELTA_TO_EXISTING_SOLUTION:
                 weights_dict = {
                     "reallocated": 1000,

--- a/src/discrete_optimization/workforce/scheduling/solvers/cpsat.py
+++ b/src/discrete_optimization/workforce/scheduling/solvers/cpsat.py
@@ -16,8 +16,8 @@ from ortools.sat.python.cp_model import (
 )
 
 from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
-from discrete_optimization.generic_tasks_tools.solvers.cpsat.allocation_scheduling import (
-    AllocationSchedulingCpSatSolver,
+from discrete_optimization.generic_tasks_tools.solvers.cpsat.generic_scheduling import (
+    GenericSchedulingCpSatSolver,
 )
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.multimode import (
     SinglemodeCpSatSolver,
@@ -97,7 +97,7 @@ class AdditionalCPConstraints:
 
 
 class CPSatAllocSchedulingSolver(
-    AllocationSchedulingCpSatSolver[
+    GenericSchedulingCpSatSolver[
         Task, UnaryResource, CumulativeResource, NonRenewableResource
     ],
     SinglemodeCpSatSolver[Task],

--- a/src/discrete_optimization/workforce/scheduling/solvers/cpsat.py
+++ b/src/discrete_optimization/workforce/scheduling/solvers/cpsat.py
@@ -403,7 +403,7 @@ class CPSatAllocSchedulingSolver(
 
         # Overlap constraints
         for index_team in key_per_team:
-            self.create_renewable_resources_constraint(
+            self.create_calendar_resources_constraint(
                 self.problem.index_to_team[index_team]
             )
             if additional_constraints is not None:
@@ -434,7 +434,7 @@ class CPSatAllocSchedulingSolver(
 
         # Resource constraints
         for resource in self.problem.resources_list:
-            self.create_renewable_resources_constraint(resource)
+            self.create_calendar_resources_constraint(resource)
         if optional_activities:
             self.variables["actually_done"] = self.create_actually_done_variables()
         # Objectives definitions

--- a/src/discrete_optimization/workforce/scheduling/solvers/cpsat_auto.py
+++ b/src/discrete_optimization/workforce/scheduling/solvers/cpsat_auto.py
@@ -4,29 +4,23 @@
 import logging
 import time
 from collections.abc import Iterable
-from functools import reduce
 from typing import Any, Optional, Union
 
 import numpy as np
 from ortools.sat.python.cp_model import (
     CpSolverSolutionCallback,
-    IntervalVar,
     IntVar,
-    LinearExprT,
 )
 
 from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
 from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
     NoNonRenewableResource,
 )
-from discrete_optimization.generic_tasks_tools.solvers.cpsat.generic_scheduling import (
-    GenericSchedulingCpSatSolver,
+from discrete_optimization.generic_tasks_tools.solvers.cpsat.auto import (
+    Objective,
+    SinglemodeGenericSchedulingAutoCpSatSolver,
+    TemporarySolution,
 )
-from discrete_optimization.generic_tasks_tools.solvers.cpsat.multimode_scheduling import (
-    SinglemodeSchedulingCpSatSolver,
-)
-from discrete_optimization.generic_tools.do_problem import Solution
-from discrete_optimization.generic_tools.do_solver import WarmstartMixin
 from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
     CategoricalHyperparameter,
     EnumHyperparameter,
@@ -98,13 +92,11 @@ class AdditionalCPConstraints:
         self.adding_margin_on_sequence = adding_margin_on_sequence
 
 
-class CPSatAllocSchedulingSolver(
-    GenericSchedulingCpSatSolver[
+class CPSatAutoAllocSchedulingSolver(
+    SinglemodeGenericSchedulingAutoCpSatSolver[
         Task, UnaryResource, CumulativeResource, NoNonRenewableResource
     ],
-    SinglemodeSchedulingCpSatSolver[Task],
     SolverAllocScheduling,
-    WarmstartMixin,
 ):
     hyperparameters = [
         CategoricalHyperparameter(
@@ -143,32 +135,7 @@ class CPSatAllocSchedulingSolver(
     variables: dict[str, dict[Any, Any]]
 
     at_most_one_unary_resource_per_task = True
-
-    def get_task_start_or_end_variable(
-        self, task: Task, start_or_end: StartOrEnd
-    ) -> LinearExprT:
-        i_task = self.problem.tasks_to_index[task]
-        if start_or_end == StartOrEnd.START:
-            key = "starts_var"
-        else:
-            key = "ends_var"
-        return self.variables[key][i_task]
-
-    def get_task_unary_resource_is_present_variable(
-        self, task: Task, unary_resource: UnaryResource
-    ) -> LinearExprT:
-        """Return a 0-1 variable/expression telling if the unary_resource is used for the task.
-
-        NB: sometimes the given resource is never to be used by a task and the variable has not been created.
-        The convention is to return 0 in that case.
-
-        """
-        i_task = self.problem.tasks_to_index[task]
-        i_team = self.problem.teams_to_index[unary_resource]
-        try:
-            return self.variables["is_present_var"][i_task][i_team]
-        except KeyError:
-            return 0
+    objective = Objective.NB_UNARY_RESOURCES_USED
 
     @staticmethod
     def implements_lexico_api() -> bool:
@@ -182,13 +149,13 @@ class CPSatAllocSchedulingSolver(
 
     def set_lexico_objective(self, obj: Union[str, ObjectivesEnum]) -> None:
         obj = _get_variables_obj_key(obj)
-        self.cp_model.Minimize(self.variables["objectives"][obj])
+        self.cp_model.minimize(self.variables["objectives"][obj])
 
     def add_lexico_constraint(
         self, obj: Union[str, ObjectivesEnum], value: float
     ) -> Iterable[Any]:
         obj = _get_variables_obj_key(obj)
-        return [self.cp_model.Add(self.variables["objectives"][obj] <= value)]
+        return [self.cp_model.add(self.variables["objectives"][obj] <= value)]
 
     def get_lexico_objective_value(
         self, obj: Union[str, ObjectivesEnum], res: ResultStorage
@@ -200,7 +167,7 @@ class CPSatAllocSchedulingSolver(
     def set_model_obj_aggregated(
         self, objs_weights: list[tuple[Union[str, ObjectivesEnum], float]]
     ):
-        self.cp_model.Minimize(
+        self.cp_model.minimize(
             sum(
                 [
                     x[1] * self.variables["objectives"][_get_variables_obj_key(x[0])]
@@ -209,206 +176,148 @@ class CPSatAllocSchedulingSolver(
             )
         )
 
-    def retrieve_solution(self, cpsolvercb: CpSolverSolutionCallback) -> Solution:
+    def convert_task_variables_to_solution(
+        self, temp_sol: TemporarySolution[Task, UnaryResource]
+    ) -> AllocSchedulingSolution:
         schedule = np.zeros((self.problem.number_tasks, 2), dtype=int)
         allocation = -np.ones(self.problem.number_tasks, dtype=int)
-        logger.info(f"Objs = {[cpsolvercb.Value(x) for x in self.variables['objs']]}")
+        for i_task in range(self.problem.number_tasks):
+            task = self.problem.index_to_task[i_task]
+            task_variable = temp_sol.task_variables[task]
+            schedule[i_task, 0] = task_variable.start
+            schedule[i_task, 1] = task_variable.end
+            for team in task_variable.allocated:
+                allocation[i_task] = self.problem.teams_to_index[team]
+        sol = AllocSchedulingSolution(
+            problem=self.problem, schedule=schedule, allocation=allocation
+        )
+        sol._intern_obj = temp_sol.metadata
+        return sol
+
+    def retrieve_tasks_variables(
+        self, cpsolvercb: CpSolverSolutionCallback
+    ) -> TemporarySolution[Task, UnaryResource]:
+        """Create solution at temporary format from cpsat variables.
+
+        Override it to
+        - add logs
+        - store objective variables values in metadata
+
+        """
+        # retrieve main tasks variables
+        temp_sol = super().retrieve_tasks_variables(cpsolvercb)
+        # log objectives
+        logger.info(f"Objs = {[cpsolvercb.value(x) for x in self.variables['objs']]}")
         logger.info(
-            f"Obj = {cpsolvercb.ObjectiveValue()}, Bound={cpsolvercb.BestObjectiveBound()}"
+            f"Obj = {cpsolvercb.objective_value}, Bound={cpsolvercb.best_objective_bound}"
         )
         if "resched_objs" in self.variables:
             for obj in self.variables["resched_objs"]:
                 logger.info(f"Obj :{obj}")
                 logger.info(
-                    f"Value : {cpsolvercb.Value(self.variables['resched_objs'][obj])}"
+                    f"Value : {cpsolvercb.value(self.variables['resched_objs'][obj])}"
                 )
-        for t in range(self.problem.number_tasks):
-            start = int(cpsolvercb.Value(self.variables["starts_var"][t]))
-            end = int(cpsolvercb.Value(self.variables["ends_var"][t]))
-            schedule[t, 0] = start
-            schedule[t, 1] = end
-            for index_team in self.variables["is_present_var"][t]:
-                if cpsolvercb.Value(self.variables["is_present_var"][t][index_team]):
-                    allocation[t] = index_team
-        sol = AllocSchedulingSolution(
-            problem=self.problem, schedule=schedule, allocation=allocation
-        )
-        sol._intern_obj = {}
+        # store objectives
         for obj in self.variables["objectives"]:
-            sol._intern_obj[obj] = cpsolvercb.Value(self.variables["objectives"][obj])
-        return sol
+            temp_sol.metadata[obj] = cpsolvercb.value(self.variables["objectives"][obj])
+        return temp_sol
 
-    def set_warm_start(self, solution: AllocSchedulingSolution) -> None:
-        if solution is not None:
-            self.cp_model.ClearHints()
-            for t in range(self.problem.number_tasks):
-                self.cp_model.AddHint(
-                    self.variables["starts_var"][t], int(solution.schedule[t, 0])
-                )
-                self.cp_model.AddHint(
-                    self.variables["ends_var"][t], int(solution.schedule[t, 1])
-                )
-                if "actually_done" in self.variables:
-                    self.cp_model.AddHint(self.variables["actually_done"][t], 1)
-
-                for index_team in self.variables["is_present_var"][t]:
-                    if solution.allocation[t] == index_team:
-                        self.cp_model.AddHint(
-                            self.variables["is_present_var"][t][index_team], 1
-                        )
-                    else:
-                        self.cp_model.AddHint(
-                            self.variables["is_present_var"][t][index_team], 0
-                        )
-            team_used = set(solution.allocation)
-            for team in range(self.problem.number_teams):
-                if team in team_used:
-                    self.cp_model.AddHint(self.variables["used"][team], 1)
-                else:
-                    self.cp_model.AddHint(self.variables["used"][team], 0)
-            if "reallocation" in self.variables:
-                for x in self.variables["reallocation"]:
-                    self.cp_model.AddHint(x, 0)
-            if "is_shifted" in self.variables:
-                for x in self.variables["is_shifted"]:
-                    self.cp_model.AddHint(x, 0)
-            if "delta_starts_abs" in self.variables:
-                for x in self.variables["delta_starts_abs"]:
-                    self.cp_model.AddHint(x, 0)
-            if "max_delta_start" in self.variables:
-                self.cp_model.AddHint(self.variables["max_delta_start"], 0)
-            if "objectives" in self.variables:
-                if ObjectivesEnum.MAKESPAN in self.variables["objectives"]:
-                    self.cp_model.AddHint(
-                        self.variables["objectives"][ObjectivesEnum.MAKESPAN],
-                        int(np.max(solution.schedule[:, 1])),
-                    )
-
-    def get_task_unary_resource_interval(
+    def is_compatible_task_unary_resource(
         self, task: Task, unary_resource: UnaryResource
-    ) -> IntervalVar:
-        return self.variables["interval_task_team"][self.problem.tasks_to_index[task]][
-            self.problem.teams_to_index[unary_resource]
-        ]
-
-    def get_task_interval(self, task: Task) -> IntervalVar:
-        return self.variables["interval_task"][self.problem.tasks_to_index[task]]
+    ) -> bool:
+        return unary_resource in self.compatible_teams[task]
 
     def init_model(
-        self, objectives: Optional[list[ObjectivesEnum]] = None, **args: Any
+        self, objectives: Optional[list[ObjectivesEnum]] = None, **kwargs: Any
     ) -> None:
-        additional_constraints: AdditionalCPConstraints = args.get(
+        # optional parameters
+        kwargs = self.complete_with_default_hyperparameters(kwargs)
+        additional_constraints: AdditionalCPConstraints = kwargs.get(
             "additional_constraints", None
         )
+        # store forced allocation for is_compatible_task_unary_resource
+        self.compatible_teams: dict[Task, set[UnaryResource]] = dict(
+            self.problem.compatible_teams_per_activity
+        )
+        if additional_constraints is not None:
+            self.compatible_teams.update(
+                {
+                    self.problem.index_to_task[i_task]: {
+                        self.problem.index_to_team[i_team]
+                    }
+                    for i_task, i_team in additional_constraints.forced_allocation.items()
+                }
+            )
+        self.compatible_tasks: dict[UnaryResource, set[Task]] = {
+            team: {
+                task
+                for task in self.problem.tasks_list
+                if team in self.compatible_teams
+            }
+            for team in self.problem.unary_resources_list
+        }
+
+        add_lower_bound = kwargs["add_lower_bound"]
+        optional_activities = kwargs["optional_activities"]
+        adding_redundant_cumulative = kwargs["adding_redundant_cumulative"]
+
+        self.exactly_one_unary_resource_per_task = not optional_activities
+
+        super().init_model(**kwargs)
+
         if objectives is None:
             objectives = [ObjectivesEnum.NB_TEAMS]
-        args = self.complete_with_default_hyperparameters(args)
-        add_lower_bound = args["add_lower_bound"]
-        optional_activities = args["optional_activities"]
-        adding_redundant_cumulative = args["adding_redundant_cumulative"]
-        super().init_model(**args)
-        starts_var = {}
-        ends_var = {}
-        is_present_var = {}
-        interval_var = {}
-        opt_interval_var = {}
-        st_lb = [
-            (
-                int(self.problem.get_lb_start_window(t)),
-                int(self.problem.get_ub_start_window(t)),
-                int(self.problem.get_lb_end_window(t)),
-                int(self.problem.get_ub_end_window(t)),
-            )
-            for t in self.problem.tasks_list
-        ]
-        dur = [
-            self.problem.tasks_data[t].duration_task for t in self.problem.tasks_list
-        ]
-        key_per_team = {j: [] for j in self.problem.index_to_team}
-        compatible_teams: dict[int, set[int]] = (
-            self.problem.compatible_teams_index_all_activity()
-        )
-        self.variables = {
-            "starts_var": starts_var,
-            "ends_var": ends_var,
-            "is_present_var": is_present_var,
-            "objectives": {},
-            "key_per_team": key_per_team,
-            "interval_task_team": opt_interval_var,
-            "interval_task": interval_var,
-        }
-        if additional_constraints is not None:
-            forced_alloc = additional_constraints.forced_allocation
-            if forced_alloc is not None:
-                for i in forced_alloc:
-                    if forced_alloc[i] is not None:
-                        compatible_teams[i] = {forced_alloc[i]}
-        for i, task in enumerate(self.problem.tasks_list):
-            starts_var[i] = self.cp_model.NewIntVar(
-                lb=st_lb[i][0], ub=st_lb[i][1], name=f"start_{i}"
-            )
-            ends_var[i] = self.cp_model.NewIntVar(
-                lb=st_lb[i][2], ub=st_lb[i][3], name=f"end_{i}"
-            )
-            interval_var[i] = self.cp_model.NewIntervalVar(
-                start=starts_var[i], end=ends_var[i], size=dur[i], name=f"interval_{i}"
-            )
-            is_present_var[i] = {}
-            opt_interval_var[i] = {}
-            for index_team in compatible_teams[i]:
-                # same as "allocation_binary" variable in the allocation problem
-                is_present_var[i][index_team] = self.cp_model.NewBoolVar(
-                    name=f"alloc_{i}_{index_team}"
-                )
-                opt_interval_var[i][index_team] = self.cp_model.NewOptionalIntervalVar(
-                    start=starts_var[i],
-                    end=ends_var[i],
-                    size=dur[i],
-                    is_present=is_present_var[i][index_team],
-                    name=f"interval_{i}_{index_team}",
-                )
-                key_per_team[index_team].append((i, index_team))
-            if not optional_activities:
-                self.cp_model.AddExactlyOne(
-                    [is_present_var[i][x] for x in is_present_var[i]]
-                )
-                # else managed later by self.create_actually_done_variables()
 
-        # Precedence constraints
-        self.create_precedence_constraints()
+        self.variables = {}
+        self.variables["objectives"] = {}
 
         # Same allocation constraints
-        for l_t in self.problem.same_allocation:
-            indexes = [self.problem.tasks_to_index[tt] for tt in l_t]
-            common_teams = reduce(
-                lambda x, y: x.intersection(set(is_present_var[y].keys())),
-                indexes,
-                set(self.problem.index_to_team),
-            )
-            for c in common_teams:
-                self.cp_model.AddAllowedAssignments(
-                    [is_present_var[ind][c] for ind in indexes],
+        for common_tasks in self.problem.same_allocation:
+            common_teams = [
+                team
+                for team in self.problem.unary_resources_list
+                if all(
+                    self.is_compatible_task_unary_resource(
+                        task=task, unary_resource=team
+                    )
+                    for task in common_tasks
+                )
+            ]
+
+            for team in common_teams:
+                self.cp_model.add_allowed_assignments(
                     [
-                        tuple([1] * len(indexes)),
-                        tuple([0] * len(indexes)),
+                        self.get_task_unary_resource_is_present_variable(
+                            task=task, unary_resource=team
+                        )
+                        for task in common_tasks
+                    ],
+                    [
+                        tuple([1] * len(common_tasks)),
+                        tuple([0] * len(common_tasks)),
                     ],
                 )
             # Redundant
-            for c in common_teams:
-                for i in range(len(indexes) - 1):
-                    self.cp_model.Add(
-                        is_present_var[indexes[i]][c]
-                        == is_present_var[indexes[i + 1]][c]
+            list_common_tasks = list(common_tasks)
+            for team in common_teams:
+                for i_task in range(len(list_common_tasks) - 1):
+                    self.cp_model.add(
+                        self.get_task_unary_resource_is_present_variable(
+                            task=list_common_tasks[i_task], unary_resource=team
+                        )
+                        == self.get_task_unary_resource_is_present_variable(
+                            task=list_common_tasks[i_task + 1], unary_resource=team
+                        )
                     )
 
         # Overlap constraints
-        for index_team in key_per_team:
-            self.create_renewable_resources_constraint(
-                self.problem.index_to_team[index_team]
-            )
-            if additional_constraints is not None:
+        if additional_constraints is not None:
+            for team in self.problem.unary_resources_list:
                 tasks_team = [
-                    opt_interval_var[x[0]][x[1]] for x in key_per_team[index_team]
+                    self.get_task_unary_resource_interval(
+                        task=task, unary_resource=team
+                    )
+                    for task in self.compatible_tasks[team]
                 ]
                 if len(tasks_team) > 0:
                     if (
@@ -418,29 +327,29 @@ class CPSatAllocSchedulingSolver(
                         margin = additional_constraints.adding_margin_on_sequence[1]
                         # create just additional interval for the "routing" constraint.
                         intervals = [
-                            self.cp_model.NewOptionalFixedSizeIntervalVar(
-                                start=starts_var[x[0]],
-                                size=dur[x[0]] + margin,
-                                is_present=is_present_var[x[0]][x[1]],
-                                name=f"dummy_longer_task_{x[0], x[1]}",
+                            self.cp_model.new_optional_fixed_size_interval_var(
+                                start=self.get_task_start_or_end_variable(
+                                    task=task, start_or_end=StartOrEnd.START
+                                ),
+                                size=self.problem.tasks_data[task].duration_task
+                                + margin,
+                                is_present=self.get_task_unary_resource_is_present_variable(
+                                    task=task, unary_resource=team
+                                ),
+                                name=f"dummy_longer_task_{task, team}",
                             )
-                            for x in key_per_team[index_team]
+                            for task in self.compatible_tasks[team]
                         ]
-                        self.cp_model.AddCumulative(
+                        self.cp_model.add_cumulative(
                             intervals=intervals,
                             demands=[1] * len(intervals),
                             capacity=1,
                         )
 
-        # Resource constraints
-        for resource in self.problem.resources_list:
-            self.create_renewable_resources_constraint(resource)
-        if optional_activities:
-            self.variables["actually_done"] = self.create_actually_done_variables()
         # Objectives definitions
         if ObjectivesEnum.DELTA_TO_EXISTING_SOLUTION in objectives:
-            assert "base_solution" in args
-            sol: AllocSchedulingSolution = args["base_solution"]
+            assert "base_solution" in kwargs
+            sol: AllocSchedulingSolution = kwargs["base_solution"]
             problem = sol.problem
             self.create_delta_objectives(
                 base_solution=sol,
@@ -457,36 +366,39 @@ class CPSatAllocSchedulingSolver(
             ] = -self.get_nb_tasks_done_variable()
         used = self.create_used_variables_dict()
         self.variables["used"] = used
-        if args["symmbreak_on_used"]:
+        if kwargs["symmbreak_on_used"]:
             equivalent_ = compute_equivalent_teams_scheduling_problem(self.problem)
             for group in equivalent_:
                 for ind1, ind2 in zip(group[:-1], group[1:]):
-                    self.cp_model.AddImplication(used[ind2], used[ind1])
-                    self.cp_model.Add(used[ind1] >= used[ind2])
+                    self.cp_model.add_implication(used[ind2], used[ind1])
+                    self.cp_model.add(used[ind1] >= used[ind2])
         nb_teams_var = self.get_nb_unary_resources_used_variable()
         self.variables["objectives"][ObjectivesEnum.NB_TEAMS] = nb_teams_var
         if adding_redundant_cumulative:
             # we need to introduce this new variable with positive lower bound
             # if we instead directly addCumulative with nb_teams_var, the solver
             # does not find a solution anymore (oddly)
-            capacity = self.cp_model.NewIntVar(
+            capacity = self.cp_model.new_int_var(
                 lb=1, ub=self.problem.number_teams, name="capacity"
             )
-            self.cp_model.Add(capacity == nb_teams_var)
-            self.cp_model.AddCumulative(
-                intervals=[interval_var[x] for x in interval_var],
-                demands=[1 for x in interval_var],
+            self.cp_model.add(capacity == nb_teams_var)
+            self.cp_model.add_cumulative(
+                intervals=[
+                    self.get_task_interval(task=task)
+                    for task in self.problem.tasks_list
+                ],
+                demands=[1 for _ in range(self.problem.number_tasks)],
                 capacity=capacity,
             )
         if add_lower_bound:
-            lprovider: SubBrick = args["lower_bound_method"]
+            lprovider: SubBrick = kwargs["lower_bound_method"]
             t_deb = time.perf_counter()
             lbound_provider: BaseAllocSchedulingLowerBoundProvider = lprovider.cls(
                 self.problem
             )
             bound = lbound_provider.get_lb_nb_teams(**lprovider.kwargs)
             t_end = time.perf_counter()
-            self.cp_model.Add(nb_teams_var >= bound)
+            self.cp_model.add(nb_teams_var >= bound)
             self.time_bounds = t_end - t_deb
             self.bound_teams = bound
             self.status_bound = lbound_provider.status
@@ -495,7 +407,7 @@ class CPSatAllocSchedulingSolver(
             self.time_bounds = 0
             self.status_bound = None
 
-        self.add_objective_functions_on_cumul(objectives=objectives, **args)
+        self.add_objective_functions_on_cumul(objectives=objectives, **kwargs)
         if additional_constraints is not None:
             self.set_additional_constraints(
                 additional_constraint=additional_constraints
@@ -538,7 +450,7 @@ class CPSatAllocSchedulingSolver(
                     ]
                 )
         self.variables["objs"] = objs
-        self.cp_model.Minimize(sum(weights[i] * objs[i] for i in range(len(objs))))
+        self.cp_model.minimize(sum(weights[i] * objs[i] for i in range(len(objs))))
 
     def add_objective_functions_on_cumul(
         self, objectives: Optional[list[ObjectivesEnum]] = None, **args
@@ -553,8 +465,7 @@ class CPSatAllocSchedulingSolver(
             dict_fairness = model_fairness(
                 used_team=self.variables["used"],
                 allocation_variables=[
-                    self.variables["is_present_var"][i]
-                    for i in range(self.problem.number_tasks)
+                    self.allocation_is_present[task] for task in self.problem.tasks_list
                 ],
                 value_per_task=dur,
                 modelisation_dispersion=modelisation_dispersion,
@@ -574,19 +485,18 @@ class CPSatAllocSchedulingSolver(
             variables = cumulate_value_per_teams_version_2(
                 used_team=self.variables["used"],
                 allocation_variables=[
-                    self.variables["is_present_var"][i]
-                    for i in range(self.problem.number_tasks)
+                    self.allocation_is_present[task] for task in self.problem.tasks_list
                 ],
                 value_per_task=dur,
                 cp_model=self.cp_model,
                 number_teams=self.problem.number_teams,
                 name_value="workload_",
             )
-            min_value = self.cp_model.NewIntVar(
+            min_value = self.cp_model.new_int_var(
                 lb=0, ub=sum(dur), name="min_value_workload"
             )
 
-            self.cp_model.AddMinEquality(min_value, variables["workload_per_team_nz"])
+            self.cp_model.add_min_equality(min_value, variables["workload_per_team_nz"])
             self.variables["objectives"][ObjectivesEnum.MIN_WORKLOAD] = min_value
 
     def set_additional_constraints(
@@ -603,18 +513,18 @@ class CPSatAllocSchedulingSolver(
                 and additional_constraint.nb_teams_bounds[1]
                 == additional_constraint.nb_teams_bounds[0]
             ):
-                self.cp_model.Add(
+                self.cp_model.add(
                     sum([used[x] for x in used])
                     == additional_constraint.nb_teams_bounds[0]
                 )
             else:
                 if additional_constraint.nb_teams_bounds[0] is not None:
-                    self.cp_model.Add(
+                    self.cp_model.add(
                         sum([used[x] for x in used])
                         >= additional_constraint.nb_teams_bounds[0]
                     )
                 if additional_constraint.nb_teams_bounds[1] is not None:
-                    self.cp_model.Add(
+                    self.cp_model.add(
                         sum([used[x] for x in used])
                         <= additional_constraint.nb_teams_bounds[1]
                     )
@@ -626,9 +536,9 @@ class CPSatAllocSchedulingSolver(
                 if additional_constraint.team_used_constraint[team_index] is not None:
                     # don't care for the syntax warning, i want that it only works with booleans
                     if additional_constraint.team_used_constraint[team_index] == True:
-                        self.cp_model.Add(used[team_index] == 1)
+                        self.cp_model.add(used[team_index] == 1)
                     if additional_constraint.team_used_constraint[team_index] == False:
-                        self.cp_model.Add(used[team_index] == 0)
+                        self.cp_model.add(used[team_index] == 0)
 
     def create_delta_objectives(
         self,
@@ -641,7 +551,7 @@ class CPSatAllocSchedulingSolver(
         )
         len_common_tasks = len(common_tasks)
         reallocation_bool = [
-            self.cp_model.NewBoolVar(name=f"realloc_{self.problem.tasks_to_index[t]}")
+            self.cp_model.new_bool_var(name=f"realloc_{self.problem.tasks_to_index[t]}")
             for t in common_tasks
         ]
         self.variables["reallocation"] = reallocation_bool
@@ -649,7 +559,7 @@ class CPSatAllocSchedulingSolver(
         delta_starts = []
         delta_starts_abs = []
         is_shifted = [
-            self.cp_model.NewBoolVar(name=f"shifted_{self.problem.tasks_to_index[t]}")
+            self.cp_model.new_bool_var(name=f"shifted_{self.problem.tasks_to_index[t]}")
             for t in common_tasks
         ]
         self.variables["is_shifted"] = is_shifted
@@ -677,50 +587,44 @@ class CPSatAllocSchedulingSolver(
                 ]
 
             if team_of_base_solution is not None:
-                index_team = self.problem.teams_to_index[team_of_base_solution]
                 if not ignore_reallocation:
-                    if (
-                        index_team
-                        not in self.variables["is_present_var"][index_in_problem]
-                    ):
-                        logger.debug("Problem")
-                    else:
-                        self.cp_model.Add(
-                            self.variables["is_present_var"][index_in_problem][
-                                index_team
-                            ]
-                            == 1
-                        ).OnlyEnforceIf(reallocation_bool[i].Not())
-                        self.cp_model.Add(
-                            self.variables["is_present_var"][index_in_problem][
-                                index_team
-                            ]
-                            == 0
-                        ).OnlyEnforceIf(reallocation_bool[i])
+                    is_present = self.get_task_unary_resource_is_present_variable(
+                        task=tt, unary_resource=team_of_base_solution
+                    )
+                    self.cp_model.add(is_present == 1).only_enforce_if(
+                        reallocation_bool[i].Not()
+                    )
+                    self.cp_model.add(is_present == 0).only_enforce_if(
+                        reallocation_bool[i]
+                    )
                 else:
-                    self.cp_model.Add(reallocation_bool[i] == 0)
+                    self.cp_model.add(reallocation_bool[i] == 0)
 
             delta_starts.append(
                 -int(base_solution.schedule[index_in_base_problem, 0])
-                + self.variables["starts_var"][index_in_problem]
+                + self.get_task_start_or_end_variable(
+                    task=tt, start_or_end=StartOrEnd.START
+                )
             )
-            self.cp_model.Add(delta_starts[-1] != 0).OnlyEnforceIf(is_shifted[i])
-            self.cp_model.Add(delta_starts[-1] == 0).OnlyEnforceIf(is_shifted[i].Not())
+            self.cp_model.add(delta_starts[-1] != 0).only_enforce_if(is_shifted[i])
+            self.cp_model.add(delta_starts[-1] == 0).only_enforce_if(
+                is_shifted[i].Not()
+            )
             delta_starts_abs.append(
-                self.cp_model.NewIntVar(
+                self.cp_model.new_int_var(
                     lb=0,
                     ub=self.problem.horizon,
                     name=f"delta_abs_starts_{index_in_problem}",
                 )
             )
-            self.cp_model.AddAbsEquality(delta_starts_abs[-1], delta_starts[-1])
+            self.cp_model.add_abs_equality(delta_starts_abs[-1], delta_starts[-1])
         self.variables["delta_starts_abs"] = delta_starts_abs
         self.variables["delta_starts"] = delta_starts
-        max_delta_start = self.cp_model.NewIntVar(
+        max_delta_start = self.cp_model.new_int_var(
             lb=0, ub=self.problem.horizon, name=f"max_delta_starts"
         )
         self.variables["max_delta_start"] = max_delta_start
-        self.cp_model.AddMaxEquality(max_delta_start, delta_starts_abs)
+        self.cp_model.add_max_equality(max_delta_start, delta_starts_abs)
         objs = [
             sum(reallocation_bool)
         ]  # count the number of changes of team/task allocation
@@ -746,13 +650,6 @@ class CPSatAllocSchedulingSolver(
             for team, used_var in self.used_variables.items()
         }
         return used
-
-    def create_actually_done_variables(self) -> dict[int, IntVar]:
-        self.create_done_variables()
-        return {
-            self.problem.tasks_to_index[task]: done_var
-            for task, done_var in self.done_variables.items()
-        }
 
 
 def _get_variables_obj_key(

--- a/tests/fjsp/solvers/test_cpsat_auto.py
+++ b/tests/fjsp/solvers/test_cpsat_auto.py
@@ -1,0 +1,360 @@
+#  Copyright (c) 2024-2025 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+
+import logging
+import os.path
+import time
+from typing import Optional
+
+import pytest
+
+import discrete_optimization.fjsp.parser as fjsp_parser
+import discrete_optimization.jsp.parser as jsp_parser
+from discrete_optimization.fjsp.problem import FJobShopSolution, Job
+from discrete_optimization.fjsp.solvers.cpsat_auto import (
+    CpSatAutoFjspSolver,
+    FJobShopProblem,
+)
+from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
+from discrete_optimization.generic_tools.callbacks.callback import Callback
+from discrete_optimization.generic_tools.callbacks.early_stoppers import (
+    NbIterationStopper,
+)
+from discrete_optimization.generic_tools.cp_tools import ParametersCp, SignEnum
+from discrete_optimization.generic_tools.ortools_cpsat_tools import OrtoolsCpSatSolver
+from discrete_optimization.generic_tools.result_storage.result_storage import (
+    ResultStorage,
+)
+from discrete_optimization.jsp.problem import JobShopProblem
+
+logging.basicConfig(level=logging.INFO)
+
+
+class StatsCpsatCallback(Callback):
+    def __init__(self):
+        self.starting_time: int = None
+        self.end_time: int = None
+        self.stats: list[dict] = []
+        self.final_status: str = None
+
+    def on_step_end(
+        self, step: int, res: ResultStorage, solver: OrtoolsCpSatSolver
+    ) -> Optional[bool]:
+        self.stats.append(
+            {
+                "obj": solver.clb.ObjectiveValue(),
+                "bound": solver.clb.BestObjectiveBound(),
+                "time": time.perf_counter() - self.starting_time,
+                "time-cpsat": {
+                    "user-time": solver.clb.UserTime(),
+                    "wall-time": solver.clb.WallTime(),
+                },
+            }
+        )
+        if solver.clb.ObjectiveValue() == solver.clb.BestObjectiveBound():
+            return False
+
+    def on_solve_start(self, solver: OrtoolsCpSatSolver):
+        self.starting_time = time.perf_counter()
+
+    def on_solve_end(self, res: ResultStorage, solver: OrtoolsCpSatSolver):
+        """Called at the end of solve.
+        Args:
+        res: current result storage
+        solver: solvers using the callback
+        """
+        status_name = solver.solver.status_name()
+        # status_do: StatusSolver = cpstatus_to_dostatus(status_name)
+        if len(self.stats) > 0:
+            if (
+                solver.solver.ObjectiveValue() != self.stats[-1]["obj"]
+                or solver.solver.BestObjectiveBound() != self.stats[-1]["bound"]
+            ):
+                self.stats.append(
+                    {
+                        "obj": solver.solver.ObjectiveValue(),
+                        "bound": solver.solver.BestObjectiveBound(),
+                        "time": time.perf_counter() - self.starting_time,
+                        "time-cpsat": {
+                            "user-time": solver.solver.UserTime(),
+                            "wall-time": solver.solver.WallTime(),
+                        },
+                    }
+                )
+        self.final_status = status_name
+
+
+@pytest.mark.parametrize("duplicate_temporal_var", [False, True])
+@pytest.mark.parametrize("add_cumulative_constraint", [False, True])
+def test_fjsp_solver_on_jsp(duplicate_temporal_var, add_cumulative_constraint):
+    file_path = [
+        f for f in jsp_parser.get_data_available() if os.path.basename(f) == "orb10"
+    ][0]
+    problem: JobShopProblem = jsp_parser.parse_file(file_path)
+    fproblem = FJobShopProblem(
+        list_jobs=[
+            Job(job_id=i, sub_jobs=[[sj] for sj in problem.list_jobs[i]])
+            for i in range(problem.n_jobs)
+        ],
+        n_jobs=problem.n_jobs,
+        n_machines=problem.n_machines,
+    )
+    solver = CpSatAutoFjspSolver(problem=fproblem)
+    p = ParametersCp.default()
+    res = solver.solve(
+        parameters_cp=p,
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+        duplicate_temporal_var=duplicate_temporal_var,
+        add_cumulative_constraint=add_cumulative_constraint,
+    )
+    sol, _ = res.get_best_solution_fit()
+    assert fproblem.satisfy(sol)
+
+    # test prob.task_lists and sol.get_start_stime/end_time
+    assert len(problem.tasks_list) == problem.n_all_jobs
+    for task in problem.tasks_list:
+        print(sol.get_start_time(task), sol.get_end_time(task))
+
+
+@pytest.mark.parametrize("duplicate_temporal_var", [False, True])
+@pytest.mark.parametrize("add_cumulative_constraint", [False, True])
+def test_cpsat_fjsp(duplicate_temporal_var, add_cumulative_constraint):
+    files = fjsp_parser.get_data_available()
+    print(files)
+    file = [f for f in files if "Behnke1.fjs" in f][0]
+    print(file)
+    problem = fjsp_parser.parse_file(file)
+    print(problem)
+    solver = CpSatAutoFjspSolver(problem=problem)
+    p = ParametersCp.default()
+    res = solver.solve(
+        parameters_cp=p,
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+        ortools_cpsat_solver_kwargs=dict(log_search_progress=True),
+        duplicate_temporal_var=duplicate_temporal_var,
+        add_cumulative_constraint=add_cumulative_constraint,
+    )
+    sol, _ = res.get_best_solution_fit()
+    assert problem.satisfy(sol)
+    # test prob.task_lists and sol.get_start_stime/end_time
+    assert len(problem.tasks_list) == problem.n_all_jobs
+    for task in problem.tasks_list:
+        print(sol.get_start_time(task), sol.get_end_time(task))
+
+
+def test_objectives():
+    files = fjsp_parser.get_data_available()
+    file = [f for f in files if "Behnke1.fjs" in f][0]
+    problem = fjsp_parser.parse_file(file)
+    solver = CpSatAutoFjspSolver(problem=problem)
+    solver.init_model()
+    p = ParametersCp.default()
+
+    subtasks = {(0, 0), (2, 2)}
+    # max end time subtasks
+    objective = solver.get_subtasks_makespan_variable(subtasks)
+    solver.minimize_variable(objective)
+    sol, _ = solver.solve(callbacks=[NbIterationStopper(nb_iteration_max=1)])[-1]
+    solver.solver.ObjectiveValue() == max(sol.get_end_time(task) for task in subtasks)
+
+
+def test_mode_constraint():
+    files = fjsp_parser.get_data_available()
+    file = [f for f in files if "Behnke1.fjs" in f][0]
+    problem = fjsp_parser.parse_file(file)
+    assert problem.is_multimode
+
+    solver = CpSatAutoFjspSolver(problem=problem)
+    p = ParametersCp.default()
+    kwargs_solve = dict(
+        parameters_cp=p,
+        duplicate_temporal_var=True,
+        add_cumulative_constraint=True,
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+    )
+    task = (0, 0)
+    print(problem.get_task_modes(task))
+    mode = 0
+    sol: FJobShopSolution = solver.solve(**kwargs_solve).get_best_solution()
+    assert not (sol.get_mode(task) == mode)
+
+    solver.add_constraint_on_task_mode(task, mode)
+    sol: FJobShopSolution = solver.solve(**kwargs_solve).get_best_solution()
+    assert sol.get_mode(task) == mode
+
+    mode_nok = 5
+    with pytest.raises(ValueError):
+        solver.add_constraint_on_task_mode(task, mode_nok)
+
+
+def test_mode_constraint_monomode():
+    filename = "la02"
+    filepath = [f for f in jsp_parser.get_data_available() if f.endswith(filename)][0]
+    problem: JobShopProblem = jsp_parser.parse_file(filepath)
+    fproblem = FJobShopProblem(
+        list_jobs=[
+            Job(job_id=i, sub_jobs=[[sj] for sj in problem.list_jobs[i]])
+            for i in range(problem.n_jobs)
+        ],
+        n_jobs=problem.n_jobs,
+        n_machines=problem.n_machines,
+    )
+    assert not fproblem.is_multimode
+
+    solver = CpSatAutoFjspSolver(problem=fproblem)
+    p = ParametersCp.default()
+    kwargs_solve = dict(
+        parameters_cp=p,
+        duplicate_temporal_var=True,
+        add_cumulative_constraint=True,
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+    )
+    task = (0, 1)
+    mode = 0
+    solver.init_model()
+    solver.add_constraint_on_task_mode(task, mode)
+    sol: FJobShopSolution = solver.solve(**kwargs_solve).get_best_solution()
+    assert sol.get_mode(task) == mode
+
+    mode_nok = 3
+    with pytest.raises(ValueError):
+        solver.add_constraint_on_task_mode(task, mode_nok)
+
+
+@pytest.mark.parametrize(
+    "task, start_or_end, sign , time",
+    [
+        ((0, 1), StartOrEnd.START, SignEnum.LESS, 20),
+        ((0, 0), StartOrEnd.END, SignEnum.EQUAL, 120),
+    ],
+)
+def test_task_constraints(task, start_or_end, sign, time):
+    files = fjsp_parser.get_data_available()
+    file = [f for f in files if "Behnke1.fjs" in f][0]
+    problem = fjsp_parser.parse_file(file)
+    solver = CpSatAutoFjspSolver(problem=problem)
+    p = ParametersCp.default()
+    sol: FJobShopSolution = solver.solve(
+        parameters_cp=p,
+        duplicate_temporal_var=True,
+        add_cumulative_constraint=True,
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+    ).get_best_solution()
+    print(sol.schedule)
+    # before adding the constraint, not already satisfied
+    assert not sol.constraint_on_task_satisfied(
+        task=task, start_or_end=start_or_end, sign=sign, time=time
+    )
+    # add constraint: should be now satisfied
+    cstrs = solver.add_constraint_on_task(
+        task=task, start_or_end=start_or_end, sign=sign, time=time
+    )
+    sol = solver.solve(
+        parameters_cp=p,
+        duplicate_temporal_var=True,
+        add_cumulative_constraint=True,
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+    ).get_best_solution()
+    print(sol.schedule)
+    assert sol.constraint_on_task_satisfied(
+        task=task, start_or_end=start_or_end, sign=sign, time=time
+    )
+    # check constraints can be effectively removed
+    solver.remove_constraints(cstrs)
+    sol = solver.solve(
+        parameters_cp=p,
+        duplicate_temporal_var=True,
+        add_cumulative_constraint=True,
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+    ).get_best_solution()
+    print(sol.schedule)
+    assert not sol.constraint_on_task_satisfied(
+        task=task, start_or_end=start_or_end, sign=sign, time=time
+    )
+
+
+def test_chaining_tasks_constraint():
+    task1 = (0, 0)
+    task2 = (1, 4)
+    files = fjsp_parser.get_data_available()
+    file = [f for f in files if "Behnke1.fjs" in f][0]
+    problem = fjsp_parser.parse_file(file)
+    solver = CpSatAutoFjspSolver(problem=problem)
+    p = ParametersCp.default()
+    sol: FJobShopSolution = solver.solve(
+        parameters_cp=p,
+        duplicate_temporal_var=True,
+        add_cumulative_constraint=True,
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+    ).get_best_solution()
+    print(sol.schedule)
+    # before adding the constraint, not already satisfied
+    assert not sol.constraint_chaining_tasks_satisfied(task1=task1, task2=task2)
+    # add constraint: should be now satisfied
+    cstrs = solver.add_constraint_chaining_tasks(task1=task1, task2=task2)
+    sol = solver.solve(
+        parameters_cp=p,
+        duplicate_temporal_var=True,
+        add_cumulative_constraint=True,
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+    ).get_best_solution()
+    print(sol.schedule)
+    assert sol.constraint_chaining_tasks_satisfied(task1=task1, task2=task2)
+    # check constraints can be effectively removed
+    solver.remove_constraints(cstrs)
+    sol = solver.solve(
+        parameters_cp=p,
+        duplicate_temporal_var=True,
+        add_cumulative_constraint=True,
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+    ).get_best_solution()
+    print(sol.schedule)
+    assert not sol.constraint_chaining_tasks_satisfied(task1=task1, task2=task2)
+
+
+def test_cpsat_retrieve_stats():
+    files = fjsp_parser.get_data_available()
+    print(files)
+    file = [f for f in files if "Behnke1.fjs" in f][0]
+    print(file)
+    problem = fjsp_parser.parse_file(file)
+    print(problem)
+    solver = CpSatAutoFjspSolver(problem=problem)
+    p = ParametersCp.default()
+    res = solver.solve(
+        parameters_cp=p,
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+        ortools_cpsat_solver_kwargs=dict(log_search_progress=True),
+        duplicate_temporal_var=True,
+        add_cumulative_constraint=True,
+        retrieve_stats=True,
+    )
+    assert res.stats is not None
+    assert res.stats[-1]["obj"] == solver.solver.ObjectiveValue()
+    # assert res.stats[-1]["bound"] == solver.solver.BestObjectiveBound()
+    sol, _ = res.get_best_solution_fit()
+    assert problem.satisfy(sol)
+
+
+def test_cpsat_retrieve_stats_via_clb():
+    files = fjsp_parser.get_data_available()
+    file = [f for f in files if "Behnke1.fjs" in f][0]
+    problem = fjsp_parser.parse_file(file)
+    solver = CpSatAutoFjspSolver(problem=problem)
+    p = ParametersCp.default()
+    stats_clb = StatsCpsatCallback()
+    res = solver.solve(
+        callbacks=[stats_clb, NbIterationStopper(nb_iteration_max=1)],
+        parameters_cp=p,
+        ortools_cpsat_solver_kwargs=dict(log_search_progress=True),
+        duplicate_temporal_var=True,
+        add_cumulative_constraint=True,
+        retrieve_stats=False,
+    )
+    assert stats_clb.stats is not None
+    assert stats_clb.stats[-1]["obj"] == solver.solver.ObjectiveValue()
+    print(stats_clb.stats)
+    # assert res.stats[-1]["bound"] == solver.solver.BestObjectiveBound()
+    sol, _ = res.get_best_solution_fit()
+    assert problem.satisfy(sol)

--- a/tests/generic_tasks_tools/solvers/cpsat/test_auto.py
+++ b/tests/generic_tasks_tools/solvers/cpsat/test_auto.py
@@ -104,7 +104,7 @@ class MyProblem(
     def cumulative_resources_list(self) -> list[CumulativeResource]:
         return self.cumulative_resources
 
-    def get_renewable_resource_consumption(
+    def get_cumulative_resource_consumption(
         self, resource: Resource, task: Task, mode: int
     ) -> int:
         return self.mode_details[task][mode].get(resource, 0)
@@ -153,9 +153,9 @@ class MyProblem(
         return dict(
             makespan=variable.get_max_end_time(),
             nb_allocated=variable.compute_nb_unary_resources_used(),
-            nb_resources_used=variable.compute_nb_renewable_resources_used()
+            nb_resources_used=variable.compute_nb_calendar_resources_used()
             + variable.compute_nb_non_renewable_resources_used(),
-            resources_consumptions=variable.compute_aggregated_renewable_resources_consumptions()
+            resources_consumptions=variable.compute_aggregated_calendar_resources_consumptions()
             + variable.compute_aggregated_non_renewable_resources_consumptions(),
             nb_tasks_done=variable.compute_nb_tasks_done(),
         )
@@ -165,7 +165,7 @@ class MyProblem(
         return (
             variable.check_precedence_constraints()
             and variable.check_all_non_renewable_resource_capacity_constraints()
-            and variable.check_all_renewable_resource_capacity_constraints()
+            and variable.check_all_calendar_resource_capacity_constraints()
             and variable.check_duration_constraints()
         )
 

--- a/tests/generic_tasks_tools/solvers/cpsat/test_auto.py
+++ b/tests/generic_tasks_tools/solvers/cpsat/test_auto.py
@@ -1,0 +1,395 @@
+#  Copyright (c) 2026 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+import copy
+import logging
+from copy import deepcopy
+from typing import Iterable, Union
+
+import pytest
+
+from discrete_optimization.generic_tasks_tools.generic_scheduling import (
+    GenericSchedulingProblem,
+    GenericSchedulingSolution,
+)
+from discrete_optimization.generic_tasks_tools.solvers.cpsat.auto import (
+    GenericSchedulingAutoCpSatSolver,
+    Objective,
+    TaskVariable,
+    TemporarySolution,
+)
+from discrete_optimization.generic_tools.callbacks.early_stoppers import (
+    NbIterationStopper,
+)
+from discrete_optimization.generic_tools.cp_tools import ParametersCp
+from discrete_optimization.generic_tools.do_problem import (
+    ModeOptim,
+    ObjectiveDoc,
+    ObjectiveHandling,
+    ObjectiveRegister,
+    Solution,
+    TypeObjective,
+)
+
+UnaryResource = str
+CumulativeResource = str
+Resource = Union[UnaryResource, CumulativeResource]
+NonRenewableResource = str
+Task = str
+
+
+class MySolution(
+    GenericSchedulingSolution[
+        Task, UnaryResource, CumulativeResource, NonRenewableResource
+    ]
+):
+    problem: MyProblem
+
+    def __init__(
+        self,
+        problem: MyProblem,
+        temp_sol: TemporarySolution[Task, UnaryResource],
+    ):
+        super().__init__(problem)
+        self.temp_sol = temp_sol
+
+    def get_end_time(self, task: Task) -> int:
+        return self.temp_sol.task_variables[task].end
+
+    def get_start_time(self, task: Task) -> int:
+        return self.temp_sol.task_variables[task].start
+
+    def get_mode(self, task: Task) -> int:
+        return self.temp_sol.task_variables[task].mode
+
+    def is_allocated(self, task: Task, unary_resource: UnaryResource) -> bool:
+        return unary_resource in self.temp_sol.task_variables[task].allocated
+
+    def copy(self) -> Solution:
+        return MySolution(problem=self.problem, temp_sol=deepcopy(self.temp_sol))
+
+
+class MyProblem(
+    GenericSchedulingProblem[
+        Task, UnaryResource, CumulativeResource, NonRenewableResource
+    ]
+):
+    horizon = 10
+    non_renewable_resources = ["non_renewable_resource"]
+    cumulative_resources = ["cumulative_resource"]
+    unary_resources = ["worker1", "worker2"]
+    resource_availabilities = {
+        "non_renewable_resource": 1,
+        "cumulative_resource": [
+            (3, 5, 1),
+            (5, 10, 2),
+        ],
+        "worker1": [(1, 4, 1)],
+        "worker2": [(3, 18, 1)],
+    }
+    mode_details = {
+        "task-1": {
+            0: {"non_renewable_resource": 2, "duration": 1},
+            1: {"non_renewable_resource": 1, "duration": 3},
+        },
+        "task-2": {
+            0: {"cumulative_resource": 2, "duration": 4},
+        },
+    }
+    successors = {"task-1": ["task-2"]}
+
+    @property
+    def cumulative_resources_list(self) -> list[CumulativeResource]:
+        return self.cumulative_resources
+
+    def get_renewable_resource_consumption(
+        self, resource: Resource, task: Task, mode: int
+    ) -> int:
+        return self.mode_details[task][mode].get(resource, 0)
+
+    def get_resource_availabilities(
+        self, resource: Resource
+    ) -> list[tuple[int, int, int]]:
+        return self.resource_availabilities[resource]
+
+    def get_task_mode_duration(self, task: Task, mode: int) -> int:
+        return self.mode_details[task][mode]["duration"]
+
+    @property
+    def non_renewable_resources_list(self) -> list[NonRenewableResource]:
+        return self.non_renewable_resources
+
+    def get_non_renewable_resource_capacity(
+        self, resource: NonRenewableResource
+    ) -> int:
+        return self.resource_availabilities[resource]
+
+    def get_non_renewable_resource_consumption(
+        self, resource: NonRenewableResource, task: Task, mode: int
+    ) -> int:
+        return self.mode_details[task][mode].get(resource, 0)
+
+    @property
+    def unary_resources_list(self) -> list[UnaryResource]:
+        return self.unary_resources
+
+    def get_precedence_constraints(self) -> dict[Task, Iterable[Task]]:
+        return self.successors
+
+    def get_makespan_upper_bound(self) -> int:
+        return self.horizon
+
+    def get_task_modes(self, task: Task) -> set[int]:
+        return set(self.mode_details[task])
+
+    @property
+    def tasks_list(self) -> list[Task]:
+        return list(self.mode_details)
+
+    def evaluate(self, variable: Solution) -> dict[str, float]:
+        variable: MySolution
+        return dict(
+            makespan=variable.get_max_end_time(),
+            nb_allocated=variable.compute_nb_unary_resources_used(),
+            nb_resources_used=variable.compute_nb_renewable_resources_used()
+            + variable.compute_nb_non_renewable_resources_used(),
+            resources_consumptions=variable.compute_aggregated_renewable_resources_consumptions()
+            + variable.compute_aggregated_non_renewable_resources_consumptions(),
+            nb_tasks_done=variable.compute_nb_tasks_done(),
+        )
+
+    def satisfy(self, variable: Solution) -> bool:
+        variable: MySolution
+        return (
+            variable.check_precedence_constraints()
+            and variable.check_all_non_renewable_resource_capacity_constraints()
+            and variable.check_all_renewable_resource_capacity_constraints()
+            and variable.check_duration_constraints()
+        )
+
+    def get_solution_type(self) -> type[Solution]:
+        return MySolution
+
+    def get_objective_register(self) -> ObjectiveRegister:
+        return ObjectiveRegister(
+            objective_sense=ModeOptim.MINIMIZATION,
+            objective_handling=ObjectiveHandling.SINGLE,
+            dict_objective_to_doc=dict(
+                makespan=ObjectiveDoc(
+                    type=TypeObjective.OBJECTIVE,
+                    default_weight=1,
+                ),
+                nb_allocated=ObjectiveDoc(
+                    type=TypeObjective.OBJECTIVE,
+                    default_weight=1,
+                ),
+                nb_resources_used=ObjectiveDoc(
+                    type=TypeObjective.OBJECTIVE,
+                    default_weight=1,
+                ),
+                resources_consumptions=ObjectiveDoc(
+                    type=TypeObjective.OBJECTIVE,
+                    default_weight=1,
+                ),
+                nb_tasks_done=ObjectiveDoc(
+                    type=TypeObjective.OBJECTIVE,
+                    default_weight=-1,
+                ),
+            ),
+        )
+
+
+class MyAutoCpsatSolver(
+    GenericSchedulingAutoCpSatSolver[
+        Task, UnaryResource, CumulativeResource, NonRenewableResource
+    ]
+):
+    problem: MyProblem
+
+    def convert_task_variables_to_solution(
+        self, temp_sol: TemporarySolution[Task, UnaryResource]
+    ) -> MySolution:
+        return MySolution(problem=self.problem, temp_sol=temp_sol)
+
+
+def test_problem(caplog):
+    problem = MyProblem()
+    sol = MySolution(
+        problem=problem,
+        temp_sol=TemporarySolution(
+            task_variables={
+                "task-1": TaskVariable(start=1, end=4, mode=1, allocated=["worker1"]),
+                "task-2": TaskVariable(start=5, end=9, mode=0, allocated=["worker2"]),
+            }
+        ),
+    )
+    problem.satisfy(sol)
+    d = problem.evaluate(sol)
+    assert d["makespan"] == 9
+    assert d["nb_tasks_done"] == 2
+    assert d["nb_allocated"] == 2
+    assert d["nb_resources_used"] == 4
+    assert d["resources_consumptions"] == 5
+
+    sol = MySolution(
+        problem=problem,
+        temp_sol=TemporarySolution(
+            task_variables={
+                "task-1": TaskVariable(start=3, end=6, mode=1, allocated=["worker2"]),
+                "task-2": TaskVariable(start=6, end=10, mode=0, allocated=["worker2"]),
+            }
+        ),
+    )
+    problem.satisfy(sol)
+    d = problem.evaluate(sol)
+    assert d["makespan"] == 10
+    assert d["nb_tasks_done"] == 2
+    assert d["nb_allocated"] == 1
+
+    sol = MySolution(
+        problem=problem,
+        temp_sol=TemporarySolution(
+            task_variables={
+                "task-1": TaskVariable(
+                    start=3,
+                    end=6,
+                    mode=1,
+                ),
+                "task-2": TaskVariable(
+                    start=6,
+                    end=10,
+                    mode=0,
+                ),
+            }
+        ),
+    )
+    problem.satisfy(sol)
+    d = problem.evaluate(sol)
+    assert d["makespan"] == 10
+    assert d["nb_tasks_done"] == 0
+    assert d["nb_allocated"] == 0
+
+    # nok: worker not available
+    sol = MySolution(
+        problem=problem,
+        temp_sol=TemporarySolution(
+            task_variables={
+                "task-1": TaskVariable(start=3, end=6, mode=1, allocated=["worker1"]),
+                "task-2": TaskVariable(start=6, end=10, mode=0, allocated=["worker1"]),
+            }
+        ),
+    )
+    with caplog.at_level(level=logging.DEBUG):
+        assert not problem.satisfy(sol)
+    assert "worker1" in caplog.text
+
+    # nok: cumulative resource not available
+    sol = MySolution(
+        problem=problem,
+        temp_sol=TemporarySolution(
+            task_variables={
+                "task-1": TaskVariable(start=1, end=4, mode=1, allocated=["worker1"]),
+                "task-2": TaskVariable(start=4, end=8, mode=0, allocated=["worker2"]),
+            }
+        ),
+    )
+    with caplog.at_level(level=logging.DEBUG):
+        assert not problem.satisfy(sol)
+    assert "cumulative_resource" in caplog.text
+
+    # nok: duration not correct
+    sol = MySolution(
+        problem=problem,
+        temp_sol=TemporarySolution(
+            task_variables={
+                "task-1": TaskVariable(start=1, end=2, mode=1, allocated=["worker1"]),
+                "task-2": TaskVariable(start=5, end=9, mode=0, allocated=["worker2"]),
+            }
+        ),
+    )
+    with caplog.at_level(level=logging.DEBUG):
+        assert not problem.satisfy(sol)
+    assert "Duration" in caplog.text
+
+    # lower cumulative_resource requirement => better sol
+    problem.mode_details = copy.deepcopy(problem.mode_details)
+    problem.mode_details["task-2"][0]["cumulative_resource"] = 1
+    sol = MySolution(
+        problem=problem,
+        temp_sol=TemporarySolution(
+            task_variables={
+                "task-1": TaskVariable(start=1, end=4, mode=1, allocated=["worker1"]),
+                "task-2": TaskVariable(start=4, end=8, mode=0, allocated=["worker2"]),
+            }
+        ),
+    )
+    assert problem.satisfy(sol)
+
+
+@pytest.mark.parametrize("objective", Objective)
+def test_auto(objective):
+    problem = MyProblem()
+
+    # prepare solver
+    solver = MyAutoCpsatSolver(problem=problem)
+    solver.objective = objective
+    if objective in [
+        Objective.NB_UNARY_RESOURCES_USED,
+        Objective.NB_RESOURCES_USED,
+        Objective.RESOURCES_CONSUMPTION,
+    ]:
+        solver.exactly_one_unary_resource_per_task = True
+    solver.init_model()
+    if objective == Objective.CUSTOM:
+        objective_var = (
+            solver.get_global_makespan_variable() - solver.get_nb_tasks_done_variable()
+        )
+        solver.cp_model.minimize(objective_var)
+
+    # solve
+    res = solver.solve()
+
+    # check sol and kpis
+    sol: MySolution
+    sol, fit = res[-1]
+    assert problem.satisfy(sol)
+    kpi = problem.evaluate(sol)
+    print(kpi)
+    print(sol.temp_sol.task_variables)
+
+    if objective == Objective.NB_UNARY_RESOURCES_USED:
+        assert kpi["nb_allocated"] == 1
+    elif objective == Objective.NB_RESOURCES_USED:
+        assert kpi["nb_resources_used"] == 3
+    elif objective == Objective.MAKESPAN:
+        assert kpi["makespan"] == 9
+    elif objective == Objective.NB_TASKS_DONE:
+        assert kpi["nb_tasks_done"] == 2
+    elif objective == Objective.CUSTOM:
+        assert kpi["nb_tasks_done"] == 2
+        assert kpi["makespan"] == 9
+        assert kpi["nb_allocated"] == 2
+
+    # check warm start from a "bad" solution
+    bad_sol = MySolution(
+        problem=problem,
+        temp_sol=TemporarySolution(
+            task_variables={
+                "task-1": TaskVariable(start=1, end=4, mode=1, allocated=["worker1"]),
+                "task-2": TaskVariable(start=6, end=10, mode=0, allocated=["worker2"]),
+            }
+        ),
+    )
+    problem.satisfy(bad_sol)
+
+    # warm start + 1 sol only => should find the "bad" solution
+    solver.set_warm_start(solution=bad_sol)
+    res = solver.solve(
+        ortools_cpsat_solver_kwargs=dict(fix_variables_to_their_hinted_value=True),
+        parameters_cp=ParametersCp.default(),
+        callbacks=[NbIterationStopper(1)],
+    )
+    sol, fit = res[0]
+    assert sol.temp_sol.task_variables == bad_sol.temp_sol.task_variables

--- a/tests/generic_tasks_tools/test_cumulative_resource.py
+++ b/tests/generic_tasks_tools/test_cumulative_resource.py
@@ -4,12 +4,12 @@
 
 import pytest
 
+from discrete_optimization.generic_tasks_tools.calendar_resource import (
+    convert_calendar_to_availability_intervals,
+)
 from discrete_optimization.generic_tasks_tools.cumulative_resource import (
     CumulativeResourceProblem,
     CumulativeResourceSolution,
-)
-from discrete_optimization.generic_tasks_tools.renewable_resource import (
-    convert_calendar_to_availability_intervals,
 )
 from discrete_optimization.generic_tools.do_problem import ObjectiveRegister, Solution
 from discrete_optimization.generic_tools.encoding_register import EncodingRegister
@@ -57,7 +57,7 @@ class MyCumulativeResourceProblem(
 
     @property
     def cumulative_resources_list(self) -> list[CumulativeResource]:
-        return self.renewable_resources_list
+        return self.calendar_resources_list
 
     def get_task_mode_duration(self, task: Task, mode: int) -> int:
         return self.mode_details[task][mode]["duration"]
@@ -71,14 +71,14 @@ class MyCumulativeResourceProblem(
         return self.resource_availabilities[resource]
 
     @property
-    def renewable_resources_list(self) -> list[Resource]:
+    def calendar_resources_list(self) -> list[Resource]:
         return list(self.resource_availabilities)
 
     @property
     def tasks_list(self) -> list[Task]:
         return list(self.mode_details)
 
-    def get_renewable_resource_consumption(
+    def get_cumulative_resource_consumption(
         self, resource: CumulativeResource, task: Task, mode: int
     ) -> int:
         try:
@@ -148,7 +148,7 @@ class MyCumulativeResourceSolution(
 
 def test_cumulative_resource_problem():
     pb = MyCumulativeResourceProblem()
-    for resource in pb.renewable_resources_list:
+    for resource in pb.calendar_resources_list:
         assert pb.get_resource_max_capacity(resource) == pb.max_capacities[resource]
         expected_result = pb.consolidated_availabilities[resource]
         assert pb.get_resource_consolidated_availabilities(resource) == expected_result
@@ -158,7 +158,7 @@ def test_cumulative_resource_problem():
 
 def test_cumulative_resource_problem_ko():
     pb = MyKOCumulativeResourceProblem()
-    for resource in pb.renewable_resources_list:
+    for resource in pb.calendar_resources_list:
         with pytest.raises(ValueError):
             pb.get_resource_consolidated_availabilities(resource)
         with pytest.raises(ValueError):
@@ -174,34 +174,34 @@ def test_cumulative_resource_solution():
         modes={"task-1": 0, "task-2": 0},
         starts={"task-1": 0, "task-2": 0},
     )
-    assert solution.check_renewable_resource_capacity_constraint("R1")
-    assert not solution.check_renewable_resource_capacity_constraint("R5")
-    assert not solution.check_all_renewable_resource_capacity_constraints()
+    assert solution.check_calendar_resource_capacity_constraint("R1")
+    assert not solution.check_calendar_resource_capacity_constraint("R5")
+    assert not solution.check_all_calendar_resource_capacity_constraints()
     solution = MyCumulativeResourceSolution(
         problem=pb,
         modes={"task-1": 1, "task-2": 0},
         starts={"task-1": 2, "task-2": 3},
     )
-    assert not solution.check_all_renewable_resource_capacity_constraints()
+    assert not solution.check_all_calendar_resource_capacity_constraints()
     # ok
     solution = MyCumulativeResourceSolution(
         problem=pb,
         modes={"task-1": 0, "task-2": 0},
         starts={"task-1": 1, "task-2": 2},
     )
-    assert solution.check_all_renewable_resource_capacity_constraints()
+    assert solution.check_all_calendar_resource_capacity_constraints()
     solution = MyCumulativeResourceSolution(
         problem=pb,
         modes={"task-1": 1, "task-2": 0},
         starts={"task-1": 1, "task-2": 1},
     )
-    assert solution.check_all_renewable_resource_capacity_constraints()
+    assert solution.check_all_calendar_resource_capacity_constraints()
     solution = MyCumulativeResourceSolution(
         problem=pb,
         modes={"task-1": 1, "task-2": 0},
         starts={"task-1": 1, "task-2": 3},
     )
-    assert solution.check_all_renewable_resource_capacity_constraints()
+    assert solution.check_all_calendar_resource_capacity_constraints()
 
 
 def test_convert_calendar_to_availability_intervals():

--- a/tests/generic_tasks_tools/test_cumulative_resource.py
+++ b/tests/generic_tasks_tools/test_cumulative_resource.py
@@ -14,11 +14,15 @@ from discrete_optimization.generic_tasks_tools.renewable_resource import (
 from discrete_optimization.generic_tools.do_problem import ObjectiveRegister, Solution
 from discrete_optimization.generic_tools.encoding_register import EncodingRegister
 
-Resource = str
+CumulativeResource = str
+OtherRenewableResource = CumulativeResource
+Resource = CumulativeResource
 Task = str
 
 
-class MyCumulativeResourceProblem(CumulativeResourceProblem[Task, Resource]):
+class MyCumulativeResourceProblem(
+    CumulativeResourceProblem[Task, CumulativeResource, OtherRenewableResource]
+):
     resource_availabilities = dict(
         R1=[
             (5, 7, 4),
@@ -51,8 +55,9 @@ class MyCumulativeResourceProblem(CumulativeResourceProblem[Task, Resource]):
         },
     }
 
-    def is_cumulative_resource(self, resource: Resource) -> bool:
-        return True
+    @property
+    def cumulative_resources_list(self) -> list[CumulativeResource]:
+        return self.renewable_resources_list
 
     def get_task_mode_duration(self, task: Task, mode: int) -> int:
         return self.mode_details[task][mode]["duration"]
@@ -74,7 +79,7 @@ class MyCumulativeResourceProblem(CumulativeResourceProblem[Task, Resource]):
         return list(self.mode_details)
 
     def get_renewable_resource_consumption(
-        self, resource: Resource, task: Task, mode: int
+        self, resource: CumulativeResource, task: Task, mode: int
     ) -> int:
         try:
             return self.mode_details[task][mode][resource]
@@ -110,7 +115,9 @@ class MyKOCumulativeResourceProblem(MyCumulativeResourceProblem):
     resource_availabilities = dict(R4=[(5, 7, 4), (2, 3, 1), (0, 3, 0)])
 
 
-class MyCumulativeResourceSolution(CumulativeResourceSolution[Task, Resource]):
+class MyCumulativeResourceSolution(
+    CumulativeResourceSolution[Task, CumulativeResource, OtherRenewableResource]
+):
     problem: MyCumulativeResourceProblem
 
     def __init__(

--- a/tests/generic_tasks_tools/test_renewable_resource.py
+++ b/tests/generic_tasks_tools/test_renewable_resource.py
@@ -2,7 +2,7 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
-from discrete_optimization.generic_tasks_tools.renewable_resource import (
+from discrete_optimization.generic_tasks_tools.calendar_resource import (
     convert_availability_intervals_to_calendar,
     convert_calendar_to_availability_intervals,
     merge_resources_availability_intervals,

--- a/tests/jsp/solvers/test_cpsat_auto.py
+++ b/tests/jsp/solvers/test_cpsat_auto.py
@@ -1,0 +1,140 @@
+#  Copyright (c) 2024-2025 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+import random
+
+import numpy as np
+import pytest
+
+from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
+from discrete_optimization.generic_tools.callbacks.early_stoppers import (
+    NbIterationStopper,
+)
+from discrete_optimization.generic_tools.cp_tools import ParametersCp, SignEnum
+from discrete_optimization.jsp.parser import get_data_available, parse_file
+from discrete_optimization.jsp.problem import JobShopProblem, JobShopSolution
+from discrete_optimization.jsp.solvers.cpsat_auto import CpSatAutoJspSolver
+
+
+@pytest.fixture
+def random_seed():
+    random.seed(0)
+    np.random.seed(0)
+
+
+@pytest.fixture()
+def problem() -> JobShopProblem:
+    filename = "la02"
+    filepath = [f for f in get_data_available() if f.endswith(filename)][0]
+    return parse_file(filepath)
+
+
+def test_cpsat_jsp(random_seed, problem):
+    solver = CpSatAutoJspSolver(problem=problem)
+    parameters_cp = ParametersCp.default()
+    sol: JobShopSolution = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+        parameters_cp=parameters_cp,
+    ).get_best_solution()
+    print(sol.schedule)
+    assert problem.satisfy(sol)
+
+    # test prob.task_lists and sol.get_start_stime/end_time
+    assert len(problem.tasks_list) == problem.n_all_jobs
+    for task in problem.tasks_list:
+        print(sol.get_start_time(task), sol.get_end_time(task))
+
+    # test subojectives
+
+    # max end time subtasks
+    subtasks = {(0, 1), (1, 2)}
+    objective = solver.get_subtasks_makespan_variable(subtasks)
+    solver.minimize_variable(objective)
+    sol, _ = solver.solve(callbacks=[NbIterationStopper(nb_iteration_max=1)])[-1]
+    solver.solver.ObjectiveValue() == max(sol.get_end_time(task) for task in subtasks)
+    # sum end time subtasks
+    subtasks = {(0, 1), (1, 2)}
+    objective = solver.get_subtasks_sum_end_time_variable(subtasks)
+    solver.minimize_variable(objective)
+    sol, _ = solver.solve(callbacks=[NbIterationStopper(nb_iteration_max=1)])[-1]
+    solver.solver.ObjectiveValue() == sum(sol.get_end_time(task) for task in subtasks)
+    # sum start time subtasks
+    subtasks = {(0, 1), (1, 2)}
+    objective = solver.get_subtasks_sum_start_time_variable(subtasks)
+    solver.minimize_variable(objective)
+    sol, _ = solver.solve(callbacks=[NbIterationStopper(nb_iteration_max=1)])[-1]
+    solver.solver.ObjectiveValue() == sum(sol.get_start_time(task) for task in subtasks)
+    # max end time
+    objective = solver.get_global_makespan_variable()
+    solver.minimize_variable(objective)
+    sol, _ = solver.solve(callbacks=[NbIterationStopper(nb_iteration_max=1)])[-1]
+    solver.solver.ObjectiveValue() == sol.get_max_end_time()
+
+
+@pytest.mark.parametrize(
+    "task, start_or_end, sign , time",
+    [
+        ((0, 1), StartOrEnd.START, SignEnum.UEQ, 120),
+        ((0, 1), StartOrEnd.START, SignEnum.UP, 120),
+        ((0, 2), StartOrEnd.START, SignEnum.LEQ, 120),
+        ((0, 2), StartOrEnd.START, SignEnum.LESS, 120),
+        ((0, 2), StartOrEnd.START, SignEnum.EQUAL, 120),
+        ((0, 0), StartOrEnd.END, SignEnum.UEQ, 120),
+    ],
+)
+def test_task_constraint(problem, task, start_or_end, sign, time, random_seed):
+    solver = CpSatAutoJspSolver(problem=problem)
+    parameters_cp = ParametersCp.default()
+    sol: JobShopSolution = solver.solve(
+        parameters_cp=parameters_cp, callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+
+    # before adding the constraint, not already satisfied
+    assert not sol.constraint_on_task_satisfied(
+        task=task, start_or_end=start_or_end, sign=sign, time=time
+    )
+    # add constraint: should be now satisfied
+    cstrs = solver.add_constraint_on_task(
+        task=task, start_or_end=start_or_end, sign=sign, time=time
+    )
+    sol = solver.solve(
+        parameters_cp=parameters_cp,
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+        time_limit=1000,
+    ).get_best_solution()
+    assert sol.constraint_on_task_satisfied(
+        task=task, start_or_end=start_or_end, sign=sign, time=time
+    )
+    # check constraints can be effectively removed
+    solver.remove_constraints(cstrs)
+    sol = solver.solve(
+        parameters_cp=parameters_cp, callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+    assert not sol.constraint_on_task_satisfied(
+        task=task, start_or_end=start_or_end, sign=sign, time=time
+    )
+
+
+def test_chaining_tasks_constraint(problem, random_seed):
+    solver = CpSatAutoJspSolver(problem=problem)
+    parameters_cp = ParametersCp.default()
+    task1 = (0, 0)
+    task2 = (1, 4)
+
+    # before adding the constraint, not already satisfied
+    sol: JobShopSolution = solver.solve(
+        parameters_cp=parameters_cp, callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+    assert not sol.constraint_chaining_tasks_satisfied(task1=task1, task2=task2)
+    # add constraint
+    cstrs = solver.add_constraint_chaining_tasks(task1=task1, task2=task2)
+    sol = solver.solve(
+        parameters_cp=parameters_cp, callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+    assert sol.constraint_chaining_tasks_satisfied(task1=task1, task2=task2)
+    # remove constraint
+    solver.remove_constraints(cstrs)
+    sol = solver.solve(
+        parameters_cp=parameters_cp, callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+    assert not sol.constraint_chaining_tasks_satisfied(task1=task1, task2=task2)

--- a/tests/rcpsp/solvers/test_cpsat.py
+++ b/tests/rcpsp/solvers/test_cpsat.py
@@ -61,7 +61,7 @@ def test_ortools(model):
     fit_2 = rcpsp_problem.evaluate(solution_rebuilt)
     assert fit == -fit_2["makespan"]
     assert rcpsp_problem.satisfy(solution)
-    assert solution.check_all_renewable_resource_capacity_constraints()
+    assert solution.check_all_calendar_resource_capacity_constraints()
     rcpsp_problem.plot_ressource_view(solution)
     plot_task_gantt(rcpsp_problem, solution)
 
@@ -264,7 +264,7 @@ def test_ortools_with_calendar_resource(model):
     fit_2 = rcpsp_problem.evaluate(solution_rebuilt)
     assert fit == -fit_2["makespan"]
     assert rcpsp_problem.satisfy(solution)
-    assert solution.check_all_renewable_resource_capacity_constraints()
+    assert solution.check_all_calendar_resource_capacity_constraints()
 
     rcpsp_problem.plot_ressource_view(solution)
     plot_task_gantt(rcpsp_problem, solution)
@@ -301,7 +301,7 @@ def test_ortools_cumulativeresource_optim(model):
     result_storage = solver.solve(time_limit=50)
     solution, fit = result_storage.get_best_solution_fit()
     assert rcpsp_problem.satisfy(solution)
-    assert solution.check_all_renewable_resource_capacity_constraints()
+    assert solution.check_all_calendar_resource_capacity_constraints()
 
 
 @pytest.mark.parametrize(
@@ -316,7 +316,7 @@ def test_ortools_resource_optim(model):
     result_storage = solver.solve(time_limit=50)
     solution, fit = result_storage.get_best_solution_fit()
     assert rcpsp_problem.satisfy(solution)
-    assert solution.check_all_renewable_resource_capacity_constraints()
+    assert solution.check_all_calendar_resource_capacity_constraints()
 
 
 def test_ortools_with_cb(caplog, random_seed):

--- a/tests/rcpsp/solvers/test_cpsat_auto.py
+++ b/tests/rcpsp/solvers/test_cpsat_auto.py
@@ -61,7 +61,7 @@ def test_ortools(model):
     fit_2 = rcpsp_problem.evaluate(solution_rebuilt)
     assert fit == -fit_2["makespan"]
     assert rcpsp_problem.satisfy(solution)
-    assert solution.check_all_renewable_resource_capacity_constraints()
+    assert solution.check_all_calendar_resource_capacity_constraints()
     rcpsp_problem.plot_ressource_view(solution)
     plot_task_gantt(rcpsp_problem, solution)
 
@@ -264,7 +264,7 @@ def test_ortools_with_calendar_resource(model):
     fit_2 = rcpsp_problem.evaluate(solution_rebuilt)
     assert fit == -fit_2["makespan"]
     assert rcpsp_problem.satisfy(solution)
-    assert solution.check_all_renewable_resource_capacity_constraints()
+    assert solution.check_all_calendar_resource_capacity_constraints()
 
     rcpsp_problem.plot_ressource_view(solution)
     plot_task_gantt(rcpsp_problem, solution)
@@ -301,7 +301,7 @@ def test_ortools_cumulativeresource_optim(model):
     result_storage = solver.solve(time_limit=50)
     solution, fit = result_storage.get_best_solution_fit()
     assert rcpsp_problem.satisfy(solution)
-    assert solution.check_all_renewable_resource_capacity_constraints()
+    assert solution.check_all_calendar_resource_capacity_constraints()
 
 
 @pytest.mark.parametrize(
@@ -316,7 +316,7 @@ def test_ortools_resource_optim(model):
     result_storage = solver.solve(time_limit=50)
     solution, fit = result_storage.get_best_solution_fit()
     assert rcpsp_problem.satisfy(solution)
-    assert solution.check_all_renewable_resource_capacity_constraints()
+    assert solution.check_all_calendar_resource_capacity_constraints()
 
 
 def test_ortools_with_cb(caplog, random_seed):

--- a/tests/rcpsp/solvers/test_cpsat_auto.py
+++ b/tests/rcpsp/solvers/test_cpsat_auto.py
@@ -1,0 +1,625 @@
+#  Copyright (c) 2025 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+
+import logging
+import random
+
+import numpy as np
+import pytest
+
+from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
+from discrete_optimization.generic_tools.callbacks.callback import Callback
+from discrete_optimization.generic_tools.callbacks.early_stoppers import (
+    NbIterationStopper,
+)
+from discrete_optimization.generic_tools.cp_tools import SignEnum
+from discrete_optimization.generic_tools.result_storage.result_storage import (
+    ResultStorage,
+)
+from discrete_optimization.rcpsp.parser import get_data_available, parse_file
+from discrete_optimization.rcpsp.problem import RcpspProblem
+from discrete_optimization.rcpsp.solution import RcpspSolution
+from discrete_optimization.rcpsp.solvers.cpsat_auto import (
+    CpSatAutoCumulativeResourceRcpspSolver,
+    CpSatAutoRcpspSolver,
+    CpSatAutoResourceRcpspSolver,
+)
+from discrete_optimization.rcpsp.solvers.pile import (
+    PileCalendarRcpspSolver,
+    PileRcpspSolver,
+)
+from discrete_optimization.rcpsp.special_constraints import (
+    SpecialConstraintsDescription,
+)
+from discrete_optimization.rcpsp.utils import plot_task_gantt
+
+
+@pytest.fixture
+def random_seed():
+    random.seed(0)
+    np.random.seed(0)
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["j301_1.sm", "j1010_1.mm"],
+)
+def test_ortools(model):
+    files_available = get_data_available()
+    file = [f for f in files_available if model in f][0]
+    rcpsp_problem = parse_file(file)
+    solver = CpSatAutoRcpspSolver(problem=rcpsp_problem)
+    result_storage = solver.solve(time_limit=100)
+    solution: RcpspSolution
+    solution, fit = result_storage.get_best_solution_fit()
+    solution_rebuilt = RcpspSolution(
+        problem=rcpsp_problem,
+        rcpsp_permutation=solution.rcpsp_permutation,
+        rcpsp_modes=solution.rcpsp_modes,
+    )
+    fit_2 = rcpsp_problem.evaluate(solution_rebuilt)
+    assert fit == -fit_2["makespan"]
+    assert rcpsp_problem.satisfy(solution)
+    assert solution.check_all_renewable_resource_capacity_constraints()
+    rcpsp_problem.plot_ressource_view(solution)
+    plot_task_gantt(rcpsp_problem, solution)
+
+    # test warm start
+    start_solution = (
+        PileRcpspSolver(problem=rcpsp_problem).solve().get_best_solution_fit()[0]
+    )
+
+    # first solution is not start_solution
+    assert result_storage[0][0].rcpsp_schedule != start_solution.rcpsp_schedule
+
+    # warm start at first solution
+    solver.set_warm_start(start_solution)
+    # force first solution to be the hinted one
+    result_storage = solver.solve(
+        time_limit=100,
+        ortools_cpsat_solver_kwargs=dict(fix_variables_to_their_hinted_value=True),
+    )
+    assert result_storage[0][0].rcpsp_schedule == start_solution.rcpsp_schedule
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["j301_1.sm", "j1010_1.mm"],
+)
+def test_objectives(model):
+    files_available = get_data_available()
+    file = [f for f in files_available if model in f][0]
+    rcpsp_problem = parse_file(file)
+    solver = CpSatAutoRcpspSolver(problem=rcpsp_problem)
+    solver.init_model()
+
+    subtasks = {1, 4}
+    # max end time subtasks
+    objective = solver.get_subtasks_makespan_variable(subtasks)
+    solver.minimize_variable(objective)
+    sol, _ = solver.solve(callbacks=[NbIterationStopper(nb_iteration_max=1)])[-1]
+    solver.solver.ObjectiveValue() == max(sol.get_end_time(task) for task in subtasks)
+    # sum end time subtasks
+    objective = solver.get_subtasks_sum_end_time_variable(subtasks)
+    solver.minimize_variable(objective)
+    sol, _ = solver.solve(callbacks=[NbIterationStopper(nb_iteration_max=1)])[-1]
+    solver.solver.ObjectiveValue() == sum(sol.get_end_time(task) for task in subtasks)
+    # sum start time subtasks
+    objective = solver.get_subtasks_sum_start_time_variable(subtasks)
+    solver.minimize_variable(objective)
+    sol, _ = solver.solve(callbacks=[NbIterationStopper(nb_iteration_max=1)])[-1]
+    solver.solver.ObjectiveValue() == sum(sol.get_start_time(task) for task in subtasks)
+    # max end time
+    objective = solver.get_global_makespan_variable()
+    solver.minimize_variable(objective)
+    sol, _ = solver.solve(callbacks=[NbIterationStopper(nb_iteration_max=1)])[-1]
+    solver.solver.ObjectiveValue() == sol.get_max_end_time()
+
+
+def test_mode_constraint_monomode():
+    model = "j301_1.sm"
+    files_available = get_data_available()
+    file = [f for f in files_available if model in f][0]
+    problem = parse_file(file)
+    assert not problem.is_multimode
+
+    solver = CpSatAutoRcpspSolver(problem=problem)
+
+    task = 2
+    mode = 1
+    solver.init_model()
+    solver.add_constraint_on_task_mode(task, mode)
+    sol: RcpspSolution = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+    assert sol.get_mode(task) == mode
+
+    with pytest.raises(ValueError):
+        solver.add_constraint_on_task_mode(task, 0)
+
+
+def test_mode_constraint_multimode(random_seed):
+    model = "j1010_1.mm"
+    files_available = get_data_available()
+    file = [f for f in files_available if model in f][0]
+    problem = parse_file(file)
+    assert problem.is_multimode
+
+    solver = CpSatAutoRcpspSolver(problem=problem)
+    solver.init_model()
+
+    task = 2
+    print(problem.mode_details[task])
+
+    mode = 1
+    constraints = solver.add_constraint_on_task_mode(task, mode)
+    sol = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+    assert sol.get_mode(task) == mode
+
+    solver.remove_constraints(constraints)
+    mode = 3
+    constraints = solver.add_constraint_on_task_mode(task, mode)
+    sol = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+    assert sol.get_mode(task) == mode
+
+    mode_nok = 15
+    with pytest.raises(ValueError):
+        solver.add_constraint_on_task_mode(task, mode_nok)
+
+
+@pytest.mark.parametrize(
+    "task, start_or_end, sign , time",
+    [
+        (2, StartOrEnd.START, SignEnum.UEQ, 6),
+    ],
+)
+def test_task_constraint(task, start_or_end, sign, time):
+    model = "j301_1.sm"
+    files_available = get_data_available()
+    file = [f for f in files_available if model in f][0]
+    problem = parse_file(file)
+    solver = CpSatAutoRcpspSolver(problem=problem)
+    sol: RcpspSolution = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+
+    # before adding the constraint, not already satisfied
+    assert not sol.constraint_on_task_satisfied(
+        task=task, start_or_end=start_or_end, sign=sign, time=time
+    )
+    # add constraint: should be now satisfied
+    cstrs = solver.add_constraint_on_task(
+        task=task, start_or_end=start_or_end, sign=sign, time=time
+    )
+    sol = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+    assert sol.constraint_on_task_satisfied(
+        task=task, start_or_end=start_or_end, sign=sign, time=time
+    )
+    # check constraints can be effectively removed
+    solver.remove_constraints(cstrs)
+    sol = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+    assert not sol.constraint_on_task_satisfied(
+        task=task, start_or_end=start_or_end, sign=sign, time=time
+    )
+
+
+def test_chaining_constraints():
+    task1 = 4
+    task2 = 2
+    model = "j301_1.sm"
+    files_available = get_data_available()
+    file = [f for f in files_available if model in f][0]
+    rcpsp_problem = parse_file(file)
+    solver = CpSatAutoRcpspSolver(problem=rcpsp_problem)
+    sol: RcpspSolution = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+    assert not sol.constraint_chaining_tasks_satisfied(task1=task1, task2=task2)
+    # add constraint
+    cstrs = solver.add_constraint_chaining_tasks(task1=task1, task2=task2)
+    sol = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+    assert sol.constraint_chaining_tasks_satisfied(task1=task1, task2=task2)
+    # remove constraint
+    solver.remove_constraints(cstrs)
+    sol = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+    assert not sol.constraint_chaining_tasks_satisfied(task1=task1, task2=task2)
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["j301_1.sm", "j1010_1.mm"],
+)
+def test_ortools_with_calendar_resource(model):
+    files_available = get_data_available()
+    file = [f for f in files_available if model in f][0]
+    rcpsp_problem = parse_file(file)
+    for resource in rcpsp_problem.resources:
+        rcpsp_problem.resources[resource] = np.array(
+            rcpsp_problem.get_resource_availability_array(resource)
+        )
+        rcpsp_problem.resources[resource][10:15] = 0
+    rcpsp_problem.update_problem()
+    assert rcpsp_problem.is_calendar
+    solver = CpSatAutoRcpspSolver(problem=rcpsp_problem)
+    result_storage = solver.solve(time_limit=100)
+    solution, fit = result_storage.get_best_solution_fit()
+    solution_rebuilt = RcpspSolution(
+        problem=rcpsp_problem,
+        rcpsp_permutation=solution.rcpsp_permutation,
+        rcpsp_modes=solution.rcpsp_modes,
+    )
+    fit_2 = rcpsp_problem.evaluate(solution_rebuilt)
+    assert fit == -fit_2["makespan"]
+    assert rcpsp_problem.satisfy(solution)
+    assert solution.check_all_renewable_resource_capacity_constraints()
+
+    rcpsp_problem.plot_ressource_view(solution)
+    plot_task_gantt(rcpsp_problem, solution)
+
+    # test warm start
+    start_solution = (
+        PileCalendarRcpspSolver(problem=rcpsp_problem)
+        .solve()
+        .get_best_solution_fit()[0]
+    )
+
+    # first solution is not start_solution
+    assert result_storage[0][0].rcpsp_schedule != start_solution.rcpsp_schedule
+
+    # warm start at first solution
+    solver.set_warm_start(start_solution)
+    # force first solution to be the hinted one
+    result_storage = solver.solve(
+        time_limit=100,
+        ortools_cpsat_solver_kwargs=dict(fix_variables_to_their_hinted_value=True),
+    )
+    assert result_storage[0][0].rcpsp_schedule == start_solution.rcpsp_schedule
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["j301_1.sm", "j1010_1.mm"],
+)
+def test_ortools_cumulativeresource_optim(model):
+    files_available = get_data_available()
+    file = [f for f in files_available if model in f][0]
+    rcpsp_problem = parse_file(file)
+    solver = CpSatAutoCumulativeResourceRcpspSolver(problem=rcpsp_problem)
+    result_storage = solver.solve(time_limit=50)
+    solution, fit = result_storage.get_best_solution_fit()
+    assert rcpsp_problem.satisfy(solution)
+    assert solution.check_all_renewable_resource_capacity_constraints()
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["j301_1.sm", "j1010_1.mm"],
+)
+def test_ortools_resource_optim(model):
+    files_available = get_data_available()
+    file = [f for f in files_available if model in f][0]
+    rcpsp_problem = parse_file(file)
+    solver = CpSatAutoResourceRcpspSolver(problem=rcpsp_problem)
+    result_storage = solver.solve(time_limit=50)
+    solution, fit = result_storage.get_best_solution_fit()
+    assert rcpsp_problem.satisfy(solution)
+    assert solution.check_all_renewable_resource_capacity_constraints()
+
+
+def test_ortools_with_cb(caplog, random_seed):
+    model = "j1201_1.sm"
+    files_available = get_data_available()
+    file = [f for f in files_available if model in f][0]
+    rcpsp_problem = parse_file(file)
+    solver = CpSatAutoRcpspSolver(problem=rcpsp_problem)
+
+    class VariablePrinterCallback(Callback):
+        def __init__(self) -> None:
+            super().__init__()
+            self.nb_solution = 0
+
+        def on_step_end(
+            self, step: int, res: ResultStorage, solver: CpSatAutoRcpspSolver
+        ):
+            self.nb_solution += 1
+            sol: RcpspSolution
+            sol, fit = res.list_solution_fits[-1]
+            logging.debug(f"Solution #{self.nb_solution}:")
+            logging.debug(sol.rcpsp_schedule)
+            logging.debug(sol.rcpsp_modes)
+
+    callbacks = [VariablePrinterCallback(), NbIterationStopper(1)]
+
+    with caplog.at_level(logging.DEBUG):
+        result_storage = solver.solve(callbacks=callbacks, time_limit=20)
+
+    assert "Solution #1" in caplog.text
+    assert (
+        "stopped by user callback" in caplog.text
+    )  # stopped by callback instead of ortools timer
+    # only true if at least one solution found before 20s (ortools timer limit)
+
+
+def test_special_constraints():
+    """Test that special constraints are correctly enforced by CP-SAT solver."""
+    mode_details = {
+        1: {1: {"duration": 0}},  # dummy start
+        2: {1: {"duration": 3, "R1": 1}},
+        3: {1: {"duration": 2, "R1": 1}},
+        4: {1: {"duration": 4, "R1": 1}},
+        5: {1: {"duration": 0}},  # dummy end
+    }
+
+    successors = {
+        1: [2, 3],
+        2: [5],
+        3: [4],
+        4: [5],
+        5: [],
+    }
+
+    resources = {"R1": 2}
+
+    # Test 1: start_together constraint
+    special_constraints_1 = SpecialConstraintsDescription(
+        start_together=[(2, 3)],  # tasks 2 and 3 start together
+    )
+
+    problem_1 = RcpspProblem(
+        resources=resources,
+        non_renewable_resources=[],
+        mode_details=mode_details,
+        successors=successors,
+        horizon=100,
+        special_constraints=special_constraints_1,
+    )
+
+    solver_1 = CpSatAutoRcpspSolver(problem=problem_1)
+    result_1 = solver_1.solve(time_limit=10)
+    solution_1 = result_1.get_best_solution()
+
+    assert solution_1 is not None, "Solver should find a solution"
+    assert solution_1.get_start_time(2) == solution_1.get_start_time(3), (
+        f"start_together constraint not satisfied: "
+        f"task 2 starts at {solution_1.get_start_time(2)}, "
+        f"task 3 starts at {solution_1.get_start_time(3)}"
+    )
+    assert problem_1.satisfy(solution_1), "Solution should satisfy all constraints"
+
+    # Test 2: start_at_end constraint
+    special_constraints_2 = SpecialConstraintsDescription(
+        start_at_end=[(3, 4)],  # task 4 starts when task 3 ends
+    )
+
+    problem_2 = RcpspProblem(
+        resources=resources,
+        non_renewable_resources=[],
+        mode_details=mode_details,
+        successors=successors,
+        horizon=100,
+        special_constraints=special_constraints_2,
+    )
+
+    solver_2 = CpSatAutoRcpspSolver(problem=problem_2)
+    result_2 = solver_2.solve(time_limit=10)
+    solution_2 = result_2.get_best_solution()
+
+    assert solution_2 is not None, "Solver should find a solution"
+    assert solution_2.get_end_time(3) == solution_2.get_start_time(4), (
+        f"start_at_end constraint not satisfied: "
+        f"task 3 ends at {solution_2.get_end_time(3)}, "
+        f"task 4 starts at {solution_2.get_start_time(4)}"
+    )
+    assert problem_2.satisfy(solution_2), "Solution should satisfy all constraints"
+
+    # Test 3: start_times_window constraint
+    special_constraints_3 = SpecialConstraintsDescription(
+        start_times_window={2: (5, 10)},  # task 2 must start between 5 and 10
+    )
+
+    problem_3 = RcpspProblem(
+        resources=resources,
+        non_renewable_resources=[],
+        mode_details=mode_details,
+        successors=successors,
+        horizon=100,
+        special_constraints=special_constraints_3,
+    )
+
+    solver_3 = CpSatAutoRcpspSolver(problem=problem_3)
+    result_3 = solver_3.solve(time_limit=10)
+    solution_3 = result_3.get_best_solution()
+
+    assert solution_3 is not None, "Solver should find a solution"
+    assert 5 <= solution_3.get_start_time(2) <= 10, (
+        f"start_times_window constraint not satisfied: "
+        f"task 2 starts at {solution_3.get_start_time(2)}"
+    )
+    assert problem_3.satisfy(solution_3), "Solution should satisfy all constraints"
+
+    # Test 4: disjunctive_tasks constraint (with parallel successors)
+    successors_4 = {
+        1: [2, 3],
+        2: [5],
+        3: [5],
+        4: [5],
+        5: [],
+    }  # tasks 2 and 3 are parallel
+    special_constraints_4 = SpecialConstraintsDescription(
+        disjunctive_tasks=[(2, 3)],  # tasks 2 and 3 cannot overlap
+    )
+
+    problem_4 = RcpspProblem(
+        resources=resources,
+        non_renewable_resources=[],
+        mode_details=mode_details,
+        successors=successors_4,
+        horizon=100,
+        special_constraints=special_constraints_4,
+    )
+
+    solver_4 = CpSatAutoRcpspSolver(problem=problem_4)
+    result_4 = solver_4.solve(time_limit=10)
+    solution_4 = result_4.get_best_solution()
+
+    assert solution_4 is not None, "Solver should find a solution"
+    task2_end = solution_4.get_end_time(2)
+    task3_start = solution_4.get_start_time(3)
+    task3_end = solution_4.get_end_time(3)
+    task2_start = solution_4.get_start_time(2)
+    no_overlap = (task2_end <= task3_start) or (task3_end <= task2_start)
+    assert no_overlap, (
+        f"disjunctive_tasks constraint not satisfied: "
+        f"task 2 [{task2_start}, {task2_end}], "
+        f"task 3 [{task3_start}, {task3_end}]"
+    )
+    assert problem_4.satisfy(solution_4), "Solution should satisfy all constraints"
+
+
+def test_start_to_start_min_time_lag_negative_offset():
+    """Test start_to_start_min_time_lag constraint with negative offsets in both CP-SAT and SGS."""
+    mode_details = {
+        1: {1: {"duration": 0}},  # dummy start
+        2: {1: {"duration": 5, "R1": 1}},
+        3: {1: {"duration": 3, "R1": 1}},
+        4: {1: {"duration": 2, "R1": 1}},
+        5: {1: {"duration": 0}},  # dummy end
+    }
+
+    successors = {
+        1: [2, 3, 4],
+        2: [5],
+        3: [5],
+        4: [5],
+        5: [],
+    }
+
+    resources = {"R1": 2}
+
+    # Test with negative offset: task 3 must start at least 3 time units BEFORE task 2
+    # Constraint: start(2) + (-3) <= start(3) => start(2) - 3 <= start(3) => start(3) >= start(2) - 3
+    special_constraints = SpecialConstraintsDescription(
+        start_to_start_min_time_lag=[(2, 3, -3)],
+    )
+
+    problem = RcpspProblem(
+        resources=resources,
+        non_renewable_resources=[],
+        mode_details=mode_details,
+        successors=successors,
+        horizon=100,
+        special_constraints=special_constraints,
+    )
+
+    # Test CP-SAT solver
+    solver = CpSatAutoRcpspSolver(problem=problem)
+    result = solver.solve(time_limit=10)
+    solution = result.get_best_solution()
+
+    assert solution is not None, "Solver should find a solution"
+
+    # Verify the constraint: start(2) - 3 <= start(3)
+    start_2 = solution.get_start_time(2)
+    start_3 = solution.get_start_time(3)
+    assert start_2 - 3 <= start_3, (
+        f"start_to_start_min_time_lag constraint not satisfied: "
+        f"start(2)={start_2}, start(3)={start_3}, "
+        f"but start(2) - 3 = {start_2 - 3} > {start_3}"
+    )
+    assert problem.satisfy(solution), "Solution should satisfy all constraints"
+
+    # Test SGS schedule generation
+    # Create a solution with a specific permutation
+    from discrete_optimization.rcpsp.solution import (
+        generate_schedule_from_permutation_serial_sgs_special_constraints,
+    )
+
+    # Try different permutations to test both orderings
+    for permutation in [[0, 1, 2], [1, 0, 2]]:  # task 2 before 3, and task 3 before 2
+        test_solution = RcpspSolution(
+            problem=problem,
+            rcpsp_permutation=permutation,
+            rcpsp_modes=[1, 1, 1],
+        )
+
+        schedule, feasible = (
+            generate_schedule_from_permutation_serial_sgs_special_constraints(
+                test_solution, problem
+            )
+        )
+
+        assert feasible, (
+            f"SGS should generate feasible schedule for permutation {permutation}"
+        )
+
+        # Verify the constraint in the generated schedule
+        sgs_start_2 = schedule[2]["start_time"]
+        sgs_start_3 = schedule[3]["start_time"]
+        assert sgs_start_2 - 3 <= sgs_start_3, (
+            f"SGS violated start_to_start_min_time_lag constraint with permutation {permutation}: "
+            f"start(2)={sgs_start_2}, start(3)={sgs_start_3}, "
+            f"but start(2) - 3 = {sgs_start_2 - 3} > {sgs_start_3}"
+        )
+
+
+def test_start_to_start_min_time_lag_positive_offset():
+    """Test start_to_start_min_time_lag constraint with positive offset to ensure SGS precedence logic works."""
+    mode_details = {
+        1: {1: {"duration": 0}},  # dummy start
+        2: {1: {"duration": 2, "R1": 1}},
+        3: {1: {"duration": 3, "R1": 1}},
+        4: {1: {"duration": 0}},  # dummy end
+    }
+
+    successors = {
+        1: [2, 3],
+        2: [4],
+        3: [4],
+        4: [],
+    }
+
+    resources = {"R1": 1}
+
+    # Test with positive offset: task 3 must start at least 5 units after task 2 starts
+    # Constraint: start(2) + 5 <= start(3)
+    special_constraints = SpecialConstraintsDescription(
+        start_to_start_min_time_lag=[(2, 3, 5)],
+    )
+
+    problem = RcpspProblem(
+        resources=resources,
+        non_renewable_resources=[],
+        mode_details=mode_details,
+        successors=successors,
+        horizon=100,
+        special_constraints=special_constraints,
+    )
+
+    solver = CpSatAutoRcpspSolver(problem=problem)
+    result = solver.solve(time_limit=10)
+    solution = result.get_best_solution()
+
+    assert solution is not None, "Solver should find a solution"
+
+    # Verify the constraint: start(2) + 5 <= start(3)
+    start_2 = solution.get_start_time(2)
+    start_3 = solution.get_start_time(3)
+    assert start_2 + 5 <= start_3, (
+        f"start_to_start_min_time_lag constraint not satisfied: "
+        f"start(2)={start_2}, start(3)={start_3}, "
+        f"but start(2) + 5 = {start_2 + 5} > {start_3}"
+    )
+    assert problem.satisfy(solution), "Solution should satisfy all constraints"

--- a/tests/rcpsp/test_problem.py
+++ b/tests/rcpsp/test_problem.py
@@ -278,7 +278,7 @@ def test_update_problem(small_problem):
     assert len(problem.get_resource_availabilities("R1")) == 9
 
 
-def test_satisfy_renewable_nok(small_problem, caplog):
+def test_satisfy_calendar_nok(small_problem, caplog):
     problem = small_problem
     solution = RcpspSolution(
         problem=problem,

--- a/tests/rcpsp_multiskill/solvers/test_cpsat.py
+++ b/tests/rcpsp_multiskill/solvers/test_cpsat.py
@@ -139,7 +139,7 @@ def test_imopse_cpsat_with_calendar(caplog):
     with caplog.at_level(logging.DEBUG):
         assert not model.satisfy(solution)
 
-    assert "Violations on renewable resource capacities" in caplog.text
+    assert "Violations on calendar resource capacities" in caplog.text
     assert f"resource '{employee}'" in caplog.text
     assert f"at time {start}" in caplog.text
 

--- a/tests/rcpsp_multiskill/solvers/test_cpsat_auto.py
+++ b/tests/rcpsp_multiskill/solvers/test_cpsat_auto.py
@@ -1,0 +1,429 @@
+#  Copyright (c) 2024-2025 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+import logging
+import random
+
+import numpy as np
+import pytest
+
+from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
+from discrete_optimization.generic_tools.callbacks.early_stoppers import (
+    NbIterationStopper,
+)
+from discrete_optimization.generic_tools.cp_tools import ParametersCp, SignEnum
+from discrete_optimization.rcpsp_multiskill.parser_imopse import (
+    get_data_available,
+    parse_file,
+)
+from discrete_optimization.rcpsp_multiskill.problem import MultiskillRcpspSolution
+from discrete_optimization.rcpsp_multiskill.solvers.cpsat_auto import (
+    CpSatAutoMultiskillRcpspSolver,
+)
+
+
+def test_imopse_cpsat():
+    file = [f for f in get_data_available() if "100_5_64_9.def" in f][0]
+    model, _ = parse_file(file, max_horizon=1000)
+    cp_model = CpSatAutoMultiskillRcpspSolver(
+        problem=model,
+    )
+    cp_model.init_model(
+        one_worker_per_task=True,
+    )
+    p = ParametersCp.default_cpsat()
+    res = cp_model.solve(
+        parameters_cp=p, time_limit=20, callbacks=[NbIterationStopper(1)]
+    )
+    solution: MultiskillRcpspSolution = res.get_best_solution_fit()[0]
+    assert model.satisfy(solution)
+
+
+def test_imopse_cpsat_w_non_renewable_n_cumulative_resource():
+    file = [f for f in get_data_available() if "100_5_64_9.def" in f][0]
+    model, _ = parse_file(file, max_horizon=1000)
+
+    cp_model = CpSatAutoMultiskillRcpspSolver(
+        problem=model,
+    )
+    cp_model.init_model(
+        one_worker_per_task=True,
+    )
+    p = ParametersCp.default_cpsat()
+    res = cp_model.solve(
+        parameters_cp=p, time_limit=20, callbacks=[NbIterationStopper(1)]
+    )
+    solution: MultiskillRcpspSolution = res.get_best_solution_fit()[0]
+    assert model.satisfy(solution)
+
+    # add resources that should change schedule and mode choice
+    task = model.tasks_list[0]
+    t = solution.get_start_time(task)
+    assert solution.get_mode(task) == 1
+    calendar = [2] * model.horizon
+    calendar[t] = 1
+    model.non_renewable_resources = {"R0"}
+    model.resources_availability = {"R0": [1], "R1": calendar}
+    model.resources_set = set(model.resources_availability)
+    model.partial_preemption_data = None
+    model.always_releasable_resources = None
+    model.never_releasable_resources = None
+    # resource R1 not available at previous starting time
+    model.mode_details[task][1]["R1"] = 2
+    # new mode ok
+    model.mode_details[task][2] = dict(model.mode_details[task][1])
+    model.mode_details[task][2]["R0"] = 1
+    # previous mode ko
+    model.mode_details[task][1]["R0"] = 2
+    model.update_problem()
+    cp_model = CpSatAutoMultiskillRcpspSolver(
+        problem=model,
+    )
+    cp_model.init_model(
+        one_worker_per_task=True,
+    )
+    p = ParametersCp.default_cpsat()
+    res = cp_model.solve(
+        parameters_cp=p, time_limit=20, callbacks=[NbIterationStopper(1)]
+    )
+    solution: MultiskillRcpspSolution = res.get_best_solution_fit()[0]
+    assert model.satisfy(solution)
+    assert solution.get_start_time(task) != t
+    assert solution.get_mode(task) == 2
+
+
+def test_imopse_cpsat_with_calendar(caplog):
+    """
+    To test some part of the cp model relative to calendar handling
+    """
+    file = [f for f in get_data_available() if "100_5_64_9.def" in f][0]
+    model, _ = parse_file(file, max_horizon=1000)
+    for emp in model.employees:
+        model.employees[emp].calendar_employee = np.array(
+            model.employees[emp].calendar_employee
+        )
+        model.employees[emp].calendar_employee[5:10] = 0
+    model.update_problem()
+    cp_model = CpSatAutoMultiskillRcpspSolver(
+        problem=model,
+    )
+    cp_model.init_model(
+        one_worker_per_task=True,
+    )
+    p = ParametersCp.default_cpsat()
+    res = cp_model.solve(
+        parameters_cp=p, time_limit=20, callbacks=[NbIterationStopper(1)]
+    )
+    solution = res.get_best_solution_fit()[0]
+    assert model.satisfy(solution)
+
+    # tweak calendar to make fail the satisfy
+    # find employee used in a task
+    employee_task_found = False
+    for employee in model.employees_list:
+        for task, task_employees in solution.employee_usage.items():
+            if employee in task_employees:
+                employee_task_found = True
+                break
+        if employee_task_found:
+            break
+    # make employee unavailable at task start
+    start = solution.get_start_time(task)
+    model.employees[employee].calendar_employee[start] = 0
+    model.update_problem()
+
+    with caplog.at_level(logging.DEBUG):
+        assert not model.satisfy(solution)
+
+    assert "Violations on renewable resource capacities" in caplog.text
+    assert f"resource '{employee}'" in caplog.text
+    assert f"at time {start}" in caplog.text
+
+
+@pytest.fixture()
+def problem():
+    file = [f for f in get_data_available() if "100_5_64_9.def" in f][0]
+    problem, _ = parse_file(file, max_horizon=1000)
+    for emp in problem.employees:
+        problem.employees[emp].calendar_employee = np.array(
+            problem.employees[emp].calendar_employee
+        )
+        problem.employees[emp].calendar_employee[5:10] = 0
+    problem.update_problem()
+    return problem
+
+
+@pytest.fixture()
+def solver(problem):
+    return CpSatAutoMultiskillRcpspSolver(
+        problem=problem,
+    )
+
+
+@pytest.fixture()
+def problem_multimode(problem):
+    task = 2
+    old_mode = 1
+    new_mode = 2
+    new_details = dict(problem.mode_details[task][old_mode])
+    new_details["duration"] *= 10
+    new_details["Q8"] = 2
+    problem.mode_details[task][new_mode] = new_details
+    problem.update_problem()
+    return problem
+
+
+@pytest.fixture
+def random_seed():
+    random.seed(0)
+    np.random.seed(0)
+
+
+@pytest.mark.parametrize(
+    "task, start_or_end, sign , time",
+    [
+        (2, StartOrEnd.START, SignEnum.UEQ, 600),
+    ],
+)
+def test_task_constraint(problem, solver, task, start_or_end, sign, time):
+    sol: MultiskillRcpspSolution = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+
+    # before adding the constraint, not already satisfied
+    assert not sol.constraint_on_task_satisfied(
+        task=task, start_or_end=start_or_end, sign=sign, time=time
+    )
+    # add constraint: should be now satisfied
+    cstrs = solver.add_constraint_on_task(
+        task=task, start_or_end=start_or_end, sign=sign, time=time
+    )
+    sol = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+    assert sol.constraint_on_task_satisfied(
+        task=task, start_or_end=start_or_end, sign=sign, time=time
+    )
+    # check constraints can be effectively removed
+    solver.remove_constraints(cstrs)
+    sol = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+    assert not sol.constraint_on_task_satisfied(
+        task=task, start_or_end=start_or_end, sign=sign, time=time
+    )
+
+
+def test_constraint_nb_allocation_changes(problem):
+    solver = CpSatAutoMultiskillRcpspSolver(
+        problem=problem,
+    )
+    res = solver.solve(callbacks=[NbIterationStopper(nb_iteration_max=5)])
+    print(len(res))
+    ref: MultiskillRcpspSolution = res.get_best_solution()
+    sol: MultiskillRcpspSolution
+    for sol, _ in res:
+        print(sol.compute_nb_allocation_changes(ref))
+    sol, _ = res[0]
+    nb_changes_max = 4
+    assert sol.compute_nb_allocation_changes(ref) > nb_changes_max
+    sol = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+    assert sol.compute_nb_allocation_changes(ref) > nb_changes_max
+    solver.add_constraint_on_nb_allocation_changes(ref=ref, nb_changes=nb_changes_max)
+    sol = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+    assert sol.compute_nb_allocation_changes(ref) <= nb_changes_max
+
+
+def test_constraint_same_allocation_as_ref(problem):
+    solver = CpSatAutoMultiskillRcpspSolver(
+        problem=problem,
+    )
+    res = solver.solve(callbacks=[NbIterationStopper(nb_iteration_max=5)])
+    print(len(res))
+    ref: MultiskillRcpspSolution = res.get_best_solution()
+    sol: MultiskillRcpspSolution
+    for sol, _ in res:
+        print(sol.compute_nb_allocation_changes(ref))
+    nb_changes_max = 4
+    sol = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+    assert sol.compute_nb_allocation_changes(ref) > nb_changes_max
+    constraints = solver.add_constraint_same_allocation_as_ref(ref=ref)
+    sol = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+    assert sol.check_same_allocation_as_ref(ref)
+
+    task = 101
+    employee = 3
+    subtasks = [t for t in problem.tasks_list if t != task]
+    subresources = [e for e in problem.unary_resources_list if e != employee]
+
+    solver.remove_constraints(constraints)
+    solver.add_constraint_same_allocation_as_ref(
+        ref, tasks=subtasks, unary_resources=subresources
+    )
+    solver.add_constraint_on_task_unary_resource_allocation(
+        task=task, unary_resource=employee, used=True
+    )
+    solver.add_constraint_on_task_unary_resource_allocation(
+        task=98, unary_resource=employee, used=True
+    )
+    sol = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+    assert sol.check_same_allocation_as_ref(
+        ref, tasks=subtasks, unary_resources=subresources
+    )
+    assert not sol.check_same_allocation_as_ref(ref)
+
+
+def test_constraint_nb_usages(problem):
+    solver = CpSatAutoMultiskillRcpspSolver(
+        problem=problem,
+    )
+    sol: MultiskillRcpspSolution = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+    nb_usages_total = sol.compute_nb_unary_resource_usages()
+    solver.add_constraint_on_total_nb_usages(sign=SignEnum.UP, target=nb_usages_total)
+    sol = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+    assert sol.compute_nb_unary_resource_usages() > nb_usages_total
+
+    unary_resource = 3
+    nb_usages = sol.compute_nb_unary_resource_usages(unary_resources=(unary_resource,))
+    solver.add_constraint_on_unary_resource_nb_usages(
+        sign=SignEnum.UP, target=nb_usages, unary_resource=unary_resource
+    )
+    sol = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+    assert (
+        sol.compute_nb_unary_resource_usages(unary_resources=(unary_resource,))
+        > nb_usages
+    )
+
+
+def test_objective_global_makespan(problem):
+    solver = CpSatAutoMultiskillRcpspSolver(
+        problem=problem,
+    )
+    solver.init_model()
+
+    objective = solver.get_global_makespan_variable()
+    solver.minimize_variable(objective)
+    sol: MultiskillRcpspSolution
+    sol, _ = solver.solve(callbacks=[NbIterationStopper(nb_iteration_max=1)])[-1]
+    assert solver.solver.ObjectiveValue() == sol.get_max_end_time()
+
+
+def test_objective_subtasks_makespan(problem):
+    solver = CpSatAutoMultiskillRcpspSolver(
+        problem=problem,
+    )
+    solver.init_model()
+    subtasks = [2, 3]
+
+    objective = solver.get_subtasks_makespan_variable(subtasks)
+    solver.minimize_variable(objective)
+    sol: MultiskillRcpspSolution
+    sol, _ = solver.solve(callbacks=[NbIterationStopper(nb_iteration_max=1)])[-1]
+    assert solver.solver.ObjectiveValue() == max(
+        sol.get_end_time(task) for task in subtasks
+    )
+
+
+def test_objective_subtasks_sum_starts(problem):
+    solver = CpSatAutoMultiskillRcpspSolver(
+        problem=problem,
+    )
+    solver.init_model()
+    subtasks = [2, 3]
+    objective = solver.get_subtasks_sum_start_time_variable(subtasks)
+    solver.minimize_variable(objective)
+    sol: MultiskillRcpspSolution
+    sol, _ = solver.solve(callbacks=[NbIterationStopper(nb_iteration_max=1)])[-1]
+    assert solver.solver.ObjectiveValue() == sum(
+        sol.get_start_time(task) for task in subtasks
+    )
+
+
+def test_objective_subtasks_sum_ends(problem):
+    solver = CpSatAutoMultiskillRcpspSolver(
+        problem=problem,
+    )
+    solver.init_model()
+    subtasks = [2, 3]
+    objective = solver.get_subtasks_sum_end_time_variable(subtasks)
+    solver.minimize_variable(objective)
+    sol: MultiskillRcpspSolution
+    sol, _ = solver.solve(callbacks=[NbIterationStopper(nb_iteration_max=1)])[-1]
+    assert solver.solver.ObjectiveValue() == sum(
+        sol.get_end_time(task) for task in subtasks
+    )
+
+
+def test_objective_nb_tasks_done(problem):
+    solver = CpSatAutoMultiskillRcpspSolver(
+        problem=problem,
+    )
+    solver.init_model()
+    objective = -solver.get_nb_tasks_done_variable()
+    solver.minimize_variable(objective)
+    sol: MultiskillRcpspSolution
+    sol, _ = solver.solve(callbacks=[NbIterationStopper(nb_iteration_max=1)])[-1]
+    assert solver.solver.ObjectiveValue() == -sum(
+        max(
+            sol.is_allocated(task, unary_resource)
+            for unary_resource in problem.unary_resources_list
+        )
+        for task in problem.tasks_list
+    )
+
+
+def test_objective_nb_unary_resources_used(problem):
+    solver = CpSatAutoMultiskillRcpspSolver(
+        problem=problem,
+    )
+    solver.init_model()
+    objective = solver.get_nb_unary_resources_used_variable()
+    solver.minimize_variable(objective)
+    sol: MultiskillRcpspSolution
+    sol, _ = solver.solve(callbacks=[NbIterationStopper(nb_iteration_max=1)])[-1]
+    assert solver.solver.ObjectiveValue() == sum(
+        max(sol.is_allocated(task, unary_resource) for task in problem.tasks_list)
+        for unary_resource in problem.unary_resources_list
+    )
+
+
+def test_constraint_multimode(problem_multimode, random_seed):
+    problem = problem_multimode
+    assert problem.is_multimode
+    solver = CpSatAutoMultiskillRcpspSolver(
+        problem=problem,
+    )
+    sol = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+        parameters_cp=ParametersCp.default(),
+    ).get_best_solution()
+    task = 2
+    mode = 2
+    assert not sol.get_mode(task) == mode
+
+    solver.add_constraint_on_task_mode(task, mode)
+    sol = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+    assert sol.get_mode(task) == mode
+
+    task_nok = 3
+    mode_nok = 2
+    with pytest.raises(ValueError):
+        solver.add_constraint_on_task_mode(task_nok, mode_nok)

--- a/tests/rcpsp_multiskill/solvers/test_cpsat_auto.py
+++ b/tests/rcpsp_multiskill/solvers/test_cpsat_auto.py
@@ -135,7 +135,7 @@ def test_imopse_cpsat_with_calendar(caplog):
     with caplog.at_level(logging.DEBUG):
         assert not model.satisfy(solution)
 
-    assert "Violations on renewable resource capacities" in caplog.text
+    assert "Violations on calendar resource capacities" in caplog.text
     assert f"resource '{employee}'" in caplog.text
     assert f"at time {start}" in caplog.text
 

--- a/tests/workforce/scheduling/test_cpsat.py
+++ b/tests/workforce/scheduling/test_cpsat.py
@@ -61,32 +61,34 @@ def test_cpsat(problem):
     sol: AllocSchedulingSolution = res[-1][0]
     assert sol.check_all_renewable_resource_capacity_constraints()
     assert problem.satisfy(sol)
-    problem.evaluate(sol)
+    kpis = problem.evaluate(sol)
 
+    # test warm-start
+
+    # find a different init sol
+    solver.cp_model.add(
+        solver.get_nb_unary_resources_used_variable() > kpis["nb_teams"]
+    )
     res = solver.solve(
-        callbacks=[NbIterationStopper(nb_iteration_max=2)],
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
         parameters_cp=parameters_cp,
         time_limit=10,
     )
-    # assert len(res) == 2  # not always 2 solutions found
-    sol = res[-1][0]
-    assert problem.satisfy(sol)
-    problem.evaluate(sol)
+    init_sol: AllocSchedulingSolution = res[-1][0]
 
-    # test warm-start
     solver = CPSatAllocSchedulingSolver(problem)
     solver.init_model(
         objectives=[ObjectivesEnum.NB_TEAMS], adding_redundant_cumulative=True
     )
-    solver.set_warm_start(solution=sol)
+    solver.set_warm_start(solution=init_sol)
     res = solver.solve(
         callbacks=[NbIterationStopper(nb_iteration_max=1)],
         parameters_cp=parameters_cp,
         time_limit=10,
     )
     sol2 = res[0][0]
-    assert (sol.schedule == sol2.schedule).all()
-    assert (sol.allocation == sol2.allocation).all()
+    assert (init_sol.schedule == sol2.schedule).all()
+    assert (init_sol.allocation == sol2.allocation).all()
 
     # generate disruption
     d = generate_scheduling_disruption(

--- a/tests/workforce/scheduling/test_cpsat.py
+++ b/tests/workforce/scheduling/test_cpsat.py
@@ -59,7 +59,7 @@ def test_cpsat(problem):
     )
     assert len(res) == 1
     sol: AllocSchedulingSolution = res[-1][0]
-    assert sol.check_all_renewable_resource_capacity_constraints()
+    assert sol.check_all_calendar_resource_capacity_constraints()
     assert problem.satisfy(sol)
     kpis = problem.evaluate(sol)
 

--- a/tests/workforce/scheduling/test_cpsat_auto.py
+++ b/tests/workforce/scheduling/test_cpsat_auto.py
@@ -1,0 +1,556 @@
+#  Copyright (c) 2025 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+import logging
+
+import pytest
+
+from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
+from discrete_optimization.generic_tools.callbacks.early_stoppers import (
+    NbIterationStopper,
+)
+from discrete_optimization.generic_tools.cp_tools import ParametersCp, SignEnum
+from discrete_optimization.generic_tools.hyperparameters.hyperparameter import SubBrick
+from discrete_optimization.generic_tools.lexico_tools import LexicoSolver
+from discrete_optimization.workforce.commons.fairness_modeling import (
+    ModelisationDispersion,
+)
+from discrete_optimization.workforce.generators.resource_scenario import (
+    ParamsRandomness,
+    generate_scheduling_disruption,
+)
+from discrete_optimization.workforce.scheduling.parser import (
+    get_data_available,
+    parse_json_to_problem,
+)
+from discrete_optimization.workforce.scheduling.problem import AllocSchedulingSolution
+from discrete_optimization.workforce.scheduling.solvers.alloc_scheduling_lb import (
+    ApproximateBoundAllocScheduling,
+    BoundResourceViaRelaxedProblem,
+    LBoundAllocScheduling,
+)
+from discrete_optimization.workforce.scheduling.solvers.cpsat_auto import (
+    CPSatAutoAllocSchedulingSolver,
+    ObjectivesEnum,
+)
+from discrete_optimization.workforce.scheduling.utils import (
+    compute_changes_between_solution,
+    plotly_schedule_comparison,
+)
+
+
+@pytest.fixture()
+def problem():
+    instance = [p for p in get_data_available() if "instance_64.json" in p][0]
+    return parse_json_to_problem(instance)
+
+
+def test_cpsat(problem):
+    solver = CPSatAutoAllocSchedulingSolver(problem)
+    solver.init_model(
+        objectives=[ObjectivesEnum.NB_TEAMS], adding_redundant_cumulative=True
+    )
+    parameters_cp = ParametersCp.default()  # keep 1 process to check stopper properly
+    res = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+        parameters_cp=parameters_cp,
+        time_limit=10,
+    )
+    sol: AllocSchedulingSolution = res[-1][0]
+    assert problem.satisfy(sol)
+    kpis = problem.evaluate(sol)
+
+    # test warm-start
+
+    # find a different init sol
+    solver.cp_model.add(
+        solver.get_nb_unary_resources_used_variable() > 2 * kpis["nb_teams"]
+    )
+    res = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+        parameters_cp=parameters_cp,
+        time_limit=10,
+    )
+    init_sol: AllocSchedulingSolution = res[-1][0]
+
+    solver = CPSatAutoAllocSchedulingSolver(problem)
+    solver.init_model(
+        objectives=[ObjectivesEnum.NB_TEAMS], adding_redundant_cumulative=True
+    )
+    solver.set_warm_start(solution=init_sol)
+    res = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+        parameters_cp=parameters_cp,
+        ortools_cpsat_solver_kwargs=dict(fix_variables_to_their_hinted_value=True),
+        time_limit=10,
+    )
+    sol2: AllocSchedulingSolution = res[0][0]
+    assert (init_sol.schedule == sol2.schedule).all()
+    assert (init_sol.allocation == sol2.allocation).all()
+
+    # generate disruption
+    d = generate_scheduling_disruption(
+        original_scheduling_problem=problem,
+        original_solution=sol,
+        list_drop_resource=None,
+        params_randomness=ParamsRandomness(
+            lower_nb_disruption=1,
+            upper_nb_disruption=2,
+            lower_nb_teams=1,
+            upper_nb_teams=1,
+        ),
+    )
+    solver_relaxed = CPSatAutoAllocSchedulingSolver(d["scheduling_problem"])
+    solver_relaxed.init_model(
+        objectives=[
+            ObjectivesEnum.NB_DONE_AC,
+            ObjectivesEnum.DELTA_TO_EXISTING_SOLUTION,
+            ObjectivesEnum.NB_TEAMS,
+        ],
+        additional_constraints=d["additional_constraint_scheduling"],
+        optional_activities=True,
+        base_solution=sol,
+    )
+    res = solver_relaxed.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+        parameters_cp=parameters_cp,
+        time_limit=5,
+    )
+
+    # compare solutions
+    changes = compute_changes_between_solution(solution_a=sol, solution_b=res[-1][0])
+    for key in ["nb_reallocated", "nb_shift", "mean_shift", "sum_shift", "max_shift"]:
+        assert key in changes
+
+    # plots
+    plotly_schedule_comparison(
+        base_solution=sol,
+        updated_solution=res[-1][0],
+        problem=d["scheduling_problem"],
+        use_color_map_per_task=False,
+        color_map_per_task={},
+        plot_team_breaks=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "symmbreak_on_used, optional_activities, adding_redundant_cumulative, add_lower_bound, lower_bound_method",
+    [
+        (False, False, False, False, None),
+        (False, True, False, False, None),
+        (True, False, False, False, None),
+        (False, False, True, False, None),
+        (
+            False,
+            False,
+            False,
+            True,
+            SubBrick(
+                BoundResourceViaRelaxedProblem,
+                kwargs=dict(adding_precedence_constraint=False, time_limit=2),
+            ),
+        ),
+        (
+            False,
+            False,
+            False,
+            True,
+            SubBrick(
+                BoundResourceViaRelaxedProblem,
+                kwargs=dict(adding_precedence_constraint=True, time_limit=2),
+            ),
+        ),
+        (
+            False,
+            False,
+            False,
+            True,
+            SubBrick(
+                LBoundAllocScheduling,
+                kwargs=dict(),
+            ),
+        ),
+        (
+            False,
+            False,
+            False,
+            True,
+            SubBrick(
+                ApproximateBoundAllocScheduling,
+                kwargs=dict(),
+            ),
+        ),
+    ],
+)
+def test_cpsat_params(
+    problem,
+    symmbreak_on_used,
+    optional_activities,
+    adding_redundant_cumulative,
+    add_lower_bound,
+    lower_bound_method,
+):
+    kwargs = dict(
+        symmbreak_on_used=symmbreak_on_used,
+        optional_activities=optional_activities,
+        adding_redundant_cumulative=adding_redundant_cumulative,
+        add_lower_bound=add_lower_bound,
+        lower_bound_method=lower_bound_method,
+    )
+    parameters_cp = ParametersCp.default()  # keep 1 process to check stopper properly
+
+    solver = CPSatAutoAllocSchedulingSolver(problem, **kwargs)
+    solver.init_model(
+        objectives=[ObjectivesEnum.NB_TEAMS, ObjectivesEnum.NB_DONE_AC], **kwargs
+    )
+    res = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+        time_limit=15,
+        parameters_cp=parameters_cp,
+        **kwargs,
+    )
+    assert len(res) == 1
+    sol = res[-1][0]
+    problem.evaluate(sol)
+    if not optional_activities:
+        assert problem.satisfy(sol)
+
+
+@pytest.mark.parametrize("modelisation_dispersion", list(ModelisationDispersion))
+def test_cpsat_modelisation_dispersion(problem, modelisation_dispersion):
+    kwargs = dict(
+        modelisation_dispersion=modelisation_dispersion,
+    )
+    parameters_cp = ParametersCp.default()  # keep 1 process to check stopper properly
+
+    solver = CPSatAutoAllocSchedulingSolver(problem, **kwargs)
+    solver.init_model(
+        objectives=[ObjectivesEnum.DISPERSION],
+        adding_redundant_cumulative=True,
+        **kwargs,
+    )
+    res = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+        time_limit=10,
+        parameters_cp=parameters_cp,
+        **kwargs,
+    )
+    assert len(res) == 1
+    sol = res[-1][0]
+    assert problem.satisfy(sol)
+    problem.evaluate(sol)
+
+
+def test_cpsat_set_model_obj_aggregated(problem):
+    solver = CPSatAutoAllocSchedulingSolver(problem)
+
+    # solution to compare with for DELTA_TO_EXISTING_SOLUTION
+    res = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+        time_limit=10,
+    )
+    base_solution = res.get_best_solution()
+
+    objectives = [
+        ObjectivesEnum.NB_TEAMS,
+        ObjectivesEnum.MAKESPAN,
+        ObjectivesEnum.DELTA_TO_EXISTING_SOLUTION,
+    ]
+    objs_weights = [
+        (ObjectivesEnum.NB_TEAMS, 0.1),
+        ("MAKESPAN", 0.5),
+        ("max_delta_schedule", 1.5),
+    ]
+    solver.init_model(objectives=objectives, base_solution=base_solution)
+    solver.set_model_obj_aggregated(objs_weights=objs_weights)
+    parameters_cp = ParametersCp.default()  # keep 1 process to check stopper properly
+    # test with callback
+    res = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+        parameters_cp=parameters_cp,
+        time_limit=5,
+    )
+    assert len(res) == 1
+    sol = res[-1][0]
+    assert problem.satisfy(sol)
+    problem.evaluate(sol)
+
+
+def test_cpsat_lexico(problem):
+    solver = CPSatAutoAllocSchedulingSolver(problem)
+
+    # solution to compare with for DELTA_TO_EXISTING_SOLUTION
+    res = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+        time_limit=10,
+    )
+    base_solution = res.get_best_solution()
+
+    # objectives to consider
+    objectives = list(ObjectivesEnum)
+
+    solver.init_model(
+        objectives=objectives, base_solution=base_solution, optional_activities=True
+    )
+    objectives_available = solver.get_lexico_objectives_available()
+    for o in objectives_available:
+        assert isinstance(o, str)
+    assert (
+        len(solver.get_lexico_objectives_available()) == len(objectives) + 4
+    )  # DELTA_TO_EXISTING_SOLUTION => add 4 sous-obj
+
+    # generic lexico solver
+    lexico_solver = LexicoSolver(problem=problem, subsolver=solver)
+    parameters_cp = ParametersCp.default()  # keep 1 process to check stopper properly
+    objectives = ["MAKESPAN", "NB_TEAMS", "sum_delta_schedule"]
+    res = lexico_solver.solve(
+        subsolver_callbacks=[NbIterationStopper(nb_iteration_max=1)],
+        time_limit=10,
+        parameters_cp=parameters_cp,
+        objectives=objectives,
+    )
+    # assert len(res) == len(objectives)  # not always a new solution found for each objective
+
+
+def test_satisfy_w_resource(problem, caplog):
+    # add a cumulative resource to the problem
+    resource = "R0"
+    problem.resources_list = [resource]
+    problem.resources_capacity = {resource: 2}
+    i_task = 0
+    task = problem.tasks_list[i_task]
+    problem.tasks_data[task].resource_consumption[resource] = 2
+    problem.update_problem()
+    # solve => ok
+    solver = CPSatAutoAllocSchedulingSolver(problem)
+    res = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+    )
+    sol: AllocSchedulingSolution = res.get_best_solution()
+    assert problem.satisfy(sol)
+
+    # restrict resource capacity
+    problem.resources_capacity = {resource: 1}
+    # tweak teams calendar
+    start = sol.get_start_time(task)
+    end = sol.get_end_time(task)
+    i_team = sol.allocation[i_task]
+    team = problem.index_to_team[i_team]
+    problem.calendar_team[team] = [[end, problem.horizon]]
+    problem.update_problem()
+    # => sol nok
+    with caplog.at_level(logging.DEBUG):
+        assert not problem.satisfy(sol)
+    assert "R0" in caplog.text
+    assert team in caplog.text
+
+
+def test_task_constraint(problem):
+    solver = CPSatAutoAllocSchedulingSolver(problem)
+    res = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+    )
+    sol: AllocSchedulingSolution = res.get_best_solution()
+    print(problem.tasks_list)
+    print(problem.unary_resources_list)
+    i_task = 0
+    print(sol.schedule[i_task, :])
+    print(sol.allocation[i_task])
+    print(problem.index_to_task[i_task])
+
+    task = "80719"
+    start_or_end = StartOrEnd.START
+    sign = SignEnum.UEQ
+    time = 15
+
+    # before adding the constraint, not already satisfied
+    assert not sol.constraint_on_task_satisfied(
+        task=task, start_or_end=start_or_end, sign=sign, time=time
+    )
+    # add constraint: should be now satisfied
+    cstrs = solver.add_constraint_on_task(
+        task=task, start_or_end=start_or_end, sign=sign, time=time
+    )
+    sol = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+    assert sol.constraint_on_task_satisfied(
+        task=task, start_or_end=start_or_end, sign=sign, time=time
+    )
+    # check constraints can be effectively removed
+    solver.remove_constraints(cstrs)
+    sol = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+    assert not sol.constraint_on_task_satisfied(
+        task=task, start_or_end=start_or_end, sign=sign, time=time
+    )
+
+
+def test_chaining_constraint(problem):
+    solver = CPSatAutoAllocSchedulingSolver(problem)
+    sol: AllocSchedulingSolution
+
+    # before adding the constraint, not already satisfied
+    sol = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+    task1 = problem.tasks_list[0]
+    for task2 in problem.tasks_list[1:]:
+        if not sol.constraint_chaining_tasks_satisfied(task1=task1, task2=task2):
+            break
+    assert not sol.constraint_chaining_tasks_satisfied(task1=task1, task2=task2)
+    # add constraint
+    cstrs = solver.add_constraint_chaining_tasks(task1=task1, task2=task2)
+    sol = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+    assert sol.constraint_chaining_tasks_satisfied(task1=task1, task2=task2)
+
+
+def test_objective_global_makespan(problem):
+    solver = CPSatAutoAllocSchedulingSolver(problem)
+    sol: AllocSchedulingSolution
+    solver.init_model()
+
+    objective = solver.get_global_makespan_variable()
+    solver.minimize_variable(objective)
+    sol, _ = solver.solve(callbacks=[NbIterationStopper(nb_iteration_max=1)])[-1]
+    assert solver.solver.ObjectiveValue() == sol.get_max_end_time()
+
+
+def test_objective_subtasks_makespan(problem):
+    solver = CPSatAutoAllocSchedulingSolver(problem)
+    sol: AllocSchedulingSolution
+    solver.init_model()
+    subtasks = ["80719", "21963"]
+
+    objective = solver.get_subtasks_makespan_variable(subtasks)
+    solver.minimize_variable(objective)
+    sol, _ = solver.solve(callbacks=[NbIterationStopper(nb_iteration_max=1)])[-1]
+    assert solver.solver.ObjectiveValue() == max(
+        sol.get_end_time(task) for task in subtasks
+    )
+
+
+def test_objective_subtasks_sum_starts(problem):
+    solver = CPSatAutoAllocSchedulingSolver(problem)
+    sol: AllocSchedulingSolution
+    solver.init_model()
+    subtasks = ["80719", "21963"]
+    objective = solver.get_subtasks_sum_start_time_variable(subtasks)
+    solver.minimize_variable(objective)
+    sol, _ = solver.solve(callbacks=[NbIterationStopper(nb_iteration_max=1)])[-1]
+    assert solver.solver.ObjectiveValue() == sum(
+        sol.get_start_time(task) for task in subtasks
+    )
+
+
+def test_objective_subtasks_sum_ends(problem):
+    solver = CPSatAutoAllocSchedulingSolver(problem)
+    sol: AllocSchedulingSolution
+    solver.init_model()
+    subtasks = ["80719", "21963"]
+    objective = solver.get_subtasks_sum_end_time_variable(subtasks)
+    solver.minimize_variable(objective)
+    sol, _ = solver.solve(callbacks=[NbIterationStopper(nb_iteration_max=1)])[-1]
+    assert solver.solver.ObjectiveValue() == sum(
+        sol.get_end_time(task) for task in subtasks
+    )
+
+
+def test_objective_nb_tasks_done(problem):
+    solver = CPSatAutoAllocSchedulingSolver(problem)
+    sol: AllocSchedulingSolution
+    solver.init_model()
+    objective = -solver.get_nb_tasks_done_variable()
+    solver.minimize_variable(objective)
+    sol, _ = solver.solve(callbacks=[NbIterationStopper(nb_iteration_max=1)])[-1]
+    assert solver.solver.ObjectiveValue() == -sum(
+        max(
+            sol.is_allocated(task, unary_resource)
+            for unary_resource in problem.unary_resources_list
+        )
+        for task in problem.tasks_list
+    )
+
+
+def test_objective_nb_unary_resources_used(problem):
+    solver = CPSatAutoAllocSchedulingSolver(problem)
+    sol: AllocSchedulingSolution
+    solver.init_model()
+    objective = solver.get_nb_unary_resources_used_variable()
+    solver.minimize_variable(objective)
+    parameters_cp = ParametersCp.default()
+    res = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)], parameters_cp=parameters_cp
+    )
+    assert solver.solver.ObjectiveValue() == min(
+        sum(
+            max(sol.is_allocated(task, unary_resource) for task in problem.tasks_list)
+            for unary_resource in problem.unary_resources_list
+        )
+        for sol, _ in res
+    )
+
+
+def test_constraint_nb_usages(problem):
+    solver = CPSatAutoAllocSchedulingSolver(
+        problem=problem,
+    )
+    sol = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+    nb_usages_total = sol.compute_nb_unary_resource_usages()
+    unary_resource = "adba7"
+    nb_usages = sol.compute_nb_unary_resource_usages(unary_resources=(unary_resource,))
+
+    # constraint on total nb usages: infeasible (by hypothesis exactly 1 team by task)
+    constraints = solver.add_constraint_on_total_nb_usages(
+        sign=SignEnum.UP, target=nb_usages_total
+    )
+    sol = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+    assert sol is None
+
+    # constraint on a unary resource usage: increase team usage
+    solver.remove_constraints(constraints)
+    solver.add_constraint_on_unary_resource_nb_usages(
+        sign=SignEnum.UP, target=nb_usages, unary_resource=unary_resource
+    )
+    sol = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)]
+    ).get_best_solution()
+    assert (
+        sol.compute_nb_unary_resource_usages(unary_resources=(unary_resource,))
+        > nb_usages
+    )
+
+
+def test_constraint_nb_allocation_changes(problem):
+    solver = CPSatAutoAllocSchedulingSolver(
+        problem=problem,
+    )
+    solver.init_model()
+    ref: AllocSchedulingSolution
+    sol: AllocSchedulingSolution
+
+    # get a ref anti-optimal (we maximze nb_teams instead of minimizing it)
+    solver.cp_model.maximize(solver.get_nb_unary_resources_used_variable())
+    res = solver.solve(callbacks=[NbIterationStopper(nb_iteration_max=3)])
+    ref, _ = res[-1]
+
+    # get back initial model
+    solver.init_model()
+
+    nb_changes_max = 2
+    # w/o constraint
+    res = solver.solve(callbacks=[NbIterationStopper(nb_iteration_max=3)])
+    sol, _ = res[-1]
+    assert sol.compute_nb_allocation_changes(ref) > nb_changes_max
+    # with constraint
+    solver.add_constraint_on_nb_allocation_changes(ref=ref, nb_changes=nb_changes_max)
+    res = solver.solve(callbacks=[NbIterationStopper(nb_iteration_max=3)])
+    sol, _ = res[-1]
+    assert sol.compute_nb_allocation_changes(ref) <= nb_changes_max


### PR DESCRIPTION
- `GenericSchedulingAutoCpSatSolver` works for most generic problem class `GenericSchedulingProblem` with features
  - scheduling 
  - allocation
  - multimode
  - cumulative calendar resources 
  - non-renewable resources 
  - precedence constraints
- new mixins added to be able to adapt this solver to problem with less features without having to implement unnecessary method:
  - SinglemodeScheduling
  - WithoutNonRenewableResource
  - WithoutAllocation
  - WithoutCumulativeResource
  - WithoutRenewableResource
- always assume that this is at least a scheduling problem (start/end variables created)
- automatically create cpsat variables
- add constraints corresponding to the different features
- warmstart included
- generate temporary solution to be converted to actual problem solution via `convert_task_variables_to_solution()` to implement
- extra custom constraints to be added by overriding `init_model()`
- subclass `SinglemodeGenericSchedulingAutoCpSatSolver` gives access to `get_task_interval()` to avoid having to call a multimode method with mode=default_mode
- auto solver adapted for
  -  rcpsp
  - rcpsp_multiskill
  - jsp
  - fjsp
  - workforce/scheduling
