### PR TITLE
Add a generic CPM for scheduling problems to bounds task start/ends 

### DIFF
--- a/src/discrete_optimization/fjsp/solvers/cpsat_auto.py
+++ b/src/discrete_optimization/fjsp/solvers/cpsat_auto.py
@@ -15,7 +15,6 @@ from discrete_optimization.generic_tasks_tools.allocation import (
     NoUnaryResource,
     UnaryResource,
 )
-from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
 from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
     NoNonRenewableResource,
 )
@@ -52,38 +51,14 @@ class CpSatAutoFjspSolver(
             "max_time", self.problem.get_makespan_upper_bound()
         )  # update the upper bound for makespan
         self.duplicate_start_var_per_mode = kwargs["duplicate_temporal_var"]
-        # compute start/end of task lower bounds by forward propagation
-        self.compute_start_and_end_lower_bound()
         # whether to add cumulative constraint on top of no_overlap constraint
         self.add_no_overlap_and_cumulative = bool(kwargs["add_cumulative_constraint"])
+        # use cpm to compute start/end bounds
+        self.use_cpm_for_task_bounds = True
         super().init_model(**kwargs)
 
     def get_makespan_upper_bound(self) -> int:
         return self._max_time
-
-    def compute_start_and_end_lower_bound(self) -> None:
-        self.start_lower_bound: dict[Task, int] = {}
-        self.end_lower_bound: dict[Task, int] = {}
-
-        for j, job in enumerate(self.problem.list_jobs):
-            lb = 0
-            for k, sub_job_options in enumerate(job.sub_jobs):
-                task = j, k
-                possible_durations = [
-                    sub_job.processing_time for sub_job in sub_job_options
-                ]
-                self.start_lower_bound[task] = lb
-                lb += min(possible_durations)
-                self.end_lower_bound[task] = lb
-
-    def get_task_start_or_end_lower_bound(
-        self, task: Task, start_or_end: StartOrEnd
-    ) -> int:
-        match start_or_end:
-            case StartOrEnd.START:
-                return self.start_lower_bound[task]
-            case _:
-                return self.end_lower_bound[task]
 
     def convert_task_variables_to_solution(
         self, temp_sol: TemporarySolution[Task, UnaryResource]

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpm.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpm.py
@@ -1,7 +1,7 @@
-#  Copyright (c) 2022 AIRBUS and its affiliates.
+#  Copyright (c) 2026 AIRBUS and its affiliates.
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
-"""CPM toc ompute lower/uppe bound on start/end of tasks"""
+"""CPM to compute lower/uppe bound on start/end of tasks"""
 
 import logging
 from dataclasses import dataclass
@@ -90,22 +90,30 @@ class Cpm(Generic[Task, UnaryResource, CumulativeResource, NonRenewableResource]
             node: nx.algorithms.ancestors(self.graph_nx, node)
             for node in self.graph_nx.nodes()
         }
+        self.successors = {
+            node: nx.algorithms.descendants(self.graph_nx, node)
+            for node in self.graph_nx.nodes()
+        }
+        self._computed = False
 
     def compute_task_bounds(self) -> None:
+        """Compute task bounds by forxard/backward propagation through precedence graph
+
+        Returns:
+
+        """
         # Forward pass for lower bounds
         # starting nodes: without ancestors, start lower bound = 0
         queue = [
             (0, self.node_to_index[node])
-            for node in self.graph_nx.nodes()
-            if len(nx.algorithms.ancestors(self.graph_nx, node)) == 0
+            for node, preds in self.predecessors.items()
+            if len(preds) == 0
         ]
         self._propagate_forward_bounds_through_graph(queue)
 
         # Check if horizon is sufficient for earliest finish date found
         last_tasks = [
-            node
-            for node in self.graph_nx.nodes()
-            if len(nx.algorithms.descendants(self.graph_nx, node)) == 0
+            node for node, succs in self.successors.items() if len(succs) == 0
         ]
         # optimal makespan if there were no constraints apart from precedence
         self.makespan_cpm = max(
@@ -121,6 +129,8 @@ class Cpm(Generic[Task, UnaryResource, CumulativeResource, NonRenewableResource]
         queue = [(-self.horizon, self.node_to_index[node]) for node in last_tasks]
         self._propagate_backward_bounds_through_graph(queue)
 
+        self._computed = True
+
     def get_task_bounds(self) -> dict[Task, tuple[int, int, int, int]]:
         """Return computed bounds on task start and end.
 
@@ -128,6 +138,8 @@ class Cpm(Generic[Task, UnaryResource, CumulativeResource, NonRenewableResource]
             start_lower_bound, end_lower_bound, start_upper_bound, end_upper_bound
 
         """
+        if not self._computed:
+            self.compute_task_bounds()
         return {
             task: (
                 bounds.start_lower_bound,
@@ -139,10 +151,18 @@ class Cpm(Generic[Task, UnaryResource, CumulativeResource, NonRenewableResource]
         }
 
     def get_a_critical_path(self) -> list[Task]:
+        """Compute a critical path.
+
+        It takes into account no other constraints that precedence constraints.
+        It starts from a task without predecessor to a task without successor.
+
+        Returns:
+
+        """
+        if not self._computed:
+            self.compute_task_bounds()
         last_tasks = [
-            node
-            for node in self.graph_nx.nodes()
-            if len(nx.algorithms.descendants(self.graph_nx, node)) == 0
+            node for node, succs in self.successors.items() if len(succs) == 0
         ]
         critical_path = []
         preds = []
@@ -170,6 +190,45 @@ class Cpm(Generic[Task, UnaryResource, CumulativeResource, NonRenewableResource]
                     break
             preds = new_preds
         return critical_path[::-1]
+
+    def get_critical_subgraph(self) -> nx.DiGraph:
+        """Compute critical subgraph.
+
+        It includes all critical nodes.
+
+        Returns:
+            a subgraph *view* of precedence graph `self.graph_nx`
+            (so beware that attributes are shared with original graph)
+
+        """
+        if not self._computed:
+            self.compute_task_bounds()
+        last_tasks = [
+            node for node, succs in self.successors.items() if len(succs) == 0
+        ]
+        critical_nodes = set()
+        critical_nodes_to_review = []
+        # Init: critical nodes among last tasks
+        for node in last_tasks:
+            if self.map_node[node].end_lower_bound == self.makespan_cpm:
+                # critical last task
+                critical_nodes_to_review.append(node)
+        # Go backward from there
+        while len(critical_nodes_to_review) > 0:
+            critical_node = critical_nodes_to_review.pop()
+            critical_nodes.add(critical_node)
+            for node in self.immediate_predecessors[critical_node]:
+                if (
+                    self.map_node[node].start_lower_bound
+                    == self.map_node[node].start_upper_bound
+                    - self.horizon
+                    + self.makespan_cpm
+                    and self.map_node[node].end_lower_bound
+                    == self.map_node[critical_node].start_lower_bound
+                ):
+                    critical_nodes_to_review.append(node)
+
+        return self.graph_nx.subgraph(critical_nodes)
 
     def _propagate_forward_bounds_through_graph(self, queue):
         done = set()

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpm.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpm.py
@@ -1,0 +1,255 @@
+#  Copyright (c) 2022 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+"""CPM toc ompute lower/uppe bound on start/end of tasks"""
+
+import logging
+from dataclasses import dataclass
+from heapq import heapify, heappop, heappush
+from typing import Any, Generic, Optional
+
+import networkx as nx
+
+from discrete_optimization.generic_tasks_tools.allocation import UnaryResource
+from discrete_optimization.generic_tasks_tools.base import Task
+from discrete_optimization.generic_tasks_tools.cumulative_resource import (
+    CumulativeResource,
+)
+from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
+from discrete_optimization.generic_tasks_tools.generic_scheduling import (
+    GenericSchedulingProblem,
+)
+from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
+    NonRenewableResource,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Taskbounds:
+    start_lower_bound: Optional[int] = None
+    end_lower_bound: Optional[int] = None
+    start_upper_bound: Optional[int] = None
+    end_upper_bound: Optional[int] = None
+
+
+class Cpm(Generic[Task, UnaryResource, CumulativeResource, NonRenewableResource]):
+    """Propagator of bounds trough precedence graph according to minimum duration of each task.
+
+    For that we use:
+    - multimode-scheduling: we know all possible durations
+    - precedence: we use the precedence constraints
+
+    We first do a forward pass on all tasks in precedence graph for lower bounds and then a backward pass for upper bounds.
+
+    We start from lower bound 0 and upper bound horizon (problem horizon can be overriden).
+
+    This differs from classic CPM as we know that other non-precedence constraints can occur so that we cannot assume
+    end lower_bounds = end upper bound for sink tasks. So sink tasks end upper bound will be set to horizon instead.
+
+    For each task, we take best of propagated bound and existing problem bound on start/end
+    (via `problem.get_task_start_or_end_lower_bound()`).
+
+    Attributes:
+        horizon: if set, override `problem.get_makespan_upper_bound()`.
+
+    """
+
+    def __init__(
+        self,
+        problem: GenericSchedulingProblem[
+            Task, UnaryResource, CumulativeResource, NonRenewableResource
+        ],
+        horizon: Optional[int] = None,
+    ):
+        self.problem = problem
+        if horizon is None:
+            self.horizon = self.problem.get_makespan_upper_bound()
+        else:
+            self.horizon = horizon
+        self.graph_nx = self.problem.get_precedence_graph().to_networkx()
+        self.map_node: dict[Any, Taskbounds] = {
+            n: Taskbounds(None, None, None, None) for n in self.graph_nx.nodes()
+        }
+        self.node_to_index = {
+            node: i_node for i_node, node in enumerate(self.graph_nx.nodes())
+        }
+        self.index_to_node = {
+            i_node: node for node, i_node in self.node_to_index.items()
+        }
+        self.immediate_successors = {
+            node: set(nx.neighbors(self.graph_nx, node))
+            for node in self.graph_nx.nodes()
+        }
+        self.immediate_predecessors = {
+            node: set(self.graph_nx.predecessors(node))
+            for node in self.graph_nx.nodes()
+        }
+        self.predecessors = {
+            node: nx.algorithms.ancestors(self.graph_nx, node)
+            for node in self.graph_nx.nodes()
+        }
+
+    def compute_task_bounds(self) -> None:
+        # Forward pass for lower bounds
+        # starting nodes: without ancestors, start lower bound = 0
+        queue = [
+            (0, self.node_to_index[node])
+            for node in self.graph_nx.nodes()
+            if len(nx.algorithms.ancestors(self.graph_nx, node)) == 0
+        ]
+        self._propagate_forward_bounds_through_graph(queue)
+
+        # Check if horizon is sufficient for earliest finish date found
+        last_tasks = [
+            node
+            for node in self.graph_nx.nodes()
+            if len(nx.algorithms.descendants(self.graph_nx, node)) == 0
+        ]
+        # optimal makespan if there were no constraints apart from precedence
+        self.makespan_cpm = max(
+            self.map_node[task].end_lower_bound for task in last_tasks
+        )
+        if self.makespan_cpm > self.horizon:
+            raise RuntimeError(
+                f"The schedule cannot be done with given horizon {self.horizon}, as it is below the computed earliest finish date {self.makespan_cpm}"
+            )
+
+        # Backward pass for upper bounds
+        # starting nodes: without descendants, end upper bound = horizon
+        queue = [(-self.horizon, self.node_to_index[node]) for node in last_tasks]
+        self._propagate_backward_bounds_through_graph(queue)
+
+    def get_task_bounds(self) -> dict[Task, tuple[int, int, int, int]]:
+        """Return computed bounds on task start and end.
+
+        Returns:
+            start_lower_bound, end_lower_bound, start_upper_bound, end_upper_bound
+
+        """
+        return {
+            task: (
+                bounds.start_lower_bound,
+                bounds.end_lower_bound,
+                bounds.start_upper_bound,
+                bounds.end_upper_bound,
+            )
+            for task, bounds in self.map_node.items()
+        }
+
+    def get_a_critical_path(self) -> list[Task]:
+        last_tasks = [
+            node
+            for node in self.graph_nx.nodes()
+            if len(nx.algorithms.descendants(self.graph_nx, node)) == 0
+        ]
+        critical_path = []
+        preds = []
+        for node in last_tasks:
+            if self.map_node[node].end_lower_bound == self.makespan_cpm:
+                # critical last task
+                critical_path.append(node)
+                preds = self.immediate_predecessors[node]
+                cur_node = node
+                break
+        while len(preds) > 0:
+            new_preds = []
+            for node in preds:
+                if (
+                    self.map_node[node].start_lower_bound
+                    == self.map_node[node].start_upper_bound
+                    - self.horizon
+                    + self.makespan_cpm
+                    and self.map_node[node].end_lower_bound
+                    == self.map_node[cur_node].start_lower_bound
+                ):
+                    critical_path.append(node)
+                    new_preds = self.immediate_predecessors[node]
+                    cur_node = node
+                    break
+            preds = new_preds
+        return critical_path[::-1]
+
+    def _propagate_forward_bounds_through_graph(self, queue):
+        done = set()
+        heapify(queue)
+        while queue:
+            time, i_node = heappop(queue)
+            node = self.index_to_node[i_node]
+            if node in done:
+                # node already seen
+                continue
+            # update time to take into account problem bound
+            time = max(
+                time,
+                self.problem.get_task_start_or_end_lower_bound(
+                    task=node, start_or_end=StartOrEnd.START
+                ),
+            )
+            self.map_node[node].start_lower_bound = time
+            min_duration = min(
+                self.problem.get_task_mode_duration(task=node, mode=mode)
+                for mode in self.problem.get_task_modes(task=node)
+            )
+            # end lower bound : best of start lower bound + min duration and problem bound
+            self.map_node[node].end_lower_bound = max(
+                time + min_duration,
+                self.problem.get_task_start_or_end_lower_bound(
+                    task=node, start_or_end=StartOrEnd.END
+                ),
+            )
+            done.add(node)
+            next_nodes = self.immediate_successors[node]
+            for next_node in next_nodes:
+                if all(node in done for node in self.immediate_predecessors[next_node]):
+                    next_node_start_lower_bound = max(
+                        self.map_node[node].end_lower_bound
+                        for node in self.immediate_predecessors[next_node]
+                    )
+                    heappush(
+                        queue,
+                        (next_node_start_lower_bound, self.node_to_index[next_node]),
+                    )
+
+    def _propagate_backward_bounds_through_graph(self, queue):
+        done = set()
+        heapify(queue)
+        while queue:
+            time, i_node = heappop(queue)
+            node = self.index_to_node[i_node]
+            if node in done:
+                # node already seen
+                continue
+            # update time to take into account problem bound
+            eub = min(
+                -time,
+                self.problem.get_task_start_or_end_upper_bound(
+                    task=node, start_or_end=StartOrEnd.END
+                ),
+            )
+            self.map_node[node].end_upper_bound = eub
+            min_duration = min(
+                self.problem.get_task_mode_duration(task=node, mode=mode)
+                for mode in self.problem.get_task_modes(task=node)
+            )
+            # start upper bound: best of end upper bound - min_duration and problem bound
+            self.map_node[node].start_upper_bound = min(
+                eub - min_duration,
+                self.problem.get_task_start_or_end_upper_bound(
+                    task=node, start_or_end=StartOrEnd.START
+                ),
+            )
+            done.add(node)
+
+            next_nodes = self.immediate_predecessors[node]
+            for next_node in next_nodes:
+                if all(node in done for node in self.immediate_successors[next_node]):
+                    next_node_end_upper_bound = min(
+                        self.map_node[n].start_upper_bound
+                        for n in self.immediate_successors[next_node]
+                    )
+                    heappush(
+                        queue,
+                        (-next_node_end_upper_bound, self.node_to_index[next_node]),
+                    )

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto.py
@@ -30,13 +30,16 @@ from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
 from discrete_optimization.generic_tasks_tools.scheduling import (
     Task,
 )
+from discrete_optimization.generic_tasks_tools.solvers.cpm import Cpm
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.generic_scheduling import (
     GenericSchedulingCpSatSolver,
 )
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.multimode_scheduling import (
     SinglemodeSchedulingCpSatSolver,
 )
-from discrete_optimization.generic_tools.do_problem import Solution
+from discrete_optimization.generic_tools.do_problem import (
+    Solution,
+)
 from discrete_optimization.generic_tools.do_solver import WarmstartMixin
 
 logger = logging.getLogger(__name__)
@@ -158,6 +161,8 @@ class GenericSchedulingAutoCpSatSolver(
     """Variables tracking total consumption of each (unary, cumulative, or non-renewable) resource."""
     resource_consumption_variables_created = False
     """Flag telling whether 'resource_consumption_variables' have been created"""
+    use_cpm_for_task_bounds = False
+    """Flag telling whether cpm should be used to refine task bounds."""
 
     @property
     def needs_duration_variables(self) -> bool:
@@ -195,17 +200,62 @@ class GenericSchedulingAutoCpSatSolver(
         """
         return True
 
+    def compute_task_bounds(self) -> None:
+        """Compute tighter bounds for tasks.
+
+        - if `use_cpm_for_task_bounds`, propagate bounds forward and backward in the precedence by
+        using the min possible duration for the task.
+        - else only use min possible duration with 0, new_horizon (set by the solver in `self.get_makespan_upper_bound()`)
+
+        """
+        if self.use_cpm_for_task_bounds:
+            cpm = Cpm(problem=self.problem, horizon=self.get_makespan_upper_bound())
+            cpm.compute_task_bounds()
+            self.tasks_bounds = cpm.get_task_bounds()
+        else:
+            self.tasks_bounds = {}
+            for task in self.problem.tasks_list:
+                start_lower_bound = self.problem.get_task_start_or_end_lower_bound(
+                    task=task, start_or_end=StartOrEnd.START
+                )
+                end_upper_bound = min(
+                    # use current bound + new "horizon"
+                    self.problem.get_task_start_or_end_upper_bound(
+                        task=task, start_or_end=StartOrEnd.END
+                    ),
+                    self.get_makespan_upper_bound(),
+                )
+                min_duration = min(
+                    self.problem.get_task_mode_duration(task=task, mode=mode)
+                    for mode in self.problem.get_task_modes(task=task)
+                )
+                end_lower_bound = max(
+                    # use start_lower bound + min_durations
+                    self.problem.get_task_start_or_end_lower_bound(
+                        task=task, start_or_end=StartOrEnd.END
+                    ),
+                    start_lower_bound + min_duration,
+                )
+                start_upper_bound = min(
+                    # use end_upper_bound - min_durations
+                    self.problem.get_task_start_or_end_upper_bound(
+                        task=task, start_or_end=StartOrEnd.START
+                    ),
+                    end_upper_bound - min_duration,
+                )
+                self.tasks_bounds[task] = (
+                    start_lower_bound,
+                    end_lower_bound,
+                    start_upper_bound,
+                    end_upper_bound,
+                )
+
     def get_task_start_or_end_lower_bound(
         self, task: Task, start_or_end: StartOrEnd
     ) -> int:
         """Get a lower bound on start or end of a given task.
 
-        Default implementation:
-         - start: takes
-            - self.problem.get_task_start_or_end_upper_bound()
-        - end: best of
-            - self.problem.get_task_start_or_end_upper_bound()
-            - start_lower_bound + min(possible_durations)
+        Use either the bounds given in `__init__()` or computed via `compute_tasks_bounds()`.
 
         Args:
             task:
@@ -214,40 +264,21 @@ class GenericSchedulingAutoCpSatSolver(
         Returns:
 
         """
+        start_lower_bound, end_lower_bound, start_upper_bound, end_upper_bound = (
+            self.tasks_bounds[task]
+        )
         match start_or_end:
             case StartOrEnd.START:
-                # default to problem start lower bound
-                return self.problem.get_task_start_or_end_lower_bound(
-                    task=task, start_or_end=start_or_end
-                )
+                return start_lower_bound
             case _:
-                # deduce a bound from start lower bound and possible task durations
-                possible_durations = [
-                    self.problem.get_task_mode_duration(task=task, mode=mode)
-                    for mode in self.problem.get_task_modes(task=task)
-                ]
-                start_lower_bound = self.get_task_start_or_end_lower_bound(
-                    task=task, start_or_end=StartOrEnd.START
-                )
-                return max(
-                    self.problem.get_task_start_or_end_lower_bound(
-                        task=task, start_or_end=start_or_end
-                    ),
-                    start_lower_bound + min(possible_durations),
-                )
+                return end_lower_bound
 
     def get_task_start_or_end_upper_bound(
         self, task: Task, start_or_end: StartOrEnd
     ) -> int:
         """Get an upper bound on start or end of a given task.
 
-        Default implementation:
-        - end: takes best of
-            - self.problem.get_task_start_or_end_upper_bound()
-            - self.get_makespan_upper_bound()
-        - start: best of
-            - self.problem.get_task_start_or_end_upper_bound()
-            - end_upper_bound - min(possible_durations)
+        Use either the bounds given in `__init__()` or computed via `compute_tasks_bounds()`.
 
         Args:
             task:
@@ -256,34 +287,28 @@ class GenericSchedulingAutoCpSatSolver(
         Returns:
 
         """
+        start_lower_bound, end_lower_bound, start_upper_bound, end_upper_bound = (
+            self.tasks_bounds[task]
+        )
         match start_or_end:
-            case StartOrEnd.END:
-                # take into account the "new" horizon given by makespan upper bound
-                return min(
-                    self.problem.get_task_start_or_end_upper_bound(
-                        task=task, start_or_end=start_or_end
-                    ),
-                    self.get_makespan_upper_bound(),
-                )
+            case StartOrEnd.START:
+                return start_upper_bound
             case _:
-                # deduce a bound from upper bound on end and possible task durations
-                possible_durations = [
-                    self.problem.get_task_mode_duration(task=task, mode=mode)
-                    for mode in self.problem.get_task_modes(task=task)
-                ]
-                end_upper_bound = self.get_task_start_or_end_upper_bound(
-                    task=task, start_or_end=StartOrEnd.END
-                )
-                return min(
-                    self.problem.get_task_start_or_end_upper_bound(
-                        task=task, start_or_end=start_or_end
-                    ),
-                    end_upper_bound - min(possible_durations),
-                )
+                return end_upper_bound
 
-    def init_model(self, **kwargs: Any) -> None:
+    def init_model(
+        self,
+        tasks_bounds: Optional[dict[Task, tuple[int, int, int, int]]] = None,
+        **kwargs: Any,
+    ) -> None:
         """Init cp model and reset stored variables if any."""
         super().init_model(**kwargs)
+
+        # pre-compute tasks start/end bounds ?
+        if tasks_bounds is None:
+            self.compute_task_bounds()
+        else:
+            self.tasks_bounds = tasks_bounds
 
         self._reset_variables()
         self._create_variables()

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto.py
@@ -200,7 +200,12 @@ class GenericSchedulingAutoCpSatSolver(
     ) -> int:
         """Get a lower bound on start or end of a given task.
 
-        Default implementation: calls self.problem.get_task_start_or_end_lower_bound()
+        Default implementation:
+         - start: takes
+            - self.problem.get_task_start_or_end_upper_bound()
+        - end: best of
+            - self.problem.get_task_start_or_end_upper_bound()
+            - start_lower_bound + min(possible_durations)
 
         Args:
             task:
@@ -209,18 +214,40 @@ class GenericSchedulingAutoCpSatSolver(
         Returns:
 
         """
-        return self.problem.get_task_start_or_end_lower_bound(
-            task=task, start_or_end=start_or_end
-        )
+        match start_or_end:
+            case StartOrEnd.START:
+                # default to problem start lower bound
+                return self.problem.get_task_start_or_end_lower_bound(
+                    task=task, start_or_end=start_or_end
+                )
+            case _:
+                # deduce a bound from start lower bound and possible task durations
+                possible_durations = [
+                    self.problem.get_task_mode_duration(task=task, mode=mode)
+                    for mode in self.problem.get_task_modes(task=task)
+                ]
+                start_lower_bound = self.get_task_start_or_end_lower_bound(
+                    task=task, start_or_end=StartOrEnd.START
+                )
+                return max(
+                    self.problem.get_task_start_or_end_lower_bound(
+                        task=task, start_or_end=start_or_end
+                    ),
+                    start_lower_bound + min(possible_durations),
+                )
 
     def get_task_start_or_end_upper_bound(
         self, task: Task, start_or_end: StartOrEnd
     ) -> int:
         """Get an upper bound on start or end of a given task.
 
-        Default implementation: takes best of
-        - self.problem.get_task_start_or_end_upper_bound()
-        - self.get_makespan_upper_bound()
+        Default implementation:
+        - end: takes best of
+            - self.problem.get_task_start_or_end_upper_bound()
+            - self.get_makespan_upper_bound()
+        - start: best of
+            - self.problem.get_task_start_or_end_upper_bound()
+            - end_upper_bound - min(possible_durations)
 
         Args:
             task:
@@ -229,12 +256,30 @@ class GenericSchedulingAutoCpSatSolver(
         Returns:
 
         """
-        return min(
-            self.problem.get_task_start_or_end_upper_bound(
-                task=task, start_or_end=start_or_end
-            ),
-            self.get_makespan_upper_bound(),
-        )
+        match start_or_end:
+            case StartOrEnd.END:
+                # take into account the "new" horizon given by makespan upper bound
+                return min(
+                    self.problem.get_task_start_or_end_upper_bound(
+                        task=task, start_or_end=start_or_end
+                    ),
+                    self.get_makespan_upper_bound(),
+                )
+            case _:
+                # deduce a bound from upper bound on end and possible task durations
+                possible_durations = [
+                    self.problem.get_task_mode_duration(task=task, mode=mode)
+                    for mode in self.problem.get_task_modes(task=task)
+                ]
+                end_upper_bound = self.get_task_start_or_end_upper_bound(
+                    task=task, start_or_end=StartOrEnd.END
+                )
+                return min(
+                    self.problem.get_task_start_or_end_upper_bound(
+                        task=task, start_or_end=start_or_end
+                    ),
+                    end_upper_bound - min(possible_durations),
+                )
 
     def init_model(self, **kwargs: Any) -> None:
         """Init cp model and reset stored variables if any."""

--- a/tests/fjsp/solvers/test_cpm.py
+++ b/tests/fjsp/solvers/test_cpm.py
@@ -1,0 +1,83 @@
+#  Copyright (c) 2026 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+
+
+from discrete_optimization.fjsp.problem import Job
+from discrete_optimization.fjsp.solvers.cpsat_auto import (
+    FJobShopProblem,
+)
+from discrete_optimization.generic_tasks_tools.solvers.cpm import Cpm
+from discrete_optimization.jsp.problem import Subjob
+
+
+def test_cpm_1_critical_path():
+    problem = FJobShopProblem(
+        list_jobs=[
+            Job(
+                job_id=0,
+                sub_jobs=[
+                    [
+                        Subjob(machine_id=0, processing_time=1),
+                        Subjob(machine_id=1, processing_time=2),
+                    ],
+                    [
+                        Subjob(machine_id=0, processing_time=2),
+                        Subjob(machine_id=1, processing_time=1),
+                    ],
+                ],
+            ),
+            Job(
+                job_id=1,
+                sub_jobs=[
+                    [
+                        Subjob(machine_id=0, processing_time=1),
+                        Subjob(machine_id=1, processing_time=2),
+                    ],
+                    [
+                        Subjob(machine_id=0, processing_time=2),
+                        Subjob(machine_id=1, processing_time=3),
+                    ],
+                ],
+            ),
+        ]
+    )
+    cpm = Cpm(problem=problem)
+    assert len(cpm.get_a_critical_path()) == 2
+    assert len(cpm.get_critical_subgraph().nodes) == 2
+
+
+def test_cpm_2_critical_paths():
+    problem = FJobShopProblem(
+        list_jobs=[
+            Job(
+                job_id=0,
+                sub_jobs=[
+                    [
+                        Subjob(machine_id=0, processing_time=1),
+                        Subjob(machine_id=1, processing_time=2),
+                    ],
+                    [
+                        Subjob(machine_id=0, processing_time=2),
+                        Subjob(machine_id=1, processing_time=1),
+                    ],
+                ],
+            ),
+            Job(
+                job_id=1,
+                sub_jobs=[
+                    [
+                        Subjob(machine_id=0, processing_time=1),
+                        Subjob(machine_id=1, processing_time=2),
+                    ],
+                    [
+                        Subjob(machine_id=0, processing_time=1),
+                        Subjob(machine_id=1, processing_time=3),
+                    ],
+                ],
+            ),
+        ]
+    )
+    cpm = Cpm(problem=problem)
+    assert len(cpm.get_a_critical_path()) == 2
+    assert len(cpm.get_critical_subgraph().nodes) == 4

--- a/tests/fjsp/solvers/test_cpsat_auto.py
+++ b/tests/fjsp/solvers/test_cpsat_auto.py
@@ -26,7 +26,7 @@ from discrete_optimization.generic_tools.ortools_cpsat_tools import OrtoolsCpSat
 from discrete_optimization.generic_tools.result_storage.result_storage import (
     ResultStorage,
 )
-from discrete_optimization.jsp.problem import JobShopProblem
+from discrete_optimization.jsp.problem import JobShopProblem, Subjob
 
 logging.basicConfig(level=logging.INFO)
 
@@ -358,3 +358,44 @@ def test_cpsat_retrieve_stats_via_clb():
     # assert res.stats[-1]["bound"] == solver.solver.BestObjectiveBound()
     sol, _ = res.get_best_solution_fit()
     assert problem.satisfy(sol)
+
+
+def test_task_bounds():
+    problem = FJobShopProblem(
+        list_jobs=[
+            Job(
+                job_id=0,
+                sub_jobs=[
+                    [
+                        Subjob(machine_id=0, processing_time=1),
+                        Subjob(machine_id=1, processing_time=2),
+                    ],
+                    [
+                        Subjob(machine_id=0, processing_time=2),
+                        Subjob(machine_id=1, processing_time=1),
+                    ],
+                ],
+            ),
+            Job(
+                job_id=1,
+                sub_jobs=[
+                    [
+                        Subjob(machine_id=0, processing_time=1),
+                        Subjob(machine_id=1, processing_time=2),
+                    ],
+                    [
+                        Subjob(machine_id=0, processing_time=2),
+                        Subjob(machine_id=1, processing_time=3),
+                    ],
+                ],
+            ),
+        ]
+    )
+    solver = CpSatAutoFjspSolver(problem=problem)
+    solver.init_model()
+    assert (solver.tasks_bounds) == {
+        (0, 0): (0, 1, 7, 8),
+        (0, 1): (1, 2, 8, 9),
+        (1, 0): (0, 1, 6, 7),
+        (1, 1): (1, 3, 7, 9),
+    }

--- a/tests/generic_tasks_tools/solvers/cpsat/test_auto.py
+++ b/tests/generic_tasks_tools/solvers/cpsat/test_auto.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 
 import copy
 import logging
+import re
 from copy import deepcopy
-from typing import Iterable, Union
+from typing import Any, Iterable, Optional, Union
 
 import pytest
 
+from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
 from discrete_optimization.generic_tasks_tools.generic_scheduling import (
     GenericSchedulingProblem,
     GenericSchedulingSolution,
@@ -29,6 +31,8 @@ from discrete_optimization.generic_tools.do_problem import (
     ObjectiveDoc,
     ObjectiveHandling,
     ObjectiveRegister,
+    ParamsObjectiveFunction,
+    Problem,
     Solution,
     TypeObjective,
 )
@@ -213,6 +217,22 @@ class MyAutoCpsatSolver(
     ) -> MySolution:
         return MySolution(problem=self.problem, temp_sol=temp_sol)
 
+    def __init__(
+        self,
+        problem: Problem,
+        params_objective_function: Optional[ParamsObjectiveFunction] = None,
+        new_horizon: Optional[int] = None,
+        **kwargs: Any,
+    ):
+        super().__init__(problem, params_objective_function, **kwargs)
+        self.new_horizon = new_horizon
+
+    def get_makespan_upper_bound(self) -> int:
+        if self.new_horizon is None:
+            return super().get_makespan_upper_bound()
+        else:
+            return self.new_horizon
+
 
 def test_problem(caplog):
     problem = MyProblem()
@@ -393,3 +413,61 @@ def test_auto(objective):
     )
     sol, fit = res[0]
     assert sol.temp_sol.task_variables == bad_sol.temp_sol.task_variables
+
+
+def test_task_bounds_user():
+    problem = MyProblem()
+    solver = MyAutoCpsatSolver(problem=problem)
+    task_bounds = {"task-1": (2, 1, 3, 9), "task-2": (0, 7, 4, 10)}
+    solver.init_model(tasks_bounds=task_bounds)
+    assert solver.tasks_bounds == task_bounds
+    for task, (slb, elb, sub, eub) in task_bounds.items():
+        # start bounds
+        var = solver.start_or_end_variables[task, StartOrEnd.START]
+        m = re.match(r".*\(([0-9]*)..([0-9]*)\)", repr(var))
+        lb, ub = int(m[1]), int(m[2])
+        assert (lb, ub) == (slb, sub)
+        # end bounds
+        var = solver.start_or_end_variables[task, StartOrEnd.END]
+        m = re.match(r".*\(([0-9]*)..([0-9]*)\)", repr(var))
+        lb, ub = int(m[1]), int(m[2])
+        assert (lb, ub) == (elb, eub)
+
+
+def test_task_bounds_simple():
+    problem = MyProblem()
+    solver = MyAutoCpsatSolver(problem=problem, new_horizon=8)
+    solver.use_cpm_for_task_bounds = False
+    solver.init_model()
+    assert solver.tasks_bounds == {"task-1": (0, 1, 7, 8), "task-2": (0, 4, 4, 8)}
+
+    var = solver.start_or_end_variables["task-1", StartOrEnd.START]
+    m = re.match(r".*\(([0-9]*)..([0-9]*)\)", repr(var))
+    lb, ub = int(m[1]), int(m[2])
+    assert (lb, ub) == (0, 7)
+
+    var = solver.start_or_end_variables["task-1", StartOrEnd.END]
+    m = re.match(r".*\(([0-9]*)..([0-9]*)\)", repr(var))
+    lb, ub = int(m[1]), int(m[2])
+    assert (lb, ub) == (1, 8)
+
+
+def test_task_bounds_cpm():
+    problem = MyProblem()
+    solver = MyAutoCpsatSolver(problem=problem, new_horizon=8)
+    solver.use_cpm_for_task_bounds = True
+    solver.init_model()
+
+    task_bounds = {"task-1": (0, 1, 3, 4), "task-2": (1, 5, 4, 8)}
+    assert solver.tasks_bounds == task_bounds
+    for task, (slb, elb, sub, eub) in task_bounds.items():
+        # start bounds
+        var = solver.start_or_end_variables[task, StartOrEnd.START]
+        m = re.match(r".*\(([0-9]*)..([0-9]*)\)", repr(var))
+        lb, ub = int(m[1]), int(m[2])
+        assert (lb, ub) == (slb, sub)
+        # end bounds
+        var = solver.start_or_end_variables[task, StartOrEnd.END]
+        m = re.match(r".*\(([0-9]*)..([0-9]*)\)", repr(var))
+        lb, ub = int(m[1]), int(m[2])
+        assert (lb, ub) == (elb, eub)


### PR DESCRIPTION
The "CPM" (inspired by
discrete_optimization.rcpsp.solvers.cpm.CpmRcpspSolver) propagate bounds
through precedence graph.
- forward: lower bounds, starting from 0 with starting tasks
- backward: upper bounds, starting from horizon with ending tasks

If we forget about other constraints and set horizon to
max(end_lower_bounds of ending tasks), we get classical cpm and are able
to extract a critical path.

This can be used by cpsat auto to precompute tighter start/ends bounds to restrict the space for start/end variables,
according to the setting `use_cpm_for_task_bounds`.

It was already done by fjsp cpsat solver so we set
`use_cpm_for_task_bounds=True` for the corresponding cpsat auto solver.

As it could be possibly long to compute for big rcpsp problems, we let
the setting to Flase by default for now.

We let also the possibility to use previously computed bounds with the
argument `task_bounds` to give directly in `init_model()`.