### PR TITLE
Model machines as cumulative resources (with capa 1) in jsp/fjsp 

### DIFF
--- a/src/discrete_optimization/fjsp/problem.py
+++ b/src/discrete_optimization/fjsp/problem.py
@@ -12,15 +12,6 @@ from discrete_optimization.generic_tasks_tools.allocation import (
     WithoutAllocationProblem,
     WithoutAllocationSolution,
 )
-from discrete_optimization.generic_tasks_tools.calendar_resource import (
-    WithoutCalendarResourceProblem,
-    WithoutCalendarResourceSolution,
-)
-from discrete_optimization.generic_tasks_tools.cumulative_resource import (
-    NoCumulativeResource,
-    WithoutCumulativeResourceProblem,
-    WithoutCumulativeResourceSolution,
-)
 from discrete_optimization.generic_tasks_tools.generic_scheduling import (
     GenericSchedulingProblem,
     GenericSchedulingSolution,
@@ -43,14 +34,16 @@ from discrete_optimization.jsp.problem import Subjob, Task
 logger = logging.getLogger(__name__)
 
 
+CumulativeResource = int  # machine id
+Resource = CumulativeResource  # no other resource
+
+
 class FJobShopSolution(
     GenericSchedulingSolution[
-        Task, NoUnaryResource, NoCumulativeResource, NoNonRenewableResource
+        Task, NoUnaryResource, CumulativeResource, NoNonRenewableResource
     ],
-    WithoutCumulativeResourceSolution[Task, NoUnaryResource],
     WithoutNonRenewableResourceSolution[Task],
     WithoutAllocationSolution[Task],
-    WithoutCalendarResourceSolution[Task],
 ):
     problem: FJobShopProblem
 
@@ -93,12 +86,10 @@ class Job:
 
 class FJobShopProblem(
     GenericSchedulingProblem[
-        Task, NoUnaryResource, NoCumulativeResource, NoNonRenewableResource
+        Task, NoUnaryResource, CumulativeResource, NoNonRenewableResource
     ],
-    WithoutCumulativeResourceProblem[Task, NoUnaryResource],
     WithoutNonRenewableResourceProblem[Task],
     WithoutAllocationProblem[Task],
-    WithoutCalendarResourceProblem[Task],
 ):
     n_jobs: int
     n_machines: int
@@ -173,6 +164,27 @@ class FJobShopProblem(
             for j, job in enumerate(self.list_jobs)
             for k, sub_job_options in enumerate(job.sub_jobs)
         }
+
+    def get_cumulative_resource_consumption(
+        self, resource: CumulativeResource, task: Task, mode: int
+    ) -> int:
+        machine_id = self.mode2machine[task][mode]
+        if machine_id == resource:
+            # the machine "resource" is used
+            return 1
+        else:
+            # the machine "resource" is not used
+            return 0
+
+    @property
+    def cumulative_resources_list(self) -> list[CumulativeResource]:
+        return list(range(self.n_machines))
+
+    def get_resource_availabilities(
+        self, resource: Resource
+    ) -> list[tuple[int, int, int]]:
+        # machine always available
+        return [(0, self.horizon, 1)]
 
     def get_makespan_upper_bound(self) -> int:
         return self.horizon

--- a/src/discrete_optimization/fjsp/solvers/cpsat_auto.py
+++ b/src/discrete_optimization/fjsp/solvers/cpsat_auto.py
@@ -5,13 +5,15 @@
 import logging
 from typing import Any
 
-from discrete_optimization.fjsp.problem import FJobShopProblem, FJobShopSolution, Task
+from discrete_optimization.fjsp.problem import (
+    CumulativeResource,
+    FJobShopProblem,
+    FJobShopSolution,
+    Task,
+)
 from discrete_optimization.generic_tasks_tools.allocation import (
     NoUnaryResource,
     UnaryResource,
-)
-from discrete_optimization.generic_tasks_tools.cumulative_resource import (
-    NoCumulativeResource,
 )
 from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
 from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
@@ -30,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 class CpSatAutoFjspSolver(
     GenericSchedulingAutoCpSatSolver[
-        Task, NoUnaryResource, NoCumulativeResource, NoNonRenewableResource
+        Task, NoUnaryResource, CumulativeResource, NoNonRenewableResource
     ],
 ):
     hyperparameters = [
@@ -52,9 +54,9 @@ class CpSatAutoFjspSolver(
         self.duplicate_start_var_per_mode = kwargs["duplicate_temporal_var"]
         # compute start/end of task lower bounds by forward propagation
         self.compute_start_and_end_lower_bound()
-
+        # whether to add cumulative constraint on top of no_overlap constraint
+        self.add_no_overlap_and_cumulative = bool(kwargs["add_cumulative_constraint"])
         super().init_model(**kwargs)
-        self.create_disjunctive_constraints(**kwargs)
 
     def get_makespan_upper_bound(self) -> int:
         return self._max_time
@@ -99,18 +101,3 @@ class CpSatAutoFjspSolver(
             for j, job in enumerate(self.problem.list_jobs)
         ]
         return FJobShopSolution(problem=self.problem, schedule=schedule)
-
-    def create_disjunctive_constraints(self, **kwargs):
-        add_cumulative_constraint = kwargs["add_cumulative_constraint"]
-        for machine_tasks in self.problem.job_per_machines.values():
-            machine_intervals = [
-                self.get_task_mode_interval(task=(j, k), mode=i_opt)
-                for j, k, i_opt in machine_tasks
-            ]
-            self.cp_model.add_no_overlap(machine_intervals)
-            if add_cumulative_constraint:
-                self.cp_model.add_cumulative(
-                    intervals=machine_intervals,
-                    demands=[1 for _ in range(len(machine_tasks))],
-                    capacity=1,
-                )

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/calendar_resource.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/calendar_resource.py
@@ -20,6 +20,9 @@ from discrete_optimization.generic_tasks_tools.solvers.cpsat.scheduling import (
 class CalendarResourceCpSatSolver(SchedulingCpSatSolver[Task], Generic[Task, Resource]):
     problem: CalendarResourceProblem[Task, Resource]
 
+    add_no_overlap_and_cumulative: bool = False
+    """Flag to add cumulative constraint on top of no_ovelap constraint when resource capacity is 1."""
+
     def create_calendar_resources_constraint(self, resource: Resource):
         """Add the constraint for renewable resources with an availability calendar to the cpsat model.
 
@@ -55,6 +58,12 @@ class CalendarResourceCpSatSolver(SchedulingCpSatSolver[Task], Generic[Task, Res
         if len(intervals) > 0:
             if capacity == 1 and all(value == 1 for value in demands):
                 self.cp_model.add_no_overlap(intervals)
+                if self.add_no_overlap_and_cumulative:
+                    self.cp_model.add_cumulative(
+                        intervals=intervals,
+                        demands=demands,
+                        capacity=capacity,
+                    )
             else:
                 self.cp_model.add_cumulative(
                     intervals=intervals,

--- a/src/discrete_optimization/jsp/problem.py
+++ b/src/discrete_optimization/jsp/problem.py
@@ -10,15 +10,6 @@ from discrete_optimization.generic_tasks_tools.allocation import (
     WithoutAllocationProblem,
     WithoutAllocationSolution,
 )
-from discrete_optimization.generic_tasks_tools.calendar_resource import (
-    WithoutCalendarResourceProblem,
-    WithoutCalendarResourceSolution,
-)
-from discrete_optimization.generic_tasks_tools.cumulative_resource import (
-    NoCumulativeResource,
-    WithoutCumulativeResourceProblem,
-    WithoutCumulativeResourceSolution,
-)
 from discrete_optimization.generic_tasks_tools.generic_scheduling import (
     GenericSchedulingProblem,
     GenericSchedulingSolution,
@@ -45,14 +36,16 @@ Task = tuple[int, int]
 """Task representation: (job index, subjob index)."""
 
 
+CumulativeResource = int  # machine id
+Resource = CumulativeResource  # no other resource
+
+
 class JobShopSolution(
     GenericSchedulingSolution[
-        Task, NoUnaryResource, NoCumulativeResource, NoNonRenewableResource
+        Task, NoUnaryResource, CumulativeResource, NoNonRenewableResource
     ],
-    WithoutCumulativeResourceSolution[Task, NoUnaryResource],
     WithoutNonRenewableResourceSolution[Task],
     WithoutAllocationSolution[Task],
-    WithoutCalendarResourceSolution[Task],
     SinglemodeSchedulingSolution[Task],
 ):
     problem: JobShopProblem
@@ -89,12 +82,10 @@ class Subjob:
 
 class JobShopProblem(
     GenericSchedulingProblem[
-        Task, NoUnaryResource, NoCumulativeResource, NoNonRenewableResource
+        Task, NoUnaryResource, CumulativeResource, NoNonRenewableResource
     ],
-    WithoutCumulativeResourceProblem[Task, NoUnaryResource],
     WithoutNonRenewableResourceProblem[Task],
     WithoutAllocationProblem[Task],
-    WithoutCalendarResourceProblem[Task],
     SinglemodeSchedulingProblem[Task],
 ):
     n_jobs: int
@@ -128,6 +119,28 @@ class JobShopProblem(
             self.horizon = sum(
                 sum(subjob.processing_time for subjob in job) for job in self.list_jobs
             )
+
+    def get_cumulative_resource_consumption(
+        self, resource: CumulativeResource, task: Task, mode: int
+    ) -> int:
+        j, k = task
+        machine_id = self.list_jobs[j][k].machine_id
+        if machine_id == resource:
+            # the machine "resource" is used
+            return 1
+        else:
+            # the machine "resource" is not used
+            return 0
+
+    @property
+    def cumulative_resources_list(self) -> list[CumulativeResource]:
+        return list(range(self.n_machines))
+
+    def get_resource_availabilities(
+        self, resource: Resource
+    ) -> list[tuple[int, int, int]]:
+        # machine always available
+        return [(0, self.horizon, 1)]
 
     @property
     def tasks_list(self) -> list[Task]:

--- a/src/discrete_optimization/jsp/solvers/cpsat_auto.py
+++ b/src/discrete_optimization/jsp/solvers/cpsat_auto.py
@@ -10,9 +10,6 @@ from discrete_optimization.generic_tasks_tools.allocation import (
     NoUnaryResource,
     UnaryResource,
 )
-from discrete_optimization.generic_tasks_tools.cumulative_resource import (
-    NoCumulativeResource,
-)
 from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
     NoNonRenewableResource,
 )
@@ -20,14 +17,19 @@ from discrete_optimization.generic_tasks_tools.solvers.cpsat.auto import (
     SinglemodeGenericSchedulingAutoCpSatSolver,
     TemporarySolution,
 )
-from discrete_optimization.jsp.problem import JobShopProblem, JobShopSolution, Task
+from discrete_optimization.jsp.problem import (
+    CumulativeResource,
+    JobShopProblem,
+    JobShopSolution,
+    Task,
+)
 
 logger = logging.getLogger(__name__)
 
 
 class CpSatAutoJspSolver(
     SinglemodeGenericSchedulingAutoCpSatSolver[
-        Task, NoUnaryResource, NoCumulativeResource, NoNonRenewableResource
+        Task, NoUnaryResource, CumulativeResource, NoNonRenewableResource
     ],
 ):
     problem: JobShopProblem
@@ -36,7 +38,6 @@ class CpSatAutoJspSolver(
         return self._max_time
 
     def init_model(self, **kwargs: Any) -> None:
-        # dummy value, todo : compute a better bound
         max_time = kwargs.get(
             "max_time",
             self.problem.get_makespan_upper_bound(),
@@ -44,12 +45,6 @@ class CpSatAutoJspSolver(
         self._max_time = max_time  # will be used by the makespan variable
 
         super().init_model(**kwargs)
-
-        # No overlap task on the same machine.
-        for machine, tasks in self.problem.job_per_machines.items():
-            self.cp_model.add_no_overlap(
-                self.get_task_interval(task=task) for task in tasks
-            )
 
     def convert_task_variables_to_solution(
         self, temp_sol: TemporarySolution[Task, UnaryResource]


### PR DESCRIPTION
That way, the no overlap constraint on machines is auto generated by cpsat auto.
We also add an option in CalendarResourceCpsatSolver to add cumulative constraint on top of no overlap constraint to mimic the option existing in the fjsp cpsat solver.