### PR TITLE
Add skill mixin

### DIFF
--- a/src/discrete_optimization/coloring/solvers/cpsat.py
+++ b/src/discrete_optimization/coloring/solvers/cpsat.py
@@ -68,6 +68,7 @@ class CpSatColoringSolver(
     ] + WithStartingSolutionColoringSolver.hyperparameters
 
     at_most_one_unary_resource_per_task = True
+    exactly_one_unary_resource_per_task = True
     problem: ColoringProblem
     _nb_colors: int
 

--- a/src/discrete_optimization/fjsp/problem.py
+++ b/src/discrete_optimization/fjsp/problem.py
@@ -21,6 +21,11 @@ from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
     WithoutNonRenewableResourceProblem,
     WithoutNonRenewableResourceSolution,
 )
+from discrete_optimization.generic_tasks_tools.skill import (
+    NoSkill,
+    WithoutSkillProblem,
+    WithoutSkillSolution,
+)
 from discrete_optimization.generic_tools.do_problem import (
     ModeOptim,
     ObjectiveDoc,
@@ -34,13 +39,21 @@ from discrete_optimization.jsp.problem import Subjob, Task
 logger = logging.getLogger(__name__)
 
 
-CumulativeResource = int  # machine id
-Resource = CumulativeResource  # no other resource
+NonSkillCumulativeResource = int  # machine id
+CumulativeResource = NonSkillCumulativeResource  # no skill
+Resource = NonSkillCumulativeResource  # no other resource
 
 
 class FJobShopSolution(
     GenericSchedulingSolution[
-        Task, NoUnaryResource, CumulativeResource, NoNonRenewableResource
+        Task,
+        NoUnaryResource,
+        NoSkill,
+        NonSkillCumulativeResource,
+        NoNonRenewableResource,
+    ],
+    WithoutSkillSolution[
+        Task, NoUnaryResource, NonSkillCumulativeResource, NoUnaryResource
     ],
     WithoutNonRenewableResourceSolution[Task],
     WithoutAllocationSolution[Task],
@@ -86,7 +99,14 @@ class Job:
 
 class FJobShopProblem(
     GenericSchedulingProblem[
-        Task, NoUnaryResource, CumulativeResource, NoNonRenewableResource
+        Task,
+        NoUnaryResource,
+        NoSkill,
+        NonSkillCumulativeResource,
+        NoNonRenewableResource,
+    ],
+    WithoutSkillProblem[
+        Task, NoUnaryResource, NonSkillCumulativeResource, NoUnaryResource
     ],
     WithoutNonRenewableResourceProblem[Task],
     WithoutAllocationProblem[Task],
@@ -175,7 +195,7 @@ class FJobShopProblem(
             return 0
 
     @property
-    def cumulative_resources_list(self) -> list[CumulativeResource]:
+    def non_skill_cumulative_resources_list(self) -> list[CumulativeResource]:
         return list(range(self.n_machines))
 
     def get_resource_availabilities(

--- a/src/discrete_optimization/fjsp/solvers/cpsat_auto.py
+++ b/src/discrete_optimization/fjsp/solvers/cpsat_auto.py
@@ -6,9 +6,9 @@ import logging
 from typing import Any
 
 from discrete_optimization.fjsp.problem import (
-    CumulativeResource,
     FJobShopProblem,
     FJobShopSolution,
+    NonSkillCumulativeResource,
     Task,
 )
 from discrete_optimization.generic_tasks_tools.allocation import (
@@ -18,9 +18,13 @@ from discrete_optimization.generic_tasks_tools.allocation import (
 from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
     NoNonRenewableResource,
 )
+from discrete_optimization.generic_tasks_tools.skill import NoSkill
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.auto import (
     GenericSchedulingAutoCpSatSolver,
     TemporarySolution,
+)
+from discrete_optimization.generic_tasks_tools.solvers.cpsat.skill import (
+    WithoutSkillSchedulingCpSatSolver,
 )
 from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
     CategoricalHyperparameter,
@@ -31,7 +35,14 @@ logger = logging.getLogger(__name__)
 
 class CpSatAutoFjspSolver(
     GenericSchedulingAutoCpSatSolver[
-        Task, NoUnaryResource, CumulativeResource, NoNonRenewableResource
+        Task,
+        NoUnaryResource,
+        NoSkill,
+        NonSkillCumulativeResource,
+        NoNonRenewableResource,
+    ],
+    WithoutSkillSchedulingCpSatSolver[
+        Task, NoUnaryResource, NonSkillCumulativeResource, NoUnaryResource
     ],
 ):
     hyperparameters = [
@@ -61,7 +72,7 @@ class CpSatAutoFjspSolver(
         return self._max_time
 
     def convert_task_variables_to_solution(
-        self, temp_sol: TemporarySolution[Task, UnaryResource]
+        self, temp_sol: TemporarySolution[Task, UnaryResource, NoSkill]
     ) -> FJobShopSolution:
         schedule = [
             [

--- a/src/discrete_optimization/generic_tasks_tools/allocation.py
+++ b/src/discrete_optimization/generic_tasks_tools/allocation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from abc import abstractmethod
 from collections.abc import Hashable, Iterable
 from typing import Any, Generic, Optional, TypeVar
@@ -11,6 +12,8 @@ from discrete_optimization.generic_tasks_tools.base import (
     TasksSolution,
 )
 from discrete_optimization.generic_tools.cp_tools import SignEnum
+
+logger = logging.getLogger(__name__)
 
 UnaryResource = TypeVar("UnaryResource", bound=Hashable)
 
@@ -111,6 +114,21 @@ class AllocationSolution(TasksSolution[Task], Generic[Task, UnaryResource]):
             for task in tasks
             for unary_resource in unary_resources
         )
+
+    def check_allocation_consistency(self) -> bool:
+        for task in self.problem.tasks_list:
+            for unary_resource in self.problem.unary_resources_list:
+                if self.is_allocated(
+                    task=task, unary_resource=unary_resource
+                ) and not self.problem.is_compatible_task_unary_resource(
+                    task=task, unary_resource=unary_resource
+                ):
+                    logger.debug(
+                        f"Unary resource {unary_resource} is allocated to task {task} "
+                        "but it is not compatible with it."
+                    )
+                    return False
+        return True
 
 
 class AllocationProblem(TasksProblem[Task], Generic[Task, UnaryResource]):
@@ -308,3 +326,6 @@ class WithoutAllocationSolution(
 
     def is_allocated(self, task: Task, unary_resource: UnaryResource) -> bool:
         return False
+
+    def check_allocation_consistency(self) -> bool:
+        return True

--- a/src/discrete_optimization/generic_tasks_tools/calendar_resource.py
+++ b/src/discrete_optimization/generic_tasks_tools/calendar_resource.py
@@ -7,7 +7,7 @@ import logging
 from abc import abstractmethod
 from collections.abc import Hashable, Iterable
 from functools import cache
-from typing import Generic, Optional, TypeVar, Union
+from typing import Generic, Optional, TypeVar
 
 import numpy as np
 
@@ -267,7 +267,7 @@ class CalendarResourceSolution(SchedulingSolution[Task], Generic[Task, Resource]
 
     def compute_aggregated_calendar_resources_consumptions(
         self, weights: Optional[dict[Resource, int]] = None
-    ):
+    ) -> int:
         """Compute aggregated consumption of each calendar resource by the solution.
 
         Args:
@@ -323,9 +323,33 @@ class WithoutCalendarResourceSolution(
     def get_calendar_resource_consumption(self, resource: Resource, task: Task) -> int:
         raise ValueError(f"{resource} is not a calendar resource of the problem.")
 
+    def check_calendar_resource_capacity_constraint(self, resource: Resource) -> bool:
+        return True
+
+    def check_calendar_resource_capacity_constraints(
+        self, resources: Iterable[Resource]
+    ) -> bool:
+        return True
+
+    def check_all_calendar_resource_capacity_constraints(self) -> bool:
+        return True
+
+    def compute_aggregated_calendar_resources_consumptions(
+        self, weights: Optional[dict[Resource, int]] = None
+    ):
+        return 0
+
+    def compute_nb_calendar_resources_used(
+        self, weights: Optional[dict[Resource, int]] = None
+    ) -> int:
+        return 0
+
+    def compute_calendar_resources_consumptions(self) -> dict[Resource, int]:
+        return {}
+
 
 def convert_calendar_to_availability_intervals(
-    calendar: Union[int, list[int]], horizon: int
+    calendar: int | list[int], horizon: int
 ) -> list[tuple[int, int, int]]:
     """Convert a calendar into availability intervals.
 

--- a/src/discrete_optimization/generic_tasks_tools/cumulative_resource.py
+++ b/src/discrete_optimization/generic_tasks_tools/cumulative_resource.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Generic, Hashable, TypeVar, Union
+from typing import Generic, Hashable, TypeVar
 
 from discrete_optimization.generic_tasks_tools.base import Task
 from discrete_optimization.generic_tasks_tools.calendar_resource import (
@@ -18,7 +18,7 @@ from discrete_optimization.generic_tasks_tools.multimode_scheduling import (
 
 CumulativeResource = TypeVar("CumulativeResource", bound=Hashable)
 OtherCalendarResource = TypeVar("OtherCalendarResource", bound=Hashable)
-Resource = Union[CumulativeResource, OtherCalendarResource]
+Resource = CumulativeResource | OtherCalendarResource
 
 
 class CumulativeResourceProblem(

--- a/src/discrete_optimization/generic_tasks_tools/generic_scheduling.py
+++ b/src/discrete_optimization/generic_tasks_tools/generic_scheduling.py
@@ -1,19 +1,12 @@
 #  Copyright (c) 2026 AIRBUS and its affiliates.
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
-from typing import Generic, Union
+from typing import Generic
 
 from discrete_optimization.generic_tasks_tools.allocation import (
-    AllocationProblem,
-    AllocationSolution,
     UnaryResource,
 )
 from discrete_optimization.generic_tasks_tools.base import Task
-from discrete_optimization.generic_tasks_tools.cumulative_resource import (
-    CumulativeResource,
-    CumulativeResourceProblem,
-    CumulativeResourceSolution,
-)
 from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
     NonRenewableResource,
     NonRenewableResourceProblem,
@@ -23,16 +16,24 @@ from discrete_optimization.generic_tasks_tools.precedence_scheduling import (
     PrecedenceSchedulingProblem,
     PrecedenceSchedulingSolution,
 )
+from discrete_optimization.generic_tasks_tools.skill import (
+    NonSkillCumulativeResource,
+    Skill,
+    SkillProblem,
+    SkillSolution,
+)
 
-Resource = Union[CumulativeResource, UnaryResource]
+CumulativeResource = Skill | NonSkillCumulativeResource
+Resource = CumulativeResource | UnaryResource
 
 
 class GenericSchedulingProblem(
-    CumulativeResourceProblem[Task, CumulativeResource, UnaryResource],
+    SkillProblem[Task, UnaryResource, Skill, NonSkillCumulativeResource, UnaryResource],
     NonRenewableResourceProblem[Task, NonRenewableResource],
-    AllocationProblem[Task, UnaryResource],
     PrecedenceSchedulingProblem[Task],
-    Generic[Task, UnaryResource, CumulativeResource, NonRenewableResource],
+    Generic[
+        Task, UnaryResource, Skill, NonSkillCumulativeResource, NonRenewableResource
+    ],
 ):
     """Scheduling problem with all optional features
 
@@ -42,11 +43,14 @@ class GenericSchedulingProblem(
     - multimode: the tasks have several mode on which the duration depends
     - cumulative: the tasks consume cumulative resources according to the chosen mode
     - allocation: the tasks can have unary resources allocated to them
+    - skill: some cumulative resource are skills that are brought to tasks by allocated unary resources
     - non-renewable: the tasks consume non-renewable resources according to the chosen mode
     - precedence: precedence constraints between tasks
 
     Even though this class is generic but encompasses also more specific cases:
     - singlemode: actually only one mode per task
+    - no skills: if skills_list is empty
+    - no allocation: unary_resources is empty
     - no cumulative ressources: if resources_list list only unary resources
     - no calendar: resource capacity can be given as a constant on [0, horizon)
     - no non-renewable ressources: if non_renewable_resources_list empty
@@ -91,16 +95,19 @@ class GenericSchedulingProblem(
 
 
 class GenericSchedulingSolution(
-    CumulativeResourceSolution[Task, CumulativeResource, UnaryResource],
+    SkillSolution[
+        Task, UnaryResource, Skill, NonSkillCumulativeResource, UnaryResource
+    ],
     NonRenewableResourceSolution[Task, NonRenewableResource],
     PrecedenceSchedulingSolution[Task],
-    AllocationSolution[Task, UnaryResource],
-    Generic[Task, UnaryResource, CumulativeResource, NonRenewableResource],
+    Generic[
+        Task, UnaryResource, Skill, NonSkillCumulativeResource, NonRenewableResource
+    ],
 ):
     """Solution type associated to GenericSchedulingProblem."""
 
     problem: GenericSchedulingProblem[
-        Task, UnaryResource, CumulativeResource, NonRenewableResource
+        Task, UnaryResource, Skill, NonSkillCumulativeResource, NonRenewableResource
     ]
 
     def get_calendar_resource_consumption(self, resource: Resource, task: Task) -> int:

--- a/src/discrete_optimization/generic_tasks_tools/non_renewable_resource.py
+++ b/src/discrete_optimization/generic_tasks_tools/non_renewable_resource.py
@@ -216,3 +216,31 @@ class WithoutNonRenewableResourceSolution(
     """
 
     ...
+
+    def check_non_renewable_resource_capacity_constraint(
+        self, resource: NonRenewableResource
+    ) -> bool:
+        return True
+
+    def check_non_renewable_resource_capacity_constraints(
+        self, resources: Iterable[NonRenewableResource]
+    ):
+        return True
+
+    def check_all_non_renewable_resource_capacity_constraints(self) -> bool:
+        return True
+
+    def compute_non_renewable_resources_consumptions(
+        self,
+    ) -> dict[NonRenewableResource, int]:
+        return {}
+
+    def compute_aggregated_non_renewable_resources_consumptions(
+        self, weights: Optional[dict[NonRenewableResource, int]] = None
+    ):
+        return 0
+
+    def compute_nb_non_renewable_resources_used(
+        self, weights: Optional[dict[NonRenewableResource, int]] = None
+    ) -> int:
+        return 0

--- a/src/discrete_optimization/generic_tasks_tools/precedence.py
+++ b/src/discrete_optimization/generic_tasks_tools/precedence.py
@@ -77,3 +77,8 @@ class WithoutPrecedenceProblem(PrecedenceProblem[Task]):
 
     def get_precedence_constraints(self) -> dict[Task, Iterable[Task]]:
         return {}
+
+
+class WithoutPrecedenceSolution(PrecedenceSolution[Task]):
+    def check_precedence_constraints(self) -> bool:
+        return True

--- a/src/discrete_optimization/generic_tasks_tools/skill.py
+++ b/src/discrete_optimization/generic_tasks_tools/skill.py
@@ -1,0 +1,245 @@
+#  Copyright (c) 2026 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+"""Module containing mixins for skills.
+
+A skill is a cumulative resource which is attached to a unary resource.
+
+"""
+
+import logging
+from abc import abstractmethod
+from collections.abc import Hashable
+from functools import cache
+from typing import Generic, TypeVar
+
+from discrete_optimization.generic_tasks_tools.allocation import (
+    AllocationProblem,
+    AllocationSolution,
+    UnaryResource,
+)
+from discrete_optimization.generic_tasks_tools.base import Task
+from discrete_optimization.generic_tasks_tools.cumulative_resource import (
+    CumulativeResourceProblem,
+    CumulativeResourceSolution,
+    OtherCalendarResource,
+)
+
+logger = logging.getLogger(__name__)
+
+Skill = TypeVar("Skill", bound=Hashable)
+NonSkillCumulativeResource = TypeVar("NonSkillCumulativeResource", bound=Hashable)
+CumulativeResource = Skill | NonSkillCumulativeResource
+Resource = CumulativeResource | OtherCalendarResource
+
+
+class SkillProblem(
+    CumulativeResourceProblem[Task, CumulativeResource, OtherCalendarResource],
+    AllocationProblem[Task, UnaryResource],
+    Generic[
+        Task, UnaryResource, Skill, NonSkillCumulativeResource, OtherCalendarResource
+    ],
+):
+    @property
+    @abstractmethod
+    def skills_list(self) -> list[Skill]:
+        """List of skills needed by tasks and brought by unary resources."""
+        ...
+
+    @property
+    @abstractmethod
+    def non_skill_cumulative_resources_list(self) -> list[Skill]:
+        """List of cumulative resources that are not skills."""
+        ...
+
+    @property
+    def cumulative_resources_list(self) -> list[CumulativeResource]:
+        return self.non_skill_cumulative_resources_list + self.skills_list
+
+    @abstractmethod
+    def get_unary_resource_skill_value(
+        self, unary_resource: UnaryResource, skill: Skill
+    ) -> int:
+        """Skill value of given resource for given skill."""
+        ...
+
+    @cache
+    def get_skills_of_task(self, task: Task) -> set[Skill]:
+        return {
+            skill
+            for skill in self.skills_list
+            if any(
+                self.get_cumulative_resource_consumption(
+                    task=task, resource=skill, mode=mode
+                )
+                > 0
+                for mode in self.get_task_modes(task=task)
+            )
+        }
+
+    @cache
+    def get_unary_resource_with_skill(self, skill: Skill) -> set[UnaryResource]:
+        return {
+            unary_resource
+            for unary_resource in self.unary_resources_list
+            if self.get_unary_resource_skill_value(
+                unary_resource=unary_resource, skill=skill
+            )
+            > 0
+        }
+
+    @cache
+    def get_skills_of_unary_resource(self, unary_resource: UnaryResource) -> set[Skill]:
+        return {
+            skill
+            for skill in self.skills_list
+            if self.get_unary_resource_skill_value(
+                unary_resource=unary_resource, skill=skill
+            )
+            > 0
+        }
+
+    def update_skills(self):
+        self.get_skills_of_task.cache_clear()
+        self.get_unary_resource_with_skill.cache_clear()
+        self.get_skills_of_unary_resource.cache_clear()
+
+
+class SkillSolution(
+    CumulativeResourceSolution[Task, CumulativeResource, OtherCalendarResource],
+    AllocationSolution[Task, UnaryResource],
+    Generic[
+        Task, UnaryResource, Skill, NonSkillCumulativeResource, OtherCalendarResource
+    ],
+):
+    problem: SkillProblem[
+        Task, UnaryResource, Skill, NonSkillCumulativeResource, OtherCalendarResource
+    ]
+
+    @abstractmethod
+    def is_skill_used(
+        self, task: Task, unary_resource: UnaryResource, skill: Skill
+    ) -> bool:
+        """Tell whether the given skill from given unary_resource is used in given task.
+
+        If `True`, `self.is_allocated(task, unary_resource)` must also be `True`.
+        If the skill is not needed by the task or not in unary_resource skills, should return False.
+
+        """
+        ...
+
+    def get_skill_value_on_task(self, task: Task, skill: Skill) -> int:
+        return sum(
+            self.problem.get_unary_resource_skill_value(
+                unary_resource=unary_resource, skill=skill
+            )
+            for unary_resource in self.problem.unary_resources_list
+            if self.is_skill_used(task=task, unary_resource=unary_resource, skill=skill)
+        )
+
+    def check_skill_constraint(
+        self, task: Task, skill: Skill, exact: bool = False, slack: int = 0
+    ) -> bool:
+        value_required = self.get_calendar_resource_consumption(
+            task=task, resource=skill
+        )
+        if value_required == 0:
+            return True
+        else:
+            value_from_unary_resources = self.get_skill_value_on_task(
+                task=task, skill=skill
+            )
+            if value_from_unary_resources < value_required:
+                logger.debug(
+                    f"Violation of skill constraint for task {task} and skill {skill}"
+                )
+                return False
+            if exact and value_from_unary_resources > value_required + slack:
+                logger.debug(
+                    f"Violation of exact skill constraint for task {task} and skill {skill}"
+                )
+                return False
+            else:
+                return True
+
+    def check_skill_constraints(self, exact: bool = False, slack: int = 0) -> bool:
+        return all(
+            self.check_skill_constraint(
+                task=task, skill=skill, exact=exact, slack=slack
+            )
+            for task in self.problem.tasks_list
+            for skill in self.problem.skills_list
+        )
+
+    def check_skill_usage_and_allocation_consistency(self) -> bool:
+        for task in self.problem.tasks_list:
+            for unary_resource in self.problem.unary_resources_list:
+                is_allocated = self.is_allocated(
+                    task=task, unary_resource=unary_resource
+                )
+                for skill in self.problem.skills_list:
+                    is_skill_used = self.is_skill_used(
+                        task=task, unary_resource=unary_resource, skill=skill
+                    )
+                    if is_allocated < is_skill_used:
+                        logger.debug(
+                            f"Skill {skill} from unary_resource {unary_resource} is used for task {task}, "
+                            "but the unary_resource is not allocated to the task."
+                        )
+                        return False
+                    has_skill = (
+                        self.problem.get_unary_resource_skill_value(
+                            unary_resource=unary_resource, skill=skill
+                        )
+                        > 0
+                    )
+                    if is_skill_used > has_skill:
+                        logger.debug(
+                            f"Skill {skill} from unary_resource {unary_resource} is used for task {task}, "
+                            "but the unary_resource has not this skill."
+                        )
+                        return False
+
+        return True
+
+
+NoSkill = None
+
+
+class WithoutSkillProblem(
+    SkillProblem[
+        Task, UnaryResource, NoSkill, NonSkillCumulativeResource, OtherCalendarResource
+    ],
+    Generic[Task, UnaryResource, NonSkillCumulativeResource, OtherCalendarResource],
+):
+    @property
+    def skills_list(self) -> list[Skill]:
+        return []
+
+    def get_unary_resource_skill_value(
+        self, unary_resource: UnaryResource, skill: Skill
+    ) -> int:
+        return 0
+
+
+class WithoutSkillSolution(
+    SkillSolution[
+        Task, UnaryResource, NoSkill, NonSkillCumulativeResource, OtherCalendarResource
+    ],
+    Generic[Task, UnaryResource, NonSkillCumulativeResource, OtherCalendarResource],
+):
+    def is_skill_used(
+        self, task: Task, unary_resource: UnaryResource, skill: Skill
+    ) -> bool:
+        return False
+
+    def check_skill_constraint(
+        self, task: Task, skill: NoSkill, exact: bool = False, slack: int = 0
+    ) -> bool:
+        return True
+
+    def check_skill_constraints(self, exact: bool = False, slack: int = 0) -> bool:
+        return True
+
+    def check_skill_usage_and_allocation_consistency(self) -> bool:
+        return True

--- a/src/discrete_optimization/generic_tasks_tools/skill.py
+++ b/src/discrete_optimization/generic_tasks_tools/skill.py
@@ -19,6 +19,9 @@ from discrete_optimization.generic_tasks_tools.allocation import (
     UnaryResource,
 )
 from discrete_optimization.generic_tasks_tools.base import Task
+from discrete_optimization.generic_tasks_tools.calendar_resource import (
+    merge_resources_availability_intervals,
+)
 from discrete_optimization.generic_tasks_tools.cumulative_resource import (
     CumulativeResourceProblem,
     CumulativeResourceSolution,
@@ -98,6 +101,27 @@ class SkillProblem(
             )
             > 0
         }
+
+    def compute_skill_availabilities(self, skill: Skill) -> list[tuple[int, int, int]]:
+        """Deduce skill availabilities from unary_resource availabilities and skill values."""
+        return merge_resources_availability_intervals(
+            intervals_per_resource=[
+                [
+                    (start, end, int(is_present) * skill_value)
+                    for (start, end, is_present) in self.get_resource_availabilities(
+                        resource=unary_resource
+                    )
+                ]
+                for unary_resource in self.unary_resources_list
+                if (
+                    skill_value := self.get_unary_resource_skill_value(
+                        unary_resource=unary_resource, skill=skill
+                    )
+                )
+                > 0
+            ],
+            horizon=self.get_makespan_upper_bound(),
+        )
 
     def update_skills(self):
         self.get_skills_of_task.cache_clear()

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpm.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpm.py
@@ -22,6 +22,10 @@ from discrete_optimization.generic_tasks_tools.generic_scheduling import (
 from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
     NonRenewableResource,
 )
+from discrete_optimization.generic_tasks_tools.skill import (
+    NonSkillCumulativeResource,
+    Skill,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +63,7 @@ class Cpm(Generic[Task, UnaryResource, CumulativeResource, NonRenewableResource]
     def __init__(
         self,
         problem: GenericSchedulingProblem[
-            Task, UnaryResource, CumulativeResource, NonRenewableResource
+            Task, UnaryResource, Skill, NonSkillCumulativeResource, NonRenewableResource
         ],
         horizon: Optional[int] = None,
     ):

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/allocation.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/allocation.py
@@ -1,7 +1,7 @@
 #  Copyright (c) 2026 AIRBUS and its affiliates.
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
-
+import logging
 from abc import abstractmethod
 from enum import Enum
 from typing import Any, Iterable, Optional
@@ -17,6 +17,8 @@ from discrete_optimization.generic_tasks_tools.base import Task
 from discrete_optimization.generic_tasks_tools.solvers.utils import is_a_trivial_zero
 from discrete_optimization.generic_tools.cp_tools import SignEnum
 from discrete_optimization.generic_tools.ortools_cpsat_tools import OrtoolsCpSatSolver
+
+logger = logging.getLogger(__name__)
 
 
 class AllocationCpSatSolver(
@@ -36,6 +38,8 @@ class AllocationCpSatSolver(
     Default to False, ie several resources allowed per task.
 
     """
+    exactly_one_unary_resource_per_task = False
+    """Whether enforcing exactly one resource allocated to each task."""
 
     allocation_changes_variables_created = False
     """Flag telling whether 'allocation changes variables' have been created"""
@@ -49,8 +53,6 @@ class AllocationCpSatSolver(
     """Flag telling whether 'done variables' have been created"""
     done_variables: dict[Task, IntVar]
     """Variables tracking whether a task has at least one unary resource allocated."""
-    at_most_one_unary_resource_per_task_constraints_added = False
-    """Flag telling whether constraints ensuring at most one unary resource per task have been created"""
 
     @property
     def subset_tasks_of_interest(self) -> Iterable[Task]:
@@ -90,7 +92,6 @@ class AllocationCpSatSolver(
         self.used_variables = {}
         self.done_variables_created = False
         self.done_variables_created = {}
-        self.at_most_one_unary_resource_per_task_constraints_added = False
 
     @abstractmethod
     def get_task_unary_resource_is_present_variable(
@@ -255,8 +256,6 @@ class AllocationCpSatSolver(
                 ]
                 if len(list_is_present_variables) > 0:
                     if self.at_most_one_unary_resource_per_task:
-                        if not self.at_most_one_unary_resource_per_task_constraints_added:
-                            self.cp_model.add_at_most_one(list_is_present_variables)
                         nb_teams_allocated_to_task = sum(list_is_present_variables)
                         self.cp_model.add(
                             nb_teams_allocated_to_task == 1
@@ -269,18 +268,25 @@ class AllocationCpSatSolver(
                 else:
                     self.cp_model.add(done == 0)
             self.done_variables_created = True
-            if self.at_most_one_unary_resource_per_task:
-                self.at_most_one_unary_resource_per_task_constraints_added = True
 
-    def add_at_most_one_unary_resource_per_task_constraints(self):
-        """Add constraints to cp model so that no more than one unary resource is allocated per task.
+    def add_unary_resources_per_task_constraints(self):
+        """Add constraints on number min/max of allocated resources per task.
 
-        Calling method avoid recreating the constraint if already done (e.g. when calling `create_done_variables()`)
+        According to options `at_most_one_unary_resource_per_task` and `exactly_one_unary_resource_per_task`.
 
         """
         if (
-            self.at_most_one_unary_resource_per_task
-            and not self.at_most_one_unary_resource_per_task_constraints_added
+            self.exactly_one_unary_resource_per_task
+            and not self.at_most_one_unary_resource_per_task
+        ):
+            # warning if not exactly => at_most
+            logger.warning(
+                "`at_most_one_unary_resource_per_task` is False while `exactly_one_unary_resource_per_task` is True. "
+                "`exactly_one_unary_resource_per_task` will take the precedence."
+            )
+        if (
+            self.exactly_one_unary_resource_per_task
+            or self.at_most_one_unary_resource_per_task
         ):
             for task in self.subset_tasks_of_interest:
                 list_is_present_variables = [
@@ -296,10 +302,16 @@ class AllocationCpSatSolver(
                         )
                     )
                 ]
-                if len(list_is_present_variables) > 0:
+                if (
+                    len(list_is_present_variables) > 0
+                    and self.exactly_one_unary_resource_per_task
+                ):
+                    self.cp_model.add_exactly_one(list_is_present_variables)
+                elif (
+                    len(list_is_present_variables) > 1
+                    and self.at_most_one_unary_resource_per_task
+                ):
                     self.cp_model.add_at_most_one(list_is_present_variables)
-
-            self.at_most_one_unary_resource_per_task_constraints_added = True
 
     def get_nb_tasks_done_variable(self) -> Any:
         self.create_done_variables()

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto.py
@@ -175,6 +175,7 @@ class GenericSchedulingAutoCpSatSolver(
     """Whether using energy constraints."""
     keep_only_most_nested_energy_constraints = True
     """Whether to keep only most nested subgraphs for energy constraints."""
+    # Calendar constraints settings
 
     # cpsat variables
     start_or_end_variables: dict[tuple[Task, StartOrEnd], LinearExprT]

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto.py
@@ -130,6 +130,11 @@ class GenericSchedulingAutoCpSatSolver(
             name="avoid_interval_optional", choices=[True, False], default=True
         ),
         CategoricalHyperparameter(
+            name="add_redundant_skill_cumulative_constraints",
+            choices=[True, False],
+            default=False,
+        ),
+        CategoricalHyperparameter(
             name="use_cpm_for_task_bounds", choices=[True, False], default=False
         ),
         CategoricalHyperparameter(
@@ -176,6 +181,13 @@ class GenericSchedulingAutoCpSatSolver(
     keep_only_most_nested_energy_constraints = True
     """Whether to keep only most nested subgraphs for energy constraints."""
     # Calendar constraints settings
+    add_redundant_skill_cumulative_constraints = False
+    """Whether adding redundant calendar cumulative constraints on skills.
+
+    These constraints are redundant with the calendar constraints on unary_resources
+    as the calendar for a skill is deduce from unary_resource calendars.
+
+    """
 
     # cpsat variables
     start_or_end_variables: dict[tuple[Task, StartOrEnd], LinearExprT]
@@ -234,7 +246,10 @@ class GenericSchedulingAutoCpSatSolver(
         Returns:
 
         """
-        return True
+        if resource in self.problem.skills_list:
+            return self.add_redundant_skill_cumulative_constraints
+        else:
+            return True
 
     def compute_task_bounds(self) -> None:
         """Compute tighter bounds for tasks.
@@ -340,12 +355,17 @@ class GenericSchedulingAutoCpSatSolver(
         duplicate_start_var_per_mode: Optional[bool] = None,
         use_energy_constraints: Optional[bool] = None,
         keep_only_most_nested_energy_constraints: Optional[bool] = None,
+        add_redundant_skill_cumulative_constraints: Optional[bool] = None,
         **kwargs: Any,
     ) -> None:
         """Init cp model and reset stored variables if any."""
         super().init_model(**kwargs)
 
         # update default settings
+        if add_redundant_skill_cumulative_constraints is not None:
+            self.add_redundant_skill_cumulative_constraints = (
+                add_redundant_skill_cumulative_constraints
+            )
         if use_cpm_for_task_bounds is not None:
             self.use_cpm_for_task_bounds = use_cpm_for_task_bounds
         if use_energy_constraints is not None:

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto.py
@@ -6,7 +6,7 @@ from abc import abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Generic, Optional, Union
+from typing import Any, Generic, Optional
 
 import networkx as nx
 from ortools.sat.python.cp_model import (
@@ -30,6 +30,10 @@ from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
 )
 from discrete_optimization.generic_tasks_tools.scheduling import (
     Task,
+)
+from discrete_optimization.generic_tasks_tools.skill import (
+    NonSkillCumulativeResource,
+    Skill,
 )
 from discrete_optimization.generic_tasks_tools.solvers.cpm import Cpm
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.generic_scheduling import (
@@ -76,14 +80,14 @@ class Objective(Enum):
 
 
 @dataclass
-class TaskVariable(Generic[UnaryResource]):
+class TaskVariable(Generic[UnaryResource, Skill]):
     """Task characteristics found by a cpsat solution."""
 
     start: int  # start time of the task
     end: int  # end time of the task
     mode: int  # chosen mode for the task
-    allocated: list[UnaryResource] = field(
-        default_factory=list
+    allocated: dict[UnaryResource, set[Skill]] = field(
+        default_factory=dict
     )  # resources allocated to the task
     info: dict[str, Any] = field(
         default_factory=dict
@@ -91,19 +95,19 @@ class TaskVariable(Generic[UnaryResource]):
 
 
 @dataclass
-class TemporarySolution(Generic[Task, UnaryResource]):
+class TemporarySolution(Generic[Task, UnaryResource, Skill]):
     """Temporary format for a cpsat solution."""
 
-    task_variables: dict[Task, TaskVariable[UnaryResource]]
+    task_variables: dict[Task, TaskVariable[UnaryResource, Skill]]
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
-AnyResource = Union[NonRenewableResource, UnaryResource, CumulativeResource]
+AnyResource = NonRenewableResource | UnaryResource | Skill | NonSkillCumulativeResource
 
 
 class GenericSchedulingAutoCpSatSolver(
     GenericSchedulingCpSatSolver[
-        Task, UnaryResource, CumulativeResource, NonRenewableResource
+        Task, UnaryResource, Skill, NonSkillCumulativeResource, NonRenewableResource
     ],
     WarmstartMixin,
 ):
@@ -161,9 +165,6 @@ class GenericSchedulingAutoCpSatSolver(
     # Task start/end bounds settings
     use_cpm_for_task_bounds = False
     """Flag telling whether cpm should be used to refine task bounds."""
-    # Allocation settings
-    exactly_one_unary_resource_per_task = False
-    """Whether enforcing exactly one resource allocated to each task."""
     # Multimode settings
     duplicate_start_var_per_mode = False
     """Whether adding a start variable for each task mode."""
@@ -184,6 +185,7 @@ class GenericSchedulingAutoCpSatSolver(
     modes_start_variables: dict[Task, dict[int, LinearExprT]]
     allocation_is_present: dict[Task, dict[UnaryResource, LinearExprT]]
     allocation_intervals: dict[Task, dict[UnaryResource, IntervalVar]]
+    skill_variables: dict[Task, dict[UnaryResource, dict[Skill, LinearExprT]]]
     demand_variables: dict[Task, dict[AnyResource, LinearExprT]]
     energy_variables: dict[Task, dict[AnyResource, LinearExprT]]
     all_used_variables: dict[AnyResource, IntVar]
@@ -379,6 +381,7 @@ class GenericSchedulingAutoCpSatSolver(
         self.energy_variables = {}
         self.allocation_is_present = {}
         self.allocation_intervals = {}
+        self.skill_variables = {}
 
         self.all_used_variables_created = False
         self.all_used_variables = {}
@@ -391,6 +394,7 @@ class GenericSchedulingAutoCpSatSolver(
         if self.needs_duration_variables or self.needs_task_interval:
             self._create_task_duration_and_interval_variables()
         self._create_allocation_variables()
+        self._create_skill_variables()
         if self.avoid_interval_optional:
             self._create_demand_variables()
         if self.use_energy_constraints:
@@ -529,6 +533,64 @@ class GenericSchedulingAutoCpSatSolver(
                         name=f"interval_mode_{task}_{mode}",
                     )
                 )
+
+    def _create_skill_variables(self):
+        for task in self.problem.tasks_list:
+            skills_of_task = self.problem.get_skills_of_task(task)
+            if len(skills_of_task) == 0:
+                # no skill usage to track
+                continue
+            self.skill_variables[task] = {}
+            for unary_resource in self.problem.unary_resources_list:
+                if self.is_compatible_task_unary_resource(
+                    task=task, unary_resource=unary_resource
+                ):
+                    self.skill_variables[task][unary_resource] = {}
+                    is_allocated = self.get_task_unary_resource_is_present_variable(
+                        task=task, unary_resource=unary_resource
+                    )
+                    skills_of_unary_resource = (
+                        self.problem.get_skills_of_unary_resource(unary_resource)
+                    )
+
+                    common_skills = skills_of_task.intersection(
+                        skills_of_unary_resource
+                    )
+                    for skill in common_skills:
+                        if len(common_skills) == 1:
+                            self.skill_variables[task][unary_resource][skill] = (
+                                is_allocated
+                            )
+                        else:
+                            skill_var = self.cp_model.new_bool_var(
+                                name=f"skill_{task}_{skill}_{unary_resource}"
+                            )
+                            self.skill_variables[task][unary_resource][skill] = (
+                                skill_var
+                            )
+                            # no skill used if not allocated
+                            self.cp_model.add(skill_var <= is_allocated)
+
+                    # constraints on skill variables due to options
+                    if (
+                        len(common_skills) > 1
+                    ):  # next constraints are useless if skill_var == is_allocated
+                        if self.use_only_skill_to_allocate:
+                            if self.use_only_one_skill_per_task:
+                                # allocation => exactly one skill used
+                                self.cp_model.add_exactly_one(
+                                    self.skill_variables[task][unary_resource].values()
+                                ).only_enforce_if(is_allocated)
+                            else:
+                                # allocation => at least one skill used
+                                self.cp_model.add_at_least_one(
+                                    self.skill_variables[task][unary_resource].values()
+                                ).only_enforce_if(is_allocated)
+                        elif self.use_only_one_skill_per_task:
+                            # at most one skill from each resource used for a given task
+                            self.cp_model.add_at_most_one(
+                                self.skill_variables[task][unary_resource].values()
+                            )
 
     def _create_demand_variables(self):
         for task in self.problem.tasks_list:
@@ -688,7 +750,7 @@ class GenericSchedulingAutoCpSatSolver(
 
     def _create_mode_resource_used_variable(
         self,
-        resource: Union[Resource, NonRenewableResource],
+        resource: Resource | NonRenewableResource,
         conso_fn: Callable[[Task, int], int],
     ) -> IntVar:
         used = self.cp_model.new_bool_var(f"used_{resource}")
@@ -869,26 +931,14 @@ class GenericSchedulingAutoCpSatSolver(
         # precedence
         self.create_precedence_constraints()
         # at most or exactly one resource allocated per task?
-        self._add_unary_resources_per_task_constraints()
+        self.add_unary_resources_per_task_constraints()
+        # skill value per task constraints
+        self.create_fine_skill_constraints()
+        self.create_coarse_skill_constraints()  # redundant
         # energy constraints
         if self.use_energy_constraints:
             branches = self.prepare_energy_constraints()
             self.create_energy_constraints(branches=branches)
-
-    def _add_unary_resources_per_task_constraints(self) -> None:
-        if self.exactly_one_unary_resource_per_task:
-            if not self.at_most_one_unary_resource_per_task:
-                logger.warning(
-                    "`at_most_one_unary_resource_per_task` False `exactly_one_unary_resource_per_task` set to True. "
-                    "`exactly_one_unary_resource_per_task` will take the precedence."
-                )
-
-            for is_allocated_task_vars_mapping in self.allocation_is_present.values():
-                self.cp_model.add_exactly_one(is_allocated_task_vars_mapping.values())
-                # avoid adding at most constraint when creating done variables
-                self.at_most_one_unary_resource_per_task_constraints_added = True
-        elif self.at_most_one_unary_resource_per_task:
-            self.add_at_most_one_unary_resource_per_task_constraints()
 
     def _set_objective(self) -> None:
         objective = None
@@ -990,9 +1040,17 @@ class GenericSchedulingAutoCpSatSolver(
             else:
                 raise e
 
+    def get_skill_variable(
+        self, task: Task, unary_resource: UnaryResource, skill: Skill
+    ) -> LinearExprT:
+        try:
+            return self.skill_variables[task][unary_resource][skill]
+        except KeyError:
+            return 0
+
     def retrieve_tasks_variables(
         self, cpsolvercb: CpSolverSolutionCallback
-    ) -> TemporarySolution[Task, UnaryResource]:
+    ) -> TemporarySolution[Task, UnaryResource, Skill]:
         """Construct each task variable from the cpsat solver internal solution.
 
         It will be called each time the cpsat solver find a new solution.
@@ -1022,13 +1080,26 @@ class GenericSchedulingAutoCpSatSolver(
                 for mode in modes:
                     if cpsolvercb.Value(self.modes_is_present[task][mode]):
                         break
-            allocated = [
-                unary_resource
+
+            def get_skill_used(task: Task, unary_resource: UnaryResource) -> set[Skill]:
+                try:
+                    skill_variables = self.skill_variables[task][unary_resource]
+                except KeyError:
+                    return set()
+                else:
+                    return {
+                        skill
+                        for skill, skill_var in skill_variables.items()
+                        if cpsolvercb.Value(skill_var)
+                    }
+
+            allocated = {
+                unary_resource: get_skill_used(task=task, unary_resource=unary_resource)
                 for unary_resource, is_allocated_var in self.allocation_is_present[
                     task
                 ].items()
                 if cpsolvercb.Value(is_allocated_var)
-            ]
+            }
             task_variables[task] = TaskVariable(
                 start=start, end=end, mode=mode, allocated=allocated
             )
@@ -1042,7 +1113,7 @@ class GenericSchedulingAutoCpSatSolver(
 
     def set_warm_start(self, solution: Solution) -> None:
         solution: GenericSchedulingSolution[
-            Task, UnaryResource, CumulativeResource, NonRenewableResource
+            Task, UnaryResource, Skill, NonSkillCumulativeResource, NonRenewableResource
         ]
         # warm start cp_model
         self.cp_model.clear_hints()
@@ -1079,9 +1150,9 @@ class GenericSchedulingAutoCpSatSolver(
 
     @abstractmethod
     def convert_task_variables_to_solution(
-        self, temp_sol: TemporarySolution[Task, UnaryResource]
+        self, temp_sol: TemporarySolution[Task, UnaryResource, Skill]
     ) -> GenericSchedulingSolution[
-        Task, UnaryResource, CumulativeResource, NonRenewableResource
+        Task, UnaryResource, Skill, NonSkillCumulativeResource, NonRenewableResource
     ]:
         """Convert solution from autosolver format into do format.
 
@@ -1212,7 +1283,7 @@ class GenericSchedulingAutoCpSatSolver(
 
 class SinglemodeGenericSchedulingAutoCpSatSolver(
     GenericSchedulingAutoCpSatSolver[
-        Task, UnaryResource, CumulativeResource, NonRenewableResource
+        Task, UnaryResource, Skill, NonSkillCumulativeResource, NonRenewableResource
     ],
     SinglemodeSchedulingCpSatSolver[Task],
 ):

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/generic_scheduling.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/generic_scheduling.py
@@ -10,18 +10,15 @@ from ortools.sat.python.cp_model import IntervalVar, LinearExprT
 from discrete_optimization.generic_tasks_tools.allocation import UnaryResource
 from discrete_optimization.generic_tasks_tools.base import Task
 from discrete_optimization.generic_tasks_tools.generic_scheduling import (
-    CumulativeResource,
     GenericSchedulingProblem,
     Resource,
 )
 from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
     NonRenewableResource,
 )
-from discrete_optimization.generic_tasks_tools.solvers.cpsat.allocation import (
-    AllocationCpSatSolver,
-)
-from discrete_optimization.generic_tasks_tools.solvers.cpsat.cumulative_resource import (
-    CumulativeResourceSchedulingCpSatSolver,
+from discrete_optimization.generic_tasks_tools.skill import (
+    NonSkillCumulativeResource,
+    Skill,
 )
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.non_renewable_resource import (
     NonRenewableCpSatSolver,
@@ -29,21 +26,28 @@ from discrete_optimization.generic_tasks_tools.solvers.cpsat.non_renewable_resou
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.precedence_scheduling import (
     PrecedenceSchedulingCpSatSolver,
 )
+from discrete_optimization.generic_tasks_tools.solvers.cpsat.skill import (
+    SkillSchedulingCpSatSolver,
+)
 
 
 class GenericSchedulingCpSatSolver(
-    CumulativeResourceSchedulingCpSatSolver[Task, CumulativeResource, UnaryResource],
+    SkillSchedulingCpSatSolver[
+        Task, UnaryResource, Skill, NonSkillCumulativeResource, UnaryResource
+    ],
     NonRenewableCpSatSolver[Task, NonRenewableResource],
-    AllocationCpSatSolver[Task, UnaryResource],
     PrecedenceSchedulingCpSatSolver[Task],
-    Generic[Task, UnaryResource, CumulativeResource, NonRenewableResource],
+    Generic[
+        Task, UnaryResource, Skill, NonSkillCumulativeResource, NonRenewableResource
+    ],
 ):
-    """Mixin for cpsat solver dealing with sheduling + allocation problems.
+    """Mixin for cpsat solver dealing with scheduling + allocation problems.
 
     Has access to helping methods to create constraints for
     - precedence
     - renewable resource with calendar (unary resource to allocate, or cumulative resource)
     - non-renewable resource capacity
+    - skills brought to tasks by allocated unary resources
 
     For a more all-in-one version actually creating variables, constraints and objectives,
     see `GenericSchedulingAutoCpSatSolver`.
@@ -51,7 +55,7 @@ class GenericSchedulingCpSatSolver(
     """
 
     problem: GenericSchedulingProblem[
-        Task, UnaryResource, CumulativeResource, NonRenewableResource
+        Task, UnaryResource, Skill, NonSkillCumulativeResource, NonRenewableResource
     ]
 
     def get_resource_consumption_intervals(

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/skill.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/skill.py
@@ -1,0 +1,188 @@
+#  Copyright (c) 2026 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+from abc import abstractmethod
+from typing import Generic
+
+from ortools.sat.python.cp_model import LinearExprT
+
+from discrete_optimization.generic_tasks_tools.allocation import UnaryResource
+from discrete_optimization.generic_tasks_tools.base import Task
+from discrete_optimization.generic_tasks_tools.cumulative_resource import (
+    OtherCalendarResource,
+)
+from discrete_optimization.generic_tasks_tools.skill import (
+    CumulativeResource,
+    NonSkillCumulativeResource,
+    NoSkill,
+    Skill,
+    SkillProblem,
+)
+from discrete_optimization.generic_tasks_tools.solvers.cpsat.allocation import (
+    AllocationCpSatSolver,
+)
+from discrete_optimization.generic_tasks_tools.solvers.cpsat.cumulative_resource import (
+    CumulativeResourceSchedulingCpSatSolver,
+)
+from discrete_optimization.generic_tasks_tools.solvers.utils import is_a_trivial_zero
+
+
+class SkillSchedulingCpSatSolver(
+    CumulativeResourceSchedulingCpSatSolver[
+        Task, CumulativeResource, OtherCalendarResource
+    ],
+    AllocationCpSatSolver[Task, UnaryResource],
+    Generic[
+        Task, UnaryResource, Skill, NonSkillCumulativeResource, OtherCalendarResource
+    ],
+):
+    """Base class for cpsat solvers dealing with scheduling problems handling skills attached to unary resources."""
+
+    use_exact_skill: bool = False
+    """Allocate exactly the needed skill value to each task."""
+    use_slack_for_skill: bool = False
+    """Allow some additional slack on skill value, even when `use_exact_skill` is activated."""
+    max_slack_for_skill: int = 5
+    """Maximum slack for skill value."""
+    use_only_one_skill_per_task: bool = False
+    """Use only one skill from each unary resource allocated to a given task."""
+    use_only_skill_to_allocate: bool = False
+    """Do not allocate a unary_resource if not contributing to a skill needed by a given task."""
+
+    problem: SkillProblem[
+        Task, UnaryResource, Skill, NonSkillCumulativeResource, OtherCalendarResource
+    ]
+
+    @abstractmethod
+    def get_skill_variable(
+        self, task: Task, unary_resource: UnaryResource, skill: Skill
+    ) -> LinearExprT:
+        """Get skill boolean variable telling if given skill is used by given unary resource for given task."""
+        ...
+
+    def create_fine_skill_constraints(self):
+        """Create constraints on skills using variable on skill contribution of each unary resource."""
+        for task in self.problem.tasks_list:
+            for skill in self.problem.get_skills_of_task(task):
+                skill_value_put_on_task = sum(
+                    skill_value * skill_used_var
+                    for unary_resource in self.problem.get_unary_resource_with_skill(
+                        skill
+                    )
+                    if (
+                        (
+                            skill_value := self.problem.get_unary_resource_skill_value(
+                                unary_resource=unary_resource, skill=skill
+                            )
+                        )
+                        > 0
+                        and not is_a_trivial_zero(
+                            (
+                                skill_used_var := self.get_skill_variable(
+                                    task=task,
+                                    unary_resource=unary_resource,
+                                    skill=skill,
+                                )
+                            )
+                        )
+                    )
+                )
+                skill_value_needed_by_task = (
+                    self.get_cumulative_resource_demand_variable(
+                        task=task, resource=skill
+                    )
+                )
+                if self.use_exact_skill:
+                    if self.use_slack_for_skill:
+                        self.cp_model.add(
+                            skill_value_put_on_task >= skill_value_needed_by_task
+                        )
+                        self.cp_model.add(
+                            skill_value_put_on_task
+                            <= skill_value_needed_by_task + self.max_slack_for_skill
+                        )
+                    else:
+                        self.cp_model.add(
+                            skill_value_put_on_task == skill_value_needed_by_task
+                        )
+                else:
+                    self.cp_model.add(
+                        skill_value_put_on_task >= skill_value_needed_by_task
+                    )
+
+    def create_coarse_skill_constraints(self):
+        """Create constraints on skills using only task allocation of each unary resource."""
+        for task in self.problem.tasks_list:
+            for skill in self.problem.get_skills_of_task(task):
+                skill_value_put_on_task = sum(
+                    skill_value * is_present_var
+                    for unary_resource in self.problem.get_unary_resource_with_skill(
+                        skill
+                    )
+                    if (
+                        (
+                            skill_value := self.problem.get_unary_resource_skill_value(
+                                unary_resource=unary_resource, skill=skill
+                            )
+                        )
+                        > 0
+                        and not is_a_trivial_zero(
+                            (
+                                is_present_var
+                                := self.get_task_unary_resource_is_present_variable(
+                                    task=task, unary_resource=unary_resource
+                                )
+                            )
+                        )
+                    )
+                )
+                skill_value_needed_by_task = (
+                    self.get_cumulative_resource_demand_variable(
+                        task=task, resource=skill
+                    )
+                )
+                self.cp_model.add(skill_value_put_on_task >= skill_value_needed_by_task)
+
+    def is_compatible_task_unary_resource(
+        self, task: Task, unary_resource: UnaryResource
+    ) -> bool:
+        if (
+            self.at_most_one_unary_resource_per_task
+            or self.exactly_one_unary_resource_per_task
+        ):
+            # will be the only resource allocated so must bring all needed skill
+            if not any(
+                all(
+                    self.problem.get_unary_resource_skill_value(
+                        unary_resource=unary_resource, skill=skill
+                    )
+                    >= self.problem.get_cumulative_resource_consumption(
+                        task=task, mode=mode, resource=skill
+                    )
+                    for skill in self.problem.get_skills_of_task(task)
+                )
+                for mode in self.problem.get_task_modes(task)
+            ):
+                return False
+        if self.use_only_skill_to_allocate:
+            # the allocation must bring useful skill to the task
+            common_skills = self.problem.get_skills_of_task(task).intersection(
+                self.problem.get_skills_of_unary_resource(unary_resource)
+            )
+            if len(common_skills) == 0:
+                return False
+        return super().is_compatible_task_unary_resource(task, unary_resource)
+
+
+class WithoutSkillSchedulingCpSatSolver(
+    SkillSchedulingCpSatSolver[
+        Task, UnaryResource, NoSkill, NonSkillCumulativeResource, OtherCalendarResource
+    ],
+    Generic[Task, UnaryResource, NonSkillCumulativeResource, OtherCalendarResource],
+):
+    """Mixin for solver on problems dealing with no skills."""
+
+    def get_skill_variable(
+        self, task: Task, unary_resource: UnaryResource, skill: Skill
+    ) -> LinearExprT:
+        return 0

--- a/src/discrete_optimization/generic_tasks_tools/solvers/lns_cp/constraint_extractor.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/lns_cp/constraint_extractor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import random
 from abc import ABC, abstractmethod
-from typing import Any, Generic, Optional, Union
+from typing import Any, Generic, Optional
 
 import numpy as np
 
@@ -314,7 +314,7 @@ class ConstraintExtractorPortfolio(BaseConstraintExtractor[Task]):
     def __init__(
         self,
         extractors: list[BaseConstraintExtractor[Task]],
-        weights: Union[list[float], np.array] = None,
+        weights: list[float] | np.ndarray | None = None,
         verbose: bool = False,
     ):
         self.extractors = extractors

--- a/src/discrete_optimization/generic_tasks_tools/solvers/lns_cp/neighbor_tools.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/lns_cp/neighbor_tools.py
@@ -6,7 +6,7 @@ import logging
 import math
 import random
 from abc import abstractmethod
-from typing import Generic, Optional, Union
+from typing import Generic, Optional
 
 import numpy as np
 import numpy.typing as npt
@@ -207,7 +207,7 @@ class NeighborBuilderMix(NeighborBuilder[Task]):
     def __init__(
         self,
         list_neighbor: list[NeighborBuilder[Task]],
-        weight_neighbor: Optional[Union[list[float], npt.NDArray[float]]] = None,
+        weight_neighbor: Optional[list[float] | npt.NDArray[float]] = None,
         verbose: bool = False,
     ):
         self.list_neighbor = list_neighbor

--- a/src/discrete_optimization/jsp/problem.py
+++ b/src/discrete_optimization/jsp/problem.py
@@ -23,6 +23,11 @@ from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
     WithoutNonRenewableResourceProblem,
     WithoutNonRenewableResourceSolution,
 )
+from discrete_optimization.generic_tasks_tools.skill import (
+    NoSkill,
+    WithoutSkillProblem,
+    WithoutSkillSolution,
+)
 from discrete_optimization.generic_tools.do_problem import (
     ModeOptim,
     ObjectiveDoc,
@@ -36,13 +41,21 @@ Task = tuple[int, int]
 """Task representation: (job index, subjob index)."""
 
 
-CumulativeResource = int  # machine id
-Resource = CumulativeResource  # no other resource
+NonSkillCumulativeResource = int  # machine id
+CumulativeResource = NonSkillCumulativeResource  # no skill
+Resource = NonSkillCumulativeResource  # no other resource
 
 
 class JobShopSolution(
     GenericSchedulingSolution[
-        Task, NoUnaryResource, CumulativeResource, NoNonRenewableResource
+        Task,
+        NoUnaryResource,
+        NoSkill,
+        NonSkillCumulativeResource,
+        NoNonRenewableResource,
+    ],
+    WithoutSkillSolution[
+        Task, NoUnaryResource, NonSkillCumulativeResource, NoUnaryResource
     ],
     WithoutNonRenewableResourceSolution[Task],
     WithoutAllocationSolution[Task],
@@ -82,7 +95,14 @@ class Subjob:
 
 class JobShopProblem(
     GenericSchedulingProblem[
-        Task, NoUnaryResource, CumulativeResource, NoNonRenewableResource
+        Task,
+        NoUnaryResource,
+        NoSkill,
+        NonSkillCumulativeResource,
+        NoNonRenewableResource,
+    ],
+    WithoutSkillProblem[
+        Task, NoUnaryResource, NonSkillCumulativeResource, NoUnaryResource
     ],
     WithoutNonRenewableResourceProblem[Task],
     WithoutAllocationProblem[Task],
@@ -133,7 +153,7 @@ class JobShopProblem(
             return 0
 
     @property
-    def cumulative_resources_list(self) -> list[CumulativeResource]:
+    def non_skill_cumulative_resources_list(self) -> list[NonSkillCumulativeResource]:
         return list(range(self.n_machines))
 
     def get_resource_availabilities(

--- a/src/discrete_optimization/jsp/solvers/cpsat_auto.py
+++ b/src/discrete_optimization/jsp/solvers/cpsat_auto.py
@@ -13,14 +13,18 @@ from discrete_optimization.generic_tasks_tools.allocation import (
 from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
     NoNonRenewableResource,
 )
+from discrete_optimization.generic_tasks_tools.skill import NoSkill
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.auto import (
     SinglemodeGenericSchedulingAutoCpSatSolver,
     TemporarySolution,
 )
+from discrete_optimization.generic_tasks_tools.solvers.cpsat.skill import (
+    WithoutSkillSchedulingCpSatSolver,
+)
 from discrete_optimization.jsp.problem import (
-    CumulativeResource,
     JobShopProblem,
     JobShopSolution,
+    NonSkillCumulativeResource,
     Task,
 )
 
@@ -29,7 +33,14 @@ logger = logging.getLogger(__name__)
 
 class CpSatAutoJspSolver(
     SinglemodeGenericSchedulingAutoCpSatSolver[
-        Task, NoUnaryResource, CumulativeResource, NoNonRenewableResource
+        Task,
+        NoUnaryResource,
+        NoSkill,
+        NonSkillCumulativeResource,
+        NoNonRenewableResource,
+    ],
+    WithoutSkillSchedulingCpSatSolver[
+        Task, NoUnaryResource, NonSkillCumulativeResource, NoUnaryResource
     ],
 ):
     problem: JobShopProblem
@@ -47,7 +58,7 @@ class CpSatAutoJspSolver(
         super().init_model(**kwargs)
 
     def convert_task_variables_to_solution(
-        self, temp_sol: TemporarySolution[Task, UnaryResource]
+        self, temp_sol: TemporarySolution[Task, UnaryResource, NoSkill]
     ) -> JobShopSolution:
         schedule = [
             [

--- a/src/discrete_optimization/rcpsp/problem.py
+++ b/src/discrete_optimization/rcpsp/problem.py
@@ -28,6 +28,7 @@ from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
 from discrete_optimization.generic_tasks_tools.generic_scheduling import (
     GenericSchedulingProblem,
 )
+from discrete_optimization.generic_tasks_tools.skill import NoSkill, WithoutSkillProblem
 from discrete_optimization.generic_tools.do_problem import (
     ModeOptim,
     ObjectiveDoc,
@@ -45,8 +46,8 @@ from discrete_optimization.rcpsp.fast_function import (
     sgs_fast_partial_schedule_incomplete_permutation_tasks,
 )
 from discrete_optimization.rcpsp.solution import (
-    CumulativeResource,
     NonRenewableResource,
+    NonSkillCumulativeResource,
     RcpspSolution,
     Resource,
     Task,
@@ -71,7 +72,10 @@ class ScheduleGenerationScheme(Enum):
 
 class RcpspProblem(
     GenericSchedulingProblem[
-        Task, NoUnaryResource, CumulativeResource, NonRenewableResource
+        Task, NoUnaryResource, NoSkill, NonSkillCumulativeResource, NonRenewableResource
+    ],
+    WithoutSkillProblem[
+        Task, NoUnaryResource, NonSkillCumulativeResource, NoUnaryResource
     ],
     WithoutAllocationProblem[Task],
 ):
@@ -367,7 +371,7 @@ class RcpspProblem(
         return self.non_renewable_resources
 
     @property
-    def cumulative_resources_list(self) -> list[CumulativeResource]:
+    def non_skill_cumulative_resources_list(self) -> list[NonSkillCumulativeResource]:
         return [
             resource
             for resource in self.resources_list

--- a/src/discrete_optimization/rcpsp/solution.py
+++ b/src/discrete_optimization/rcpsp/solution.py
@@ -20,6 +20,10 @@ from discrete_optimization.generic_tasks_tools.allocation import (
 from discrete_optimization.generic_tasks_tools.generic_scheduling import (
     GenericSchedulingSolution,
 )
+from discrete_optimization.generic_tasks_tools.skill import (
+    NoSkill,
+    WithoutSkillSolution,
+)
 from discrete_optimization.generic_tools.do_problem import RobustProblem
 
 if TYPE_CHECKING:  # avoid circular imports due to annotations
@@ -29,6 +33,7 @@ Task = Hashable
 Resource = str
 NonRenewableResource = str
 CumulativeResource = Resource
+NonSkillCumulativeResource = CumulativeResource
 
 
 class TaskDetails:
@@ -39,7 +44,10 @@ class TaskDetails:
 
 class RcpspSolution(
     GenericSchedulingSolution[
-        Task, NoUnaryResource, CumulativeResource, NonRenewableResource
+        Task, NoUnaryResource, NoSkill, NonSkillCumulativeResource, NonRenewableResource
+    ],
+    WithoutSkillSolution[
+        Task, NoUnaryResource, NonSkillCumulativeResource, NoUnaryResource
     ],
     WithoutAllocationSolution[Task],
 ):

--- a/src/discrete_optimization/rcpsp/solvers/cpsat_auto.py
+++ b/src/discrete_optimization/rcpsp/solvers/cpsat_auto.py
@@ -19,6 +19,7 @@ from discrete_optimization.generic_tasks_tools.allocation import (
     UnaryResource,
 )
 from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
+from discrete_optimization.generic_tasks_tools.skill import NoSkill
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.auto import (
     GenericSchedulingAutoCpSatSolver,
     Objective,
@@ -33,8 +34,8 @@ from discrete_optimization.rcpsp.problem import (
     Task,
 )
 from discrete_optimization.rcpsp.solution import (
-    CumulativeResource,
     NonRenewableResource,
+    NonSkillCumulativeResource,
 )
 from discrete_optimization.rcpsp.solvers import RcpspSolver
 
@@ -43,7 +44,7 @@ logger = logging.getLogger(__name__)
 
 class CpSatAutoRcpspSolver(
     GenericSchedulingAutoCpSatSolver[
-        Task, NoUnaryResource, CumulativeResource, NonRenewableResource
+        Task, NoUnaryResource, NoSkill, NonSkillCumulativeResource, NonRenewableResource
     ],
     RcpspSolver,
 ):
@@ -232,7 +233,7 @@ class CpSatAutoRcpspSolver(
         )
 
     def convert_task_variables_to_solution(
-        self, temp_sol: TemporarySolution[Task, UnaryResource]
+        self, temp_sol: TemporarySolution[Task, UnaryResource, NoSkill]
     ) -> RcpspSolution:
         schedule = {}
         modes_dict = {}
@@ -315,7 +316,7 @@ class CpSatAutoResourceRcpspSolver(CpSatAutoRcpspSolver):
 
     def retrieve_tasks_variables(
         self, cpsolvercb: CpSolverSolutionCallback
-    ) -> TemporarySolution[Task, UnaryResource]:
+    ) -> TemporarySolution[Task, UnaryResource, NoSkill]:
         """Construct each task variable from the cpsat solver internal solution.
 
         It will be called each time the cpsat solver find a new solution.
@@ -342,7 +343,7 @@ class CpSatAutoResourceRcpspSolver(CpSatAutoRcpspSolver):
         return temp_sol
 
     def convert_task_variables_to_solution(
-        self, temp_sol: TemporarySolution[Task, UnaryResource]
+        self, temp_sol: TemporarySolution[Task, UnaryResource, NoSkill]
     ) -> RcpspSolution:
         """Convert temporary solution to rcpsp format.
 
@@ -430,7 +431,7 @@ class CpSatAutoCumulativeResourceRcpspSolver(CpSatAutoRcpspSolver):
 
     def retrieve_tasks_variables(
         self, cpsolvercb: CpSolverSolutionCallback
-    ) -> TemporarySolution[Task, UnaryResource]:
+    ) -> TemporarySolution[Task, UnaryResource, NoSkill]:
         """Construct each task variable from the cpsat solver internal solution.
 
         It will be called each time the cpsat solver find a new solution.
@@ -457,7 +458,7 @@ class CpSatAutoCumulativeResourceRcpspSolver(CpSatAutoRcpspSolver):
         return temp_sol
 
     def convert_task_variables_to_solution(
-        self, temp_sol: TemporarySolution[Task, UnaryResource]
+        self, temp_sol: TemporarySolution[Task, UnaryResource, NoSkill]
     ) -> RcpspSolution:
         """Convert temporary solution to rcpsp format.
 

--- a/src/discrete_optimization/rcpsp_multiskill/problem.py
+++ b/src/discrete_optimization/rcpsp_multiskill/problem.py
@@ -109,15 +109,16 @@ class TaskDetailsPreemptive:
 
 Task = Hashable
 UnaryResource = Hashable
-CumulativeResource = str
-Resource = Union[CumulativeResource, UnaryResource]
-NonRenewableResource = str
 Skill = str
+NonSkillCumulativeResource = str
+CumulativeResource = Skill | NonSkillCumulativeResource
+Resource = CumulativeResource | UnaryResource
+NonRenewableResource = str
 
 
 class MultiskillRcpspSolution(
     GenericSchedulingSolution[
-        Task, UnaryResource, CumulativeResource, NonRenewableResource
+        Task, UnaryResource, Skill, NonSkillCumulativeResource, NonRenewableResource
     ],
 ):
     problem: MultiskillRcpspProblem
@@ -183,6 +184,15 @@ class MultiskillRcpspSolution(
 
     def get_mode(self, task: Task) -> int:
         return self.modes[task]
+
+    def is_skill_used(
+        self, task: Task, unary_resource: UnaryResource, skill: Skill
+    ) -> bool:
+        return (
+            task in self.employee_usage
+            and unary_resource in self.employee_usage[task]
+            and skill in self.employee_usage[task][unary_resource]
+        )
 
 
 class PreemptiveMultiskillRcpspSolution(MultiskillRcpspSolution):
@@ -1985,7 +1995,7 @@ def intersect(i1, i2):
 
 class MultiskillRcpspProblem(
     GenericSchedulingProblem[
-        Task, UnaryResource, CumulativeResource, NonRenewableResource
+        Task, UnaryResource, Skill, NonSkillCumulativeResource, NonRenewableResource
     ],
 ):
     sgs: ScheduleGenerationScheme
@@ -2029,7 +2039,7 @@ class MultiskillRcpspProblem(
         strictly_disjunctive_subtasks: bool = True,
     ):
         self.skills_set = skills_set
-        self.skills_list = sorted(self.skills_set)
+        self._skills_list = sorted(self.skills_set)
 
         self.resources_set = resources_set
         self.non_renewable_resources = non_renewable_resources
@@ -2115,6 +2125,7 @@ class MultiskillRcpspProblem(
         """
         self._max_skill_over_worker_to_recompute = True
         self.update_resource_sets()
+        self.update_skills()
         self.create_employee_task_compatibility()
         self.update_calendars()
         self.update_special_constraints()
@@ -2234,6 +2245,32 @@ class MultiskillRcpspProblem(
         return self._tasks_list
 
     @property
+    def skills_list(self) -> list[Skill]:
+        return self._skills_list
+
+    @property
+    def non_skill_cumulative_resources_list(self) -> list[Skill]:
+        """List of cumulative resources that are not skills.
+
+        NB: we consider also the lower bound on number of used employees as cumulative resource
+        to get the corresponding calendar constraint.
+
+        """
+        return [
+            res
+            for res in self.resources_list
+            if res not in self.non_renewable_resources
+        ] + [NB_EMPLOYEES_LB]
+
+    def get_unary_resource_skill_value(
+        self, unary_resource: UnaryResource, skill: Skill
+    ) -> int:
+        try:
+            return self.employees[unary_resource].dict_skill[skill].skill_value
+        except KeyError:
+            return 0
+
+    @property
     def non_renewable_resources_list(self) -> list[NonRenewableResource]:
         return self._non_renewable_resources_list
 
@@ -2246,23 +2283,6 @@ class MultiskillRcpspProblem(
         self, resource: NonRenewableResource, task: Task, mode: int
     ) -> int:
         return self.mode_details[task][mode].get(resource, 0)
-
-    @property
-    def cumulative_resources_list(self) -> list[CumulativeResource]:
-        """List of cumulative resources.
-
-        NB: we consider also skills as cumulative resources.
-
-        """
-        return (
-            [
-                res
-                for res in self.resources_list
-                if res not in self.non_renewable_resources
-            ]
-            + self.skills_list
-            + [NB_EMPLOYEES_LB]
-        )
 
     def get_cumulative_resource_consumption(
         self, resource: CumulativeResource, task: Task, mode: int
@@ -2376,20 +2396,14 @@ class MultiskillRcpspProblem(
             for s in self.skills_set
         }
         self.compatibility_task_employee: dict[Task, dict[UnaryResource, bool]] = {}
-        self.skills_of_task: dict[Task, set[Skill]] = {}
         for task in self.tasks_list:
             self.compatibility_task_employee[task] = {}
-            skills_of_task = set()
-            for mode in self.mode_details[task]:
-                for skill in self.skills_set:
-                    if self.mode_details[task][mode].get(skill, 0) > 0:
-                        skills_of_task.add(skill)
+            skills_of_task = self.get_skills_of_task(task)
             for employee in self.employees:
                 if any(employee in self.employees_per_skill[s] for s in skills_of_task):
                     self.compatibility_task_employee[task][employee] = True
                 else:
                     self.compatibility_task_employee[task][employee] = False
-            self.skills_of_task[task] = skills_of_task
 
     def get_precedence_constraints(self) -> dict[Task, list[Task]]:
         return self.successors
@@ -2552,43 +2566,22 @@ class MultiskillRcpspProblem(
         return self.satisfy_classic(variable)
 
     def satisfy_classic(self, rcpsp_sol: MultiskillRcpspSolution) -> bool:
-        # check the skills :
-        if len(rcpsp_sol.schedule) != self.nb_tasks:
-            return False
-        for task in self.tasks_list:
-            mode = rcpsp_sol.modes[task]
-            required_skills = {
-                s: conso
-                for s in self.mode_details[task][mode]
-                if s in self.skills_set
-                and (conso := self.mode_details[task][mode][s]) > 0
-            }
-            # Skills for the given task are used
-            if len(required_skills) > 0:
-                for skill in required_skills:
-                    employees_used = [
-                        self.employees[emp].dict_skill[skill].skill_value
-                        for emp in rcpsp_sol.employee_usage[task]
-                        if skill in rcpsp_sol.employee_usage[task][emp]
-                    ]
-                    if sum(employees_used) < required_skills[skill]:
-                        logger.debug("1")
-                        return False
-
-        # Check for renewable resources capacity violations
-        # include employees and cumulative resources
-        if not rcpsp_sol.check_all_calendar_resource_capacity_constraints():
-            return False
-
-        # Check for non-renewable resource violation
-        if not rcpsp_sol.check_all_non_renewable_resource_capacity_constraints():
-            return False
-
-        # Check precedences / successors
-        if not rcpsp_sol.check_precedence_constraints():
-            return False
-
-        return True
+        return (
+            # check all tasks scheduled
+            len(rcpsp_sol.schedule) == self.nb_tasks
+            # Check for renewable resources capacity violations
+            # include employees and cumulative resources
+            and rcpsp_sol.check_all_calendar_resource_capacity_constraints()
+            # Check for non-renewable resource violation
+            and rcpsp_sol.check_all_non_renewable_resource_capacity_constraints()
+            # Check precedences / successors
+            and rcpsp_sol.check_precedence_constraints()
+            # Check skills
+            and rcpsp_sol.check_skill_constraints()
+            # Check consistency between compatibility/allocation/skill usage
+            and rcpsp_sol.check_skill_usage_and_allocation_consistency()
+            and rcpsp_sol.check_allocation_consistency()
+        )
 
     def satisfy_preemptive(self, rcpsp_sol: PreemptiveMultiskillRcpspSolution) -> bool:
         # check the skills :

--- a/src/discrete_optimization/rcpsp_multiskill/problem.py
+++ b/src/discrete_optimization/rcpsp_multiskill/problem.py
@@ -2345,20 +2345,7 @@ class MultiskillRcpspProblem(
                 calendar=self.resources_availability[resource], horizon=self.horizon
             )
         elif resource in self.skills_set:
-            return convert_calendar_to_availability_intervals(
-                calendar=merge_resources_calendars(
-                    calendars=[
-                        [
-                            skill_level * int(present)
-                            for present in emp.calendar_employee
-                        ]
-                        for emp in self.employees.values()
-                        if (skill_level := emp.get_skill_level(resource)) > 0
-                    ],
-                    horizon=self.horizon,
-                ),
-                horizon=self.horizon,
-            )
+            return self.compute_skill_availabilities(resource)
         elif resource in self.employees:
             return convert_calendar_to_availability_intervals(
                 calendar=[

--- a/src/discrete_optimization/rcpsp_multiskill/problem.py
+++ b/src/discrete_optimization/rcpsp_multiskill/problem.py
@@ -494,7 +494,10 @@ class VariantMultiskillRcpspSolution(MultiskillRcpspSolution):
             )
 
     def update_infos_from_numba_output(
-        self, rcpsp_schedule, skills_usage, unfeasible_non_renewable_resources
+        self,
+        rcpsp_schedule: dict[int, tuple[int, int]],
+        skills_usage: dict[int, np.ndarray],
+        unfeasible_non_renewable_resources,
     ):
         if unfeasible_non_renewable_resources:
             self.schedule = {
@@ -646,7 +649,11 @@ class VariantPreemptiveMultiskillRcpspSolution(PreemptiveMultiskillRcpspSolution
             )
 
     def update_from_numba_output(
-        self, starts_dict, ends_dict, skills_usage, unfeasible_non_renewable_resources
+        self,
+        starts_dict: dict[int, np.ndarray],
+        ends_dict: dict[int, np.ndarray],
+        skills_usage: dict[int, np.ndarray],
+        unfeasible_non_renewable_resources,
     ):
         if unfeasible_non_renewable_resources:
             self.schedule = {
@@ -1008,7 +1015,7 @@ def sgs_multi_skill(solution: VariantMultiskillRcpspSolution):
         )
         rcpsp_schedule[act_id]["end_time"] = activity_end_times[act_id]
     if unfeasible_non_renewable_resources or unfeasible_in_horizon or unfeasible_skills:
-        last_act_id = max(problem.successors.keys())
+        last_act_id: Task = max(problem.successors.keys())
         rcpsp_schedule[last_act_id] = {
             "start_time": 99999999,
             "end_time": 9999999,
@@ -1266,7 +1273,7 @@ def sgs_multi_skill_preemptive(solution: VariantPreemptiveMultiskillRcpspSolutio
     rcpsp_schedule = schedules
     if unfeasible_non_renewable_resources or unfeasible_in_horizon or unfeasible_skills:
         rcpsp_schedule_feasible = False
-        last_act_id = max(problem.successors.keys())
+        last_act_id: Task = max(problem.successors.keys())
         rcpsp_schedule[last_act_id] = {
             "starts": [99999999],
             "ends": [9999999],
@@ -1603,7 +1610,7 @@ def sgs_multi_skill_preemptive_partial_schedule(
     rcpsp_schedule = schedules
     if unfeasible_non_renewable_resources or unfeasible_in_horizon or unfeasible_skills:
         rcpsp_schedule_feasible = False
-        last_act_id = max(problem.successors.keys())
+        last_act_id: Task = max(problem.successors.keys())
         rcpsp_schedule[last_act_id] = {
             "starts": [99999999],
             "ends": [9999999],
@@ -1894,7 +1901,7 @@ def sgs_multi_skill_partial_schedule(
         rcpsp_schedule[act_id]["end_time"] = activity_end_times[act_id]
     if unfeasible_non_renewable_resources or unfeasible_in_horizon or unfeasible_skills:
         rcpsp_schedule_feasible = False
-        last_act_id = max(problem.successors.keys())
+        last_act_id: Task = max(problem.successors.keys())
         if last_act_id not in rcpsp_schedule.keys():
             rcpsp_schedule[last_act_id] = {
                 "start_time": 99999999,
@@ -2013,6 +2020,8 @@ class MultiskillRcpspProblem(
     # {task_id: {mode: {resource: is_releasable during preemption }
     strictly_disjunctive_subtasks: bool
     # only used in preemptive mode, specifies that subtasks of tasks should be strictly disjunctive or not (i.e (st1, end1), (st2, end2), in strictly disjunctive case, st2>end1+1)
+    source_task: Task
+    sink_task: Task
 
     def __init__(
         self,
@@ -2067,16 +2076,20 @@ class MultiskillRcpspProblem(
             )
             self.employees_list = employees_list
         self.index_task = {self.tasks_list[i]: i for i in range(self.n_jobs)}
-        self.source_task = source_task
+
         if source_task is None:
             self.source_task = min(
                 self.tasks_list
             )  # tasks id should be comparable in this case
-        self.sink_task = sink_task
+        else:
+            self.source_task = source_task
         if sink_task is None:
             self.sink_task = max(
                 self.tasks_list
             )  # tasks id should be comparable in this case
+        else:
+            self.sink_task = sink_task
+
         self.tasks_list_non_dummy = [
             t for t in self.tasks_list if t not in {self.source_task, self.sink_task}
         ]

--- a/src/discrete_optimization/rcpsp_multiskill/solvers/cpsat.py
+++ b/src/discrete_optimization/rcpsp_multiskill/solvers/cpsat.py
@@ -26,10 +26,11 @@ from discrete_optimization.generic_tools.result_storage.result_storage import (
 )
 from discrete_optimization.rcpsp_multiskill.problem import (
     NB_EMPLOYEES_LB,
-    CumulativeResource,
     MultiskillRcpspProblem,
     MultiskillRcpspSolution,
     NonRenewableResource,
+    NonSkillCumulativeResource,
+    Skill,
     Task,
     UnaryResource,
 )
@@ -39,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 class CpSatMultiskillRcpspSolver(
     GenericSchedulingCpSatSolver[
-        Task, UnaryResource, CumulativeResource, NonRenewableResource
+        Task, UnaryResource, Skill, NonSkillCumulativeResource, NonRenewableResource
     ],
 ):
     hyperparameters = [
@@ -58,28 +59,20 @@ class CpSatMultiskillRcpspSolver(
             raise NotImplementedError()
         self.variables = {}
 
+    def get_skill_variable(
+        self, task: Task, unary_resource: UnaryResource, skill: Skill
+    ) -> LinearExprT:
+        try:
+            return self.variables["worker_variable"]["skill_used"][task][
+                unary_resource
+            ][skill]
+        except KeyError:
+            return 0
+
     def get_task_unary_resource_interval(
         self, task: Task, unary_resource: UnaryResource
     ) -> IntervalVar:
         return self.variables["worker_variable"]["opt_intervals"][task][unary_resource]
-
-    def is_compatible_task_unary_resource(
-        self, task: Task, unary_resource: UnaryResource
-    ) -> bool:
-        if len(self.problem.skills_of_task[task]) == 0:
-            # never allocate an employee to a task not needing a skill
-            return False
-        elif self._one_worker_per_task:
-            return any(
-                all(
-                    self.problem.employees[unary_resource].get_skill_level(s)
-                    >= self.problem.mode_details[task][mode].get(s, 0)
-                    for s in self.problem.skills_of_task[task]
-                )
-                for mode in self.problem.mode_details[task]
-            )
-        else:
-            return super().is_compatible_task_unary_resource(task, unary_resource)
 
     def get_task_mode_interval(self, task: Task, mode: int) -> IntervalVar:
         if not self.problem.is_multimode or len(self.problem.get_task_modes(task)) == 1:
@@ -135,8 +128,8 @@ class CpSatMultiskillRcpspSolver(
         one_skill_per_task = args.get("one_skill_per_task", False)
         redundant_skill_cumulative = args["redundant_skill_cumulative"]
         redundant_worker_cumulative = args["redundant_worker_cumulative"]
-        # store one_worker_per_task to use in `is_compatible_task_unary_resource`
-        self._one_worker_per_task = one_worker_per_task
+        # store one_worker_per_task to be used in `is_compatible_task_unary_resource`
+        self.at_most_one_unary_resource_per_task = one_worker_per_task
 
         super().init_model(**args)
         self.variables = {}

--- a/src/discrete_optimization/rcpsp_multiskill/solvers/cpsat_auto.py
+++ b/src/discrete_optimization/rcpsp_multiskill/solvers/cpsat_auto.py
@@ -6,7 +6,6 @@ from typing import Any
 
 from ortools.sat.python.cp_model import (
     CpSolverSolutionCallback,
-    Domain,
 )
 
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.auto import (
@@ -23,6 +22,8 @@ from discrete_optimization.rcpsp_multiskill.problem import (
     MultiskillRcpspProblem,
     MultiskillRcpspSolution,
     NonRenewableResource,
+    NonSkillCumulativeResource,
+    Skill,
     Task,
     UnaryResource,
 )
@@ -32,7 +33,7 @@ logger = logging.getLogger(__name__)
 
 class CpSatAutoMultiskillRcpspSolver(
     GenericSchedulingAutoCpSatSolver[
-        Task, UnaryResource, CumulativeResource, NonRenewableResource
+        Task, UnaryResource, Skill, NonSkillCumulativeResource, NonRenewableResource
     ],
 ):
     hyperparameters = [
@@ -43,10 +44,12 @@ class CpSatAutoMultiskillRcpspSolver(
             name="redundant_worker_cumulative", choices=[True, False], default=True
         ),
     ]
+    use_only_skill_to_allocate = True  # do not allocate worker without relevant skills
+
     problem: MultiskillRcpspProblem
 
     def convert_task_variables_to_solution(
-        self, temp_sol: TemporarySolution[Task, UnaryResource]
+        self, temp_sol: TemporarySolution[Task, UnaryResource, Skill]
     ) -> Solution:
         """Convert solution from autosolver format into do format.
 
@@ -68,9 +71,9 @@ class CpSatAutoMultiskillRcpspSolver(
             }
             modes_dict[task] = task_variable.mode
             employee_usage[task] = {
-                worker: contrib
-                for worker, contrib in task_variable.info["contrib"].items()
-                if len(contrib) > 0
+                worker: skills
+                for worker, skills in task_variable.allocated.items()
+                if len(skills) > 0
             }
         sol = MultiskillRcpspSolution(
             problem=self.problem,
@@ -83,14 +86,13 @@ class CpSatAutoMultiskillRcpspSolver(
 
     def retrieve_tasks_variables(
         self, cpsolvercb: CpSolverSolutionCallback
-    ) -> TemporarySolution[Task, UnaryResource]:
+    ) -> TemporarySolution[Task, UnaryResource, Skill]:
         """Construct each task variable from the cpsat solver internal solution.
 
         It will be called each time the cpsat solver find a new solution.
         At that point, value of internal variables are accessible via `cpsolvercb.value(VARIABLE_NAME)`.
 
-        We override the method from generic auto solver to add the worker skills contribution
-        and internal objective value.
+        We override the method from generic auto solver to add internal objective value.
 
         Args:
             cpsolvercb: the ortools callback called when the cpsat solver finds a new solution.
@@ -100,22 +102,6 @@ class CpSatAutoMultiskillRcpspSolver(
 
         """
         temp_sol = super().retrieve_tasks_variables(cpsolvercb)
-
-        # worker skills contribution per task
-        for task, task_variable in temp_sol.task_variables.items():
-            task_variable.info["contrib"] = {}
-            for worker in task_variable.allocated:
-                try:
-                    skills_used_vars = self.skills_used_per_worker[task][worker]
-                except KeyError:
-                    contrib = set()
-                else:
-                    contrib = {
-                        s
-                        for s, used_var in skills_used_vars.items()
-                        if cpsolvercb.value(used_var)
-                    }
-                task_variable.info["contrib"][worker] = contrib
 
         # internal objective
         temp_sol.metadata["makespan"] = cpsolvercb.value(
@@ -145,24 +131,6 @@ class CpSatAutoMultiskillRcpspSolver(
         else:
             return super().include_constraint_on_cumulative_resource(resource)
 
-    def is_compatible_task_unary_resource(
-        self, task: Task, unary_resource: UnaryResource
-    ) -> bool:
-        if len(self.problem.skills_of_task[task]) == 0:
-            # never allocate an employee to a task not needing a skill
-            return False
-        elif self._one_worker_per_task:
-            return any(
-                all(
-                    self.problem.employees[unary_resource].get_skill_level(s)
-                    >= self.problem.mode_details[task][mode].get(s, 0)
-                    for s in self.problem.skills_of_task[task]
-                )
-                for mode in self.problem.mode_details[task]
-            )
-        else:
-            return super().is_compatible_task_unary_resource(task, unary_resource)
-
     def init_model(self, **kwargs: Any) -> None:
         if self.problem.is_preemptive():
             raise NotImplementedError()
@@ -173,92 +141,17 @@ class CpSatAutoMultiskillRcpspSolver(
         self._redundant_skill_cumulative = kwargs["redundant_skill_cumulative"]
         self._redundant_worker_cumulative = kwargs["redundant_worker_cumulative"]
 
-        # additional constraints (subproblem)
-        self._one_worker_per_task = kwargs.get("one_worker_per_task", False)
-        self._one_skill_per_task = kwargs.get("one_skill_per_task", False)
-        self.at_most_one_unary_resource_per_task = self._one_worker_per_task
-
-        self._exact_skill = kwargs.get("exact_skill", False)
-        self._slack_skill = kwargs.get("slack_skill", False)
+        # additional constraints (we solve a subproblem)
+        # allocation
+        self.at_most_one_unary_resource_per_task = kwargs.get(
+            "one_worker_per_task", False
+        )
+        # skill
+        self.use_only_one_skill_per_task = kwargs.get("one_skill_per_task", False)
+        self.use_exact_skill = kwargs.get("exact_skill", False)
+        self.use_slack_for_skill = kwargs.get("slack_skill", False)
 
         super().init_model(**kwargs)
-
-        self.create_skills_used_per_worker()
-        self.create_skills_per_task_variables()
-        self.create_skills_constraint_worker()
-        self.create_skills_constraints_v2()
-        # self.create_workload_variables()  # not used for now
-
-    def create_skills_used_per_worker(self):
-        one_skill_per_task = self._one_skill_per_task
-        skills_used_var = {}
-        for task in self.problem.tasks_list:
-            skills_of_task = self.problem.skills_of_task[task]
-            if len(skills_of_task) == 0:
-                # no need of employees
-                continue
-            skills_used_var[task] = {}
-            for worker in self.problem.employees:
-                if self.is_compatible_task_unary_resource(
-                    task=task, unary_resource=worker
-                ):
-                    skills_used_var[task][worker] = {}
-                    skills_of_worker = self.problem.employees[
-                        worker
-                    ].get_non_zero_skills()
-                    for s in skills_of_task:
-                        if s in skills_of_worker:
-                            if not one_skill_per_task or len(skills_of_worker) == 1:
-                                skills_used_var[task][worker][s] = (
-                                    self.allocation_is_present[task][worker]
-                                )
-                            else:
-                                skills_used_var[task][worker][s] = (
-                                    self.cp_model.new_bool_var(
-                                        name=f"skill_{task}_{worker}_{s}"
-                                    )
-                                )
-                    for s in skills_used_var[task][worker]:
-                        self.cp_model.add(
-                            skills_used_var[task][worker][s]
-                            <= self.allocation_is_present[task][worker]
-                        )
-                    self.cp_model.add_bool_or(
-                        [
-                            skills_used_var[task][worker][s]
-                            for s in skills_used_var[task][worker]
-                        ]
-                    ).only_enforce_if(self.allocation_is_present[task][worker])
-                    if one_skill_per_task:
-                        if len(skills_used_var[task][worker]) >= 1:
-                            self.cp_model.add_at_most_one(
-                                [
-                                    skills_used_var[task][worker][s]
-                                    for s in skills_used_var[task][worker]
-                                ]
-                            )
-
-        self.skills_used_per_worker = skills_used_var
-
-    def create_skills_per_task_variables(self):
-        skills_var = {}
-        for task in self.problem.tasks_list:
-            skills_var[task] = {}
-            for s in self.problem.skills_of_task[task]:
-                possible_values = [
-                    self.problem.mode_details[task][mode].get(s, 0)
-                    for mode in self.problem.mode_details[task]
-                ]
-                skills_var[task][s] = self.cp_model.new_int_var_from_domain(
-                    domain=Domain.from_values(possible_values),
-                    name=f"skills_{task}_{s}",
-                )
-                for mode, is_present_mode in self.modes_is_present[task].items():
-                    val = self.problem.mode_details[task][mode].get(s, 0)
-                    self.cp_model.add(skills_var[task][s] == val).OnlyEnforceIf(
-                        is_present_mode
-                    )
-        self.skills_per_task = skills_var
 
     def create_workload_variables(self):
         workload = {}
@@ -288,104 +181,6 @@ class CpSatAutoMultiskillRcpspSolver(
         )
         self.max_workload_var = max_workload
         self.min_workload_var = min_workload
-
-    def create_skills_constraint_worker(self):
-        exact_skill = self._exact_skill
-        slack_skill = self._slack_skill
-        if slack_skill:
-            slack_skill_dict = {}
-        for task in self.skills_per_task:
-            if slack_skill:
-                slack_skill_dict[task] = {}
-            for s in self.skills_per_task[task]:
-                if slack_skill:
-                    slack_skill_dict[task][s] = self.cp_model.new_int_var(
-                        lb=0, ub=5, name=f"slack_{task}_{s}"
-                    )
-
-                skill_value_put_on_task = sum(
-                    skill_value * is_present_worker
-                    for worker, is_present_worker in self.allocation_is_present[
-                        task
-                    ].items()
-                    if (
-                        skill_value := self.problem.employees[worker].get_skill_level(s)
-                    )
-                    > 0
-                )
-
-                if exact_skill:
-                    if not slack_skill:
-                        self.cp_model.add(
-                            skill_value_put_on_task == self.skills_per_task[task][s]
-                        )
-                    else:
-                        self.cp_model.add(
-                            skill_value_put_on_task
-                            == self.skills_per_task[task][s] + slack_skill_dict[task][s]
-                        )
-
-                else:
-                    if not slack_skill:
-                        self.cp_model.add(
-                            skill_value_put_on_task >= self.skills_per_task[task][s]
-                        )
-                    else:
-                        self.cp_model.add(
-                            skill_value_put_on_task
-                            >= self.skills_per_task[task][s] + slack_skill_dict[task][s]
-                        )
-        if slack_skill:
-            self.slack_skill_v1_variables = slack_skill_dict
-
-    def create_skills_constraints_v2(self):
-        """
-        using skills_used variable
-        """
-        exact_skill = self._exact_skill
-        slack_skill = self._slack_skill
-        if slack_skill:
-            slack_skill_dict = {}
-        for task in self.skills_per_task:
-            if slack_skill:
-                slack_skill_dict[task] = {}
-            for s in self.skills_per_task[task]:
-                if slack_skill:
-                    slack_skill_dict[task][s] = self.cp_model.new_int_var(
-                        lb=0, ub=5, name=f"slack_{task}_{s}"
-                    )
-                skill_value_put_on_task = sum(
-                    self.problem.employees[worker].get_skill_level(s)
-                    * skills_used_var[s]
-                    for worker, skills_used_var in self.skills_used_per_worker[
-                        task
-                    ].items()
-                    if s in skills_used_var
-                )
-
-                if exact_skill:
-                    if not slack_skill:
-                        self.cp_model.add(
-                            skill_value_put_on_task == self.skills_per_task[task][s]
-                        )
-                    else:
-                        self.cp_model.add(
-                            skill_value_put_on_task
-                            == self.skills_per_task[task][s] + slack_skill_dict[task][s]
-                        )
-
-                else:
-                    if not slack_skill:
-                        self.cp_model.add(
-                            skill_value_put_on_task >= self.skills_per_task[task][s]
-                        )
-                    else:
-                        self.cp_model.add(
-                            skill_value_put_on_task
-                            >= self.skills_per_task[task][s] + slack_skill_dict[task][s]
-                        )
-        if slack_skill:
-            self.slack_skill_v2_variables = slack_skill_dict
 
     def create_total_cost_variable(self):
         self.total_cost_var = sum(

--- a/src/discrete_optimization/rcpsp_multiskill/solvers/cpsat_auto.py
+++ b/src/discrete_optimization/rcpsp_multiskill/solvers/cpsat_auto.py
@@ -124,9 +124,7 @@ class CpSatAutoMultiskillRcpspSolver(
         Returns:
 
         """
-        if resource in self.problem.skills_set:
-            return self._redundant_skill_cumulative
-        elif resource == NB_EMPLOYEES_LB:
+        if resource == NB_EMPLOYEES_LB:
             return self._redundant_worker_cumulative
         else:
             return super().include_constraint_on_cumulative_resource(resource)
@@ -138,7 +136,9 @@ class CpSatAutoMultiskillRcpspSolver(
         kwargs = self.complete_with_default_hyperparameters(kwargs)
 
         # redundant cumulative resources to consider
-        self._redundant_skill_cumulative = kwargs["redundant_skill_cumulative"]
+        self.add_redundant_skill_cumulative_constraints = kwargs[
+            "redundant_skill_cumulative"
+        ]
         self._redundant_worker_cumulative = kwargs["redundant_worker_cumulative"]
 
         # additional constraints (we solve a subproblem)

--- a/src/discrete_optimization/workforce/allocation/solvers/cpsat.py
+++ b/src/discrete_optimization/workforce/allocation/solvers/cpsat.py
@@ -333,6 +333,7 @@ class CpsatTeamAllocationSolver(
         add_lower_bound_nb_teams = kwargs["add_lower_bound_nb_teams"]
         include_all_binary_vars = kwargs["include_all_binary_vars"]
         assert include_pair_overlap or overlapping_advanced
+        self.exactly_one_unary_resource_per_task = not optional_activities
         domains_for_task: list[list[int]] = []
         # Take into account the allocation constraints directly in domains of variable.
         for i in range(self.problem.number_of_activity):
@@ -364,13 +365,10 @@ class CpsatTeamAllocationSolver(
                     ]
                     for f in forbidden:
                         self.cp_model.Add(allocation_binary[i][f] == 0)
+        # at most or exactly one allocated team per activity
+        self.add_unary_resources_per_task_constraints()
         if optional_activities:
             is_allocated = self.create_is_allocated_variables()
-        else:
-            for i in range(len(allocation_binary)):
-                self.cp_model.AddExactlyOne(
-                    [allocation_binary[i][j] for j in allocation_binary[i]]
-                )
 
         if include_pair_overlap:
             for edge in self.problem.graph_activity.edges:

--- a/src/discrete_optimization/workforce/scheduling/problem.py
+++ b/src/discrete_optimization/workforce/scheduling/problem.py
@@ -7,7 +7,7 @@ import itertools
 import logging
 from collections.abc import Hashable
 from functools import reduce
-from typing import Optional, Union
+from typing import Optional
 
 import networkx as nx
 import numpy as np
@@ -31,6 +31,11 @@ from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
     WithoutNonRenewableResourceProblem,
     WithoutNonRenewableResourceSolution,
 )
+from discrete_optimization.generic_tasks_tools.skill import (
+    NoSkill,
+    WithoutSkillProblem,
+    WithoutSkillSolution,
+)
 from discrete_optimization.generic_tools.do_problem import (
     ModeOptim,
     ObjectiveDoc,
@@ -51,13 +56,17 @@ logger = logging.getLogger(__name__)
 
 Task = Hashable
 UnaryResource = Hashable
-CumulativeResource = str
-Resource = Union[UnaryResource, CumulativeResource]
+NonSkillCumulativeResource = str
+CumulativeResource = NonSkillCumulativeResource
+Resource = UnaryResource | CumulativeResource
 
 
 class AllocSchedulingSolution(
     GenericSchedulingSolution[
-        Task, UnaryResource, CumulativeResource, NoNonRenewableResource
+        Task, UnaryResource, NoSkill, NonSkillCumulativeResource, NoNonRenewableResource
+    ],
+    WithoutSkillSolution[
+        Task, UnaryResource, NonSkillCumulativeResource, UnaryResource
     ],
     WithoutNonRenewableResourceSolution[Task],
     SinglemodeSolution[Task],
@@ -109,8 +118,9 @@ class TasksDescription:
 
 class AllocSchedulingProblem(
     GenericSchedulingProblem[
-        Task, UnaryResource, CumulativeResource, NoNonRenewableResource
+        Task, UnaryResource, NoSkill, NonSkillCumulativeResource, NoNonRenewableResource
     ],
+    WithoutSkillProblem[Task, UnaryResource, NonSkillCumulativeResource, UnaryResource],
     WithoutNonRenewableResourceProblem[Task],
     SinglemodeSchedulingProblem[Task],
 ):
@@ -173,7 +183,7 @@ class AllocSchedulingProblem(
         self.update_problem()
 
     @property
-    def cumulative_resources_list(self) -> list[CumulativeResource]:
+    def non_skill_cumulative_resources_list(self) -> list[NonSkillCumulativeResource]:
         return self.resources_list
 
     def get_cumulative_resource_consumption(

--- a/src/discrete_optimization/workforce/scheduling/solvers/cpsat.py
+++ b/src/discrete_optimization/workforce/scheduling/solvers/cpsat.py
@@ -19,11 +19,15 @@ from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
 from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
     NoNonRenewableResource,
 )
+from discrete_optimization.generic_tasks_tools.skill import NoSkill
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.generic_scheduling import (
     GenericSchedulingCpSatSolver,
 )
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.multimode_scheduling import (
     SinglemodeSchedulingCpSatSolver,
+)
+from discrete_optimization.generic_tasks_tools.solvers.cpsat.skill import (
+    WithoutSkillSchedulingCpSatSolver,
 )
 from discrete_optimization.generic_tools.do_problem import Solution
 from discrete_optimization.generic_tools.do_solver import WarmstartMixin
@@ -46,7 +50,7 @@ from discrete_optimization.workforce.commons.fairness_modeling_ortools import (
 from discrete_optimization.workforce.scheduling.problem import (
     AllocSchedulingProblem,
     AllocSchedulingSolution,
-    CumulativeResource,
+    NonSkillCumulativeResource,
     Task,
     UnaryResource,
 )
@@ -100,9 +104,12 @@ class AdditionalCPConstraints:
 
 class CPSatAllocSchedulingSolver(
     GenericSchedulingCpSatSolver[
-        Task, UnaryResource, CumulativeResource, NoNonRenewableResource
+        Task, UnaryResource, NoSkill, NonSkillCumulativeResource, NoNonRenewableResource
     ],
     SinglemodeSchedulingCpSatSolver[Task],
+    WithoutSkillSchedulingCpSatSolver[
+        Task, UnaryResource, NonSkillCumulativeResource, UnaryResource
+    ],
     SolverAllocScheduling,
     WarmstartMixin,
 ):
@@ -305,6 +312,7 @@ class CPSatAllocSchedulingSolver(
         args = self.complete_with_default_hyperparameters(args)
         add_lower_bound = args["add_lower_bound"]
         optional_activities = args["optional_activities"]
+        self.exactly_one_unary_resource_per_task = not optional_activities
         adding_redundant_cumulative = args["adding_redundant_cumulative"]
         super().init_model(**args)
         starts_var = {}
@@ -373,6 +381,9 @@ class CPSatAllocSchedulingSolver(
                     [is_present_var[i][x] for x in is_present_var[i]]
                 )
                 # else managed later by self.create_actually_done_variables()
+
+        # At most or exactly one team per activity
+        self.add_unary_resources_per_task_constraints()
 
         # Precedence constraints
         self.create_precedence_constraints()

--- a/src/discrete_optimization/workforce/scheduling/solvers/cpsat_auto.py
+++ b/src/discrete_optimization/workforce/scheduling/solvers/cpsat_auto.py
@@ -16,6 +16,7 @@ from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
 from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
     NoNonRenewableResource,
 )
+from discrete_optimization.generic_tasks_tools.skill import NoSkill
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.auto import (
     Objective,
     SinglemodeGenericSchedulingAutoCpSatSolver,
@@ -40,7 +41,7 @@ from discrete_optimization.workforce.commons.fairness_modeling_ortools import (
 from discrete_optimization.workforce.scheduling.problem import (
     AllocSchedulingProblem,
     AllocSchedulingSolution,
-    CumulativeResource,
+    NonSkillCumulativeResource,
     Task,
     UnaryResource,
 )
@@ -94,7 +95,7 @@ class AdditionalCPConstraints:
 
 class CPSatAutoAllocSchedulingSolver(
     SinglemodeGenericSchedulingAutoCpSatSolver[
-        Task, UnaryResource, CumulativeResource, NoNonRenewableResource
+        Task, UnaryResource, NoSkill, NonSkillCumulativeResource, NoNonRenewableResource
     ],
     SolverAllocScheduling,
 ):
@@ -177,7 +178,7 @@ class CPSatAutoAllocSchedulingSolver(
         )
 
     def convert_task_variables_to_solution(
-        self, temp_sol: TemporarySolution[Task, UnaryResource]
+        self, temp_sol: TemporarySolution[Task, UnaryResource, NoSkill]
     ) -> AllocSchedulingSolution:
         schedule = np.zeros((self.problem.number_tasks, 2), dtype=int)
         allocation = -np.ones(self.problem.number_tasks, dtype=int)
@@ -196,7 +197,7 @@ class CPSatAutoAllocSchedulingSolver(
 
     def retrieve_tasks_variables(
         self, cpsolvercb: CpSolverSolutionCallback
-    ) -> TemporarySolution[Task, UnaryResource]:
+    ) -> TemporarySolution[Task, UnaryResource, NoSkill]:
         """Create solution at temporary format from cpsat variables.
 
         Override it to

--- a/tests/generic_tasks_tools/solvers/cpsat/test_auto.py
+++ b/tests/generic_tasks_tools/solvers/cpsat/test_auto.py
@@ -7,7 +7,7 @@ import copy
 import logging
 import re
 from copy import deepcopy
-from typing import Any, Iterable, Optional, Union
+from typing import Any, Iterable, Optional
 
 import pytest
 
@@ -15,6 +15,11 @@ from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
 from discrete_optimization.generic_tasks_tools.generic_scheduling import (
     GenericSchedulingProblem,
     GenericSchedulingSolution,
+)
+from discrete_optimization.generic_tasks_tools.skill import (
+    NoSkill,
+    WithoutSkillProblem,
+    WithoutSkillSolution,
 )
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.auto import (
     GenericSchedulingAutoCpSatSolver,
@@ -38,23 +43,28 @@ from discrete_optimization.generic_tools.do_problem import (
 )
 
 UnaryResource = str
-CumulativeResource = str
-Resource = Union[UnaryResource, CumulativeResource]
+Skill = NoSkill
+NonSkillCumulativeResource = str
+CumulativeResource = Skill | NonSkillCumulativeResource
+Resource = UnaryResource | CumulativeResource
 NonRenewableResource = str
 Task = str
 
 
 class MySolution(
     GenericSchedulingSolution[
-        Task, UnaryResource, CumulativeResource, NonRenewableResource
-    ]
+        Task, UnaryResource, Skill, NonSkillCumulativeResource, NonRenewableResource
+    ],
+    WithoutSkillSolution[
+        Task, UnaryResource, NonSkillCumulativeResource, UnaryResource
+    ],
 ):
     problem: MyProblem
 
     def __init__(
         self,
         problem: MyProblem,
-        temp_sol: TemporarySolution[Task, UnaryResource],
+        temp_sol: TemporarySolution[Task, UnaryResource, Skill],
     ):
         super().__init__(problem)
         self.temp_sol = temp_sol
@@ -77,8 +87,9 @@ class MySolution(
 
 class MyProblem(
     GenericSchedulingProblem[
-        Task, UnaryResource, CumulativeResource, NonRenewableResource
-    ]
+        Task, UnaryResource, Skill, NonSkillCumulativeResource, NonRenewableResource
+    ],
+    WithoutSkillProblem[Task, UnaryResource, NonSkillCumulativeResource, UnaryResource],
 ):
     horizon = 10
     non_renewable_resources = ["non_renewable_resource"]
@@ -105,7 +116,7 @@ class MyProblem(
     successors = {"task-1": ["task-2"]}
 
     @property
-    def cumulative_resources_list(self) -> list[CumulativeResource]:
+    def non_skill_cumulative_resources_list(self) -> list[NonSkillCumulativeResource]:
         return self.cumulative_resources
 
     def get_cumulative_resource_consumption(
@@ -207,13 +218,13 @@ class MyProblem(
 
 class MyAutoCpsatSolver(
     GenericSchedulingAutoCpSatSolver[
-        Task, UnaryResource, CumulativeResource, NonRenewableResource
+        Task, UnaryResource, Skill, NonSkillCumulativeResource, NonRenewableResource
     ]
 ):
     problem: MyProblem
 
     def convert_task_variables_to_solution(
-        self, temp_sol: TemporarySolution[Task, UnaryResource]
+        self, temp_sol: TemporarySolution[Task, UnaryResource, Skill]
     ) -> MySolution:
         return MySolution(problem=self.problem, temp_sol=temp_sol)
 
@@ -240,8 +251,12 @@ def test_problem(caplog):
         problem=problem,
         temp_sol=TemporarySolution(
             task_variables={
-                "task-1": TaskVariable(start=1, end=4, mode=1, allocated=["worker1"]),
-                "task-2": TaskVariable(start=5, end=9, mode=0, allocated=["worker2"]),
+                "task-1": TaskVariable(
+                    start=1, end=4, mode=1, allocated={"worker1": set()}
+                ),
+                "task-2": TaskVariable(
+                    start=5, end=9, mode=0, allocated={"worker2": set()}
+                ),
             }
         ),
     )
@@ -257,8 +272,12 @@ def test_problem(caplog):
         problem=problem,
         temp_sol=TemporarySolution(
             task_variables={
-                "task-1": TaskVariable(start=3, end=6, mode=1, allocated=["worker2"]),
-                "task-2": TaskVariable(start=6, end=10, mode=0, allocated=["worker2"]),
+                "task-1": TaskVariable(
+                    start=3, end=6, mode=1, allocated={"worker2": set()}
+                ),
+                "task-2": TaskVariable(
+                    start=6, end=10, mode=0, allocated={"worker2": set()}
+                ),
             }
         ),
     )
@@ -296,8 +315,12 @@ def test_problem(caplog):
         problem=problem,
         temp_sol=TemporarySolution(
             task_variables={
-                "task-1": TaskVariable(start=3, end=6, mode=1, allocated=["worker1"]),
-                "task-2": TaskVariable(start=6, end=10, mode=0, allocated=["worker1"]),
+                "task-1": TaskVariable(
+                    start=3, end=6, mode=1, allocated={"worker1": set()}
+                ),
+                "task-2": TaskVariable(
+                    start=6, end=10, mode=0, allocated={"worker1": set()}
+                ),
             }
         ),
     )
@@ -310,8 +333,12 @@ def test_problem(caplog):
         problem=problem,
         temp_sol=TemporarySolution(
             task_variables={
-                "task-1": TaskVariable(start=1, end=4, mode=1, allocated=["worker1"]),
-                "task-2": TaskVariable(start=4, end=8, mode=0, allocated=["worker2"]),
+                "task-1": TaskVariable(
+                    start=1, end=4, mode=1, allocated={"worker1": set()}
+                ),
+                "task-2": TaskVariable(
+                    start=4, end=8, mode=0, allocated={"worker2": set()}
+                ),
             }
         ),
     )
@@ -324,8 +351,12 @@ def test_problem(caplog):
         problem=problem,
         temp_sol=TemporarySolution(
             task_variables={
-                "task-1": TaskVariable(start=1, end=2, mode=1, allocated=["worker1"]),
-                "task-2": TaskVariable(start=5, end=9, mode=0, allocated=["worker2"]),
+                "task-1": TaskVariable(
+                    start=1, end=2, mode=1, allocated={"worker1": set()}
+                ),
+                "task-2": TaskVariable(
+                    start=5, end=9, mode=0, allocated={"worker2": set()}
+                ),
             }
         ),
     )
@@ -340,8 +371,12 @@ def test_problem(caplog):
         problem=problem,
         temp_sol=TemporarySolution(
             task_variables={
-                "task-1": TaskVariable(start=1, end=4, mode=1, allocated=["worker1"]),
-                "task-2": TaskVariable(start=4, end=8, mode=0, allocated=["worker2"]),
+                "task-1": TaskVariable(
+                    start=1, end=4, mode=1, allocated={"worker1": set()}
+                ),
+                "task-2": TaskVariable(
+                    start=4, end=8, mode=0, allocated={"worker2": set()}
+                ),
             }
         ),
     )
@@ -420,8 +455,12 @@ def test_auto(
         problem=problem,
         temp_sol=TemporarySolution(
             task_variables={
-                "task-1": TaskVariable(start=1, end=4, mode=1, allocated=["worker1"]),
-                "task-2": TaskVariable(start=6, end=10, mode=0, allocated=["worker2"]),
+                "task-1": TaskVariable(
+                    start=1, end=4, mode=1, allocated={"worker1": set()}
+                ),
+                "task-2": TaskVariable(
+                    start=6, end=10, mode=0, allocated={"worker2": set()}
+                ),
             }
         ),
     )

--- a/tests/rcpsp_multiskill/solvers/test_cpsat.py
+++ b/tests/rcpsp_multiskill/solvers/test_cpsat.py
@@ -40,7 +40,21 @@ def test_imopse_cpsat():
     assert model.satisfy(solution)
 
 
-def test_imopse_cpsat_w_non_renewable_n_cumulative_resource():
+@pytest.mark.parametrize(
+    "one_worker_per_task, one_skill_per_task, exact_skill, slack_skill",
+    [
+        (True, False, False, False),
+        (True, False, False, False),
+        (False, True, False, False),
+        (False, True, True, False),
+        (False, True, True, True),
+        (False, False, True, True),
+        (True, False, True, True),
+    ],
+)
+def test_imopse_cpsat_w_non_renewable_n_cumulative_resource(
+    one_worker_per_task, one_skill_per_task, exact_skill, slack_skill
+):
     file = [f for f in get_data_available() if "100_5_64_9.def" in f][0]
     model, _ = parse_file(file, max_horizon=1000)
 
@@ -48,7 +62,10 @@ def test_imopse_cpsat_w_non_renewable_n_cumulative_resource():
         problem=model,
     )
     cp_model.init_model(
-        one_worker_per_task=True,
+        one_worker_per_task=one_worker_per_task,
+        one_skill_per_task=one_skill_per_task,
+        exact_skill=exact_skill,
+        slack_skill=slack_skill,
     )
     cp_model.cp_model.Minimize(cp_model.variables["makespan"])
     p = ParametersCp.default_cpsat()
@@ -57,6 +74,19 @@ def test_imopse_cpsat_w_non_renewable_n_cumulative_resource():
     )
     solution: MultiskillRcpspSolution = res.get_best_solution_fit()[0]
     assert model.satisfy(solution)
+    # more assert according to modeling options
+    if one_worker_per_task:
+        assert all(
+            len(allocated) <= 1 for allocated in solution.employee_usage.values()
+        )
+    if one_skill_per_task:
+        assert all(
+            all(len(skills_used) == 1 for skills_used in allocated.values())
+            for allocated in solution.employee_usage.values()
+        )
+    assert solution.check_skill_constraints(
+        exact=exact_skill, slack=5 if slack_skill else 0
+    )
 
     # add resources that should change schedule and mode choice
     task = model.tasks_list[0]

--- a/tests/rcpsp_multiskill/solvers/test_cpsat_auto.py
+++ b/tests/rcpsp_multiskill/solvers/test_cpsat_auto.py
@@ -40,15 +40,17 @@ def test_imopse_cpsat():
 
 
 @pytest.mark.parametrize(
-    "one_worker_per_task, one_skill_per_task, exact_skill, slack_skill, use_energy_constraints",
+    "one_worker_per_task, one_skill_per_task, exact_skill, slack_skill, use_energy_constraints, redundant_skill_cumulative",
     [
-        (True, False, False, False, False),
-        (True, False, False, False, True),
-        (False, True, False, False, False),
-        (False, True, True, False, False),
-        (False, True, True, True, False),
-        (False, False, True, True, False),
-        (True, False, True, True, False),
+        (False, False, False, False, False, False),
+        (False, False, False, False, False, True),
+        (True, False, False, False, False, False),
+        (True, False, False, False, True, False),
+        (False, True, False, False, False, False),
+        (False, True, True, False, False, False),
+        (False, True, True, True, False, False),
+        (False, False, True, True, False, False),
+        (True, False, True, True, False, False),
     ],
 )
 def test_imopse_cpsat_w_non_renewable_n_cumulative_resource(
@@ -57,22 +59,25 @@ def test_imopse_cpsat_w_non_renewable_n_cumulative_resource(
     exact_skill,
     slack_skill,
     use_energy_constraints,
+    redundant_skill_cumulative,
 ):
     file = [f for f in get_data_available() if "100_5_64_9.def" in f][0]
     model, _ = parse_file(file, max_horizon=1000)
 
-    cp_model = CpSatAutoMultiskillRcpspSolver(
+    solver = CpSatAutoMultiskillRcpspSolver(
         problem=model,
     )
-    cp_model.init_model(
+    solver.init_model(
         one_worker_per_task=one_worker_per_task,
         one_skill_per_task=one_skill_per_task,
         exact_skill=exact_skill,
         slack_skill=slack_skill,
         use_energy_constraints=use_energy_constraints,
+        redundant_skill_cumulative=redundant_skill_cumulative,
     )
+    print(len(solver.cp_model.proto.constraints))
     p = ParametersCp.default_cpsat()
-    res = cp_model.solve(
+    res = solver.solve(
         parameters_cp=p, time_limit=20, callbacks=[NbIterationStopper(1)]
     )
     solution: MultiskillRcpspSolution = res.get_best_solution_fit()[0]
@@ -111,14 +116,14 @@ def test_imopse_cpsat_w_non_renewable_n_cumulative_resource(
     # previous mode ko
     model.mode_details[task][1]["R0"] = 2
     model.update_problem()
-    cp_model = CpSatAutoMultiskillRcpspSolver(
+    solver = CpSatAutoMultiskillRcpspSolver(
         problem=model,
     )
-    cp_model.init_model(
+    solver.init_model(
         one_worker_per_task=True,
     )
     p = ParametersCp.default_cpsat()
-    res = cp_model.solve(
+    res = solver.solve(
         parameters_cp=p, time_limit=20, callbacks=[NbIterationStopper(1)]
     )
     solution: MultiskillRcpspSolution = res.get_best_solution_fit()[0]

--- a/tests/rcpsp_multiskill/solvers/test_cpsat_auto.py
+++ b/tests/rcpsp_multiskill/solvers/test_cpsat_auto.py
@@ -39,8 +39,25 @@ def test_imopse_cpsat():
     assert model.satisfy(solution)
 
 
-@pytest.mark.parametrize("use_energy_constraints", [False, True])
-def test_imopse_cpsat_w_non_renewable_n_cumulative_resource(use_energy_constraints):
+@pytest.mark.parametrize(
+    "one_worker_per_task, one_skill_per_task, exact_skill, slack_skill, use_energy_constraints",
+    [
+        (True, False, False, False, False),
+        (True, False, False, False, True),
+        (False, True, False, False, False),
+        (False, True, True, False, False),
+        (False, True, True, True, False),
+        (False, False, True, True, False),
+        (True, False, True, True, False),
+    ],
+)
+def test_imopse_cpsat_w_non_renewable_n_cumulative_resource(
+    one_worker_per_task,
+    one_skill_per_task,
+    exact_skill,
+    slack_skill,
+    use_energy_constraints,
+):
     file = [f for f in get_data_available() if "100_5_64_9.def" in f][0]
     model, _ = parse_file(file, max_horizon=1000)
 
@@ -48,7 +65,11 @@ def test_imopse_cpsat_w_non_renewable_n_cumulative_resource(use_energy_constrain
         problem=model,
     )
     cp_model.init_model(
-        one_worker_per_task=True, use_energy_constraints=use_energy_constraints
+        one_worker_per_task=one_worker_per_task,
+        one_skill_per_task=one_skill_per_task,
+        exact_skill=exact_skill,
+        slack_skill=slack_skill,
+        use_energy_constraints=use_energy_constraints,
     )
     p = ParametersCp.default_cpsat()
     res = cp_model.solve(
@@ -56,6 +77,19 @@ def test_imopse_cpsat_w_non_renewable_n_cumulative_resource(use_energy_constrain
     )
     solution: MultiskillRcpspSolution = res.get_best_solution_fit()[0]
     assert model.satisfy(solution)
+    # more assert according to modeling options
+    if one_worker_per_task:
+        assert all(
+            len(allocated) <= 1 for allocated in solution.employee_usage.values()
+        )
+    if one_skill_per_task:
+        assert all(
+            all(len(skills_used) == 1 for skills_used in allocated.values())
+            for allocated in solution.employee_usage.values()
+        )
+    assert solution.check_skill_constraints(
+        exact=exact_skill, slack=5 if slack_skill else 0
+    )
 
     # add resources that should change schedule and mode choice
     task = model.tasks_list[0]

--- a/tests/workforce/allocation/test_cpsat.py
+++ b/tests/workforce/allocation/test_cpsat.py
@@ -324,7 +324,9 @@ def test_compute_sufficient_assumptions(problem):
     )
 
 
-@pytest.mark.parametrize("modelisation_allocation", list(ModelisationAllocationOrtools))
+@pytest.mark.parametrize(
+    "modelisation_allocation", list(ModelisationAllocationOrtools)[::-1]
+)
 def test_constraint_nb_usages(problem, modelisation_allocation):
     solver = CpsatTeamAllocationSolver(problem)
     solver.init_model(modelisation_allocation=modelisation_allocation)
@@ -333,6 +335,7 @@ def test_constraint_nb_usages(problem, modelisation_allocation):
         callbacks=[NbIterationStopper(nb_iteration_max=1)]
     ).get_best_solution()
     nb_usages_total = sol.compute_nb_unary_resource_usages()
+    print(nb_usages_total)
     unary_resource = "adba7"
     nb_usages = sol.compute_nb_unary_resource_usages(unary_resources=(unary_resource,))
 
@@ -349,7 +352,8 @@ def test_constraint_nb_usages(problem, modelisation_allocation):
         ).get_best_solution()
         assert sol is None
     else:
-        target = int(nb_usages_total / 2)
+        print(solver.solver.value(solver.get_nb_tasks_done_variable()))
+        target = nb_usages_total - 5
         constraints = solver.add_constraint_on_total_nb_usages(
             sign=SignEnum.LESS, target=target
         )


### PR DESCRIPTION
- skill = cumulative resource that has to be brought by allocated unary resources
- mixin added to generic scheduling problem/solution/solver
- corresponding constraints added to cpsat auto
- checks added to solution (and integrated in rcpsp_multiskill satisfy())
- adaptation of problems deriving of generic scheduling
- mixin WithoutSkill to avoid implementing skills when no skill are in the problem
- add option in cpsat auto to add redundant calendar constraint on skills
- add method in skill problem to deduce skill calendar from unary resources calendars + skill values
- tests of more parameters for rcpsp_multikill (one_worker_per_task, one_skill_per_task, exact_skill, slack_skill)

Corrections in the same time:
- use | instead of Union in generic_task_tools
- add simplified checks for WithoutXXXSolution