### PR TITLE
Add timewindow mixin

### DIFF
--- a/src/discrete_optimization/generic_tasks_tools/generic_scheduling.py
+++ b/src/discrete_optimization/generic_tasks_tools/generic_scheduling.py
@@ -1,12 +1,14 @@
 #  Copyright (c) 2026 AIRBUS and its affiliates.
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
-from typing import Generic
+from functools import cache
+from typing import Generic, Optional
 
 from discrete_optimization.generic_tasks_tools.allocation import (
     UnaryResource,
 )
 from discrete_optimization.generic_tasks_tools.base import Task
+from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
 from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
     NonRenewableResource,
     NonRenewableResourceProblem,
@@ -22,9 +24,14 @@ from discrete_optimization.generic_tasks_tools.skill import (
     SkillProblem,
     SkillSolution,
 )
+from discrete_optimization.generic_tasks_tools.solvers.cpm import Cpm
 from discrete_optimization.generic_tasks_tools.timelag import (
     TimelagProblem,
     TimelagSolution,
+)
+from discrete_optimization.generic_tasks_tools.timewindow import (
+    TimewindowProblem,
+    TimewindowSolution,
 )
 
 CumulativeResource = Skill | NonSkillCumulativeResource
@@ -36,6 +43,7 @@ class GenericSchedulingProblem(
     NonRenewableResourceProblem[Task, NonRenewableResource],
     PrecedenceSchedulingProblem[Task],
     TimelagProblem[Task],
+    TimewindowProblem[Task],
     Generic[
         Task, UnaryResource, Skill, NonSkillCumulativeResource, NonRenewableResource
     ],
@@ -98,6 +106,205 @@ class GenericSchedulingProblem(
         """Check if given resource is a unary resource."""
         return resource in self.unary_resources_list
 
+    @cache
+    def get_task_start_or_end_tighter_lower_bound(
+        self,
+        task: Task,
+        start_or_end: StartOrEnd,
+        use_cpm: bool = False,
+        horizon: Optional[int] = None,
+    ) -> int:
+        """Get a tighter lower bound on task start or end using possible durations.
+
+        Args:
+            use_cpm: whether to use CPM propagating bounds through precedence graph
+            horizon: new horizon to take into account when computing tighter bounds,
+                default to problem horizon.
+
+        """
+        if horizon is None:
+            horizon = self.get_makespan_upper_bound()
+        if use_cpm:
+            tasks_bounds = self.compute_tighter_task_bounds(
+                use_cpm=True, horizon=horizon
+            )
+            start_lower_bound, end_lower_bound, start_upper_bound, end_upper_bound = (
+                tasks_bounds[task]
+            )
+            match start_or_end:
+                case StartOrEnd.START:
+                    return start_lower_bound
+                case _:
+                    return end_lower_bound
+        else:
+            if start_or_end == StartOrEnd.START:
+                return max(  # best bound between:
+                    # default bound
+                    0,
+                    # initial pb bound
+                    self.get_task_start_or_end_lower_bound(
+                        task=task, start_or_end=StartOrEnd.START
+                    ),
+                    # bound deduced from initial end lower bound and max duration
+                    self.get_task_start_or_end_lower_bound(
+                        task=task, start_or_end=StartOrEnd.END
+                    )
+                    - max(
+                        self.get_task_mode_duration(task=task, mode=mode)
+                        for mode in self.get_task_modes(task)
+                    ),
+                )
+            else:
+                return max(  # best bound between:
+                    # default bound
+                    0,
+                    # initial pb bound
+                    self.get_task_start_or_end_lower_bound(
+                        task=task, start_or_end=StartOrEnd.END
+                    ),
+                    # bound deduced from initial start lower bound and min duration
+                    max(
+                        self.get_task_start_or_end_lower_bound(
+                            task=task, start_or_end=StartOrEnd.START
+                        ),
+                        0,  # clip at 0
+                    )
+                    + min(
+                        self.get_task_mode_duration(task=task, mode=mode)
+                        for mode in self.get_task_modes(task)
+                    ),
+                )
+
+    @cache
+    def get_task_start_or_end_tighter_upper_bound(
+        self,
+        task: Task,
+        start_or_end: StartOrEnd,
+        use_cpm: bool = False,
+        horizon: Optional[int] = None,
+    ) -> int:
+        """Get a tighter upper bound on task start or end using possible durations.
+
+        Args:
+            use_cpm: whether to use CPM propagating bounds through precedence graph
+            horizon: new horizon to take into account when computing tighter bounds,
+                default to problem horizon.
+
+        """
+        if horizon is None:
+            horizon = self.get_makespan_upper_bound()
+        if use_cpm:
+            tasks_bounds = self.compute_tighter_task_bounds(
+                use_cpm=True, horizon=horizon
+            )
+            start_lower_bound, end_lower_bound, start_upper_bound, end_upper_bound = (
+                tasks_bounds[task]
+            )
+            match start_or_end:
+                case StartOrEnd.START:
+                    return start_upper_bound
+                case _:
+                    return end_upper_bound
+        else:
+            # no propagation, only using problem bounds + possible durations + new horizon
+            if start_or_end == StartOrEnd.START:
+                return min(  # best bound between:
+                    # initial pb bound
+                    self.get_task_start_or_end_upper_bound(
+                        task=task, start_or_end=StartOrEnd.START
+                    ),
+                    # bound deduced from initial end upper bound (clipped at new horizon) and min duration
+                    min(
+                        self.get_task_start_or_end_upper_bound(
+                            task=task, start_or_end=StartOrEnd.END
+                        ),
+                        horizon,  # new horizon
+                    )
+                    - min(  # min duration
+                        self.get_task_mode_duration(task=task, mode=mode)
+                        for mode in self.get_task_modes(task)
+                    ),
+                )
+            else:
+                return min(  # best bound between:
+                    # default bound: new horizon
+                    horizon,
+                    # initial pb bound
+                    self.get_task_start_or_end_upper_bound(
+                        task=task, start_or_end=StartOrEnd.END
+                    ),
+                    # bound deduced from initial start upper bound and max duration
+                    self.get_task_start_or_end_upper_bound(
+                        task=task, start_or_end=StartOrEnd.START
+                    )
+                    + max(
+                        self.get_task_mode_duration(task=task, mode=mode)
+                        for mode in self.get_task_modes(task)
+                    ),
+                )
+
+    def update_task_bounds(self) -> None:
+        """Method to be called when problem time windows are updated.
+
+        It clears necessary cache on computed tighter bounds.
+
+        """
+        self.get_task_start_or_end_tighter_upper_bound.cache_clear()
+        self.get_task_start_or_end_tighter_lower_bound.cache_clear()
+        self.compute_tighter_task_bounds.cache_clear()
+
+    @cache
+    def compute_tighter_task_bounds(
+        self, use_cpm: bool = False, horizon: Optional[int] = None
+    ) -> dict[Task, tuple[int, int, int, int]]:
+        """Compute tighter task bounds from problem time windows and min-max tak durations.
+
+        Args:
+            use_cpm: whether to use CPM propagating bounds through precedence graph
+            horizon: new horizon to take into account when computing tighter bounds,
+                default to problem horizon.
+
+        Returns:
+            {task: (start_lower_bound, end_lower_bound, start_upper_bound, end_upper_bound)}
+
+        """
+        if horizon is None:
+            horizon = self.get_makespan_upper_bound()
+        if use_cpm:
+            cpm = Cpm(problem=self, horizon=horizon)
+            cpm.compute_task_bounds()
+            return cpm.get_task_bounds()
+        else:
+            return {
+                task: (
+                    self.get_task_start_or_end_tighter_lower_bound(
+                        task=task,
+                        start_or_end=StartOrEnd.START,
+                        horizon=horizon,
+                        use_cpm=False,
+                    ),
+                    self.get_task_start_or_end_tighter_lower_bound(
+                        task=task,
+                        start_or_end=StartOrEnd.END,
+                        horizon=horizon,
+                        use_cpm=False,
+                    ),
+                    self.get_task_start_or_end_tighter_upper_bound(
+                        task=task,
+                        start_or_end=StartOrEnd.START,
+                        horizon=horizon,
+                        use_cpm=False,
+                    ),
+                    self.get_task_start_or_end_tighter_upper_bound(
+                        task=task,
+                        start_or_end=StartOrEnd.END,
+                        horizon=horizon,
+                        use_cpm=False,
+                    ),
+                )
+                for task in self.tasks_list
+            }
+
 
 class GenericSchedulingSolution(
     SkillSolution[
@@ -106,6 +313,7 @@ class GenericSchedulingSolution(
     NonRenewableResourceSolution[Task, NonRenewableResource],
     PrecedenceSchedulingSolution[Task],
     TimelagSolution[Task],
+    TimewindowSolution[Task],
     Generic[
         Task, UnaryResource, Skill, NonSkillCumulativeResource, NonRenewableResource
     ],

--- a/src/discrete_optimization/generic_tasks_tools/scheduling.py
+++ b/src/discrete_optimization/generic_tasks_tools/scheduling.py
@@ -42,38 +42,6 @@ class SchedulingProblem(TasksProblem[Task]):
         """Get an upper bound on global makespan."""
         pass
 
-    def get_task_start_or_end_lower_bound(
-        self, task: Task, start_or_end: StartOrEnd
-    ) -> int:
-        """Get a lower bound on start or end of a given task.
-
-        Default implementation: 0
-
-        Args:
-            task:
-            start_or_end:
-
-        Returns:
-
-        """
-        return 0
-
-    def get_task_start_or_end_upper_bound(
-        self, task: Task, start_or_end: StartOrEnd
-    ) -> int:
-        """Get an upper bound on start or end of a given task.
-
-        Default implementation: makespan upper bound
-
-        Args:
-            task:
-            start_or_end:
-
-        Returns:
-
-        """
-        return self.get_makespan_upper_bound()
-
 
 class SchedulingSolution(TasksSolution[Task]):
     """Base class for solution to scheduling problems."""

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpm.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpm.py
@@ -3,10 +3,12 @@
 #  LICENSE file in the root directory of this source tree.
 """CPM to compute lower/uppe bound on start/end of tasks"""
 
+from __future__ import annotations
+
 import logging
 from dataclasses import dataclass
 from heapq import heapify, heappop, heappush
-from typing import Any, Generic, Optional
+from typing import TYPE_CHECKING, Any, Generic, Optional
 
 import networkx as nx
 
@@ -16,9 +18,6 @@ from discrete_optimization.generic_tasks_tools.cumulative_resource import (
     CumulativeResource,
 )
 from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
-from discrete_optimization.generic_tasks_tools.generic_scheduling import (
-    GenericSchedulingProblem,
-)
 from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
     NonRenewableResource,
 )
@@ -26,6 +25,11 @@ from discrete_optimization.generic_tasks_tools.skill import (
     NonSkillCumulativeResource,
     Skill,
 )
+
+if TYPE_CHECKING:  # avoid circular imports due to annotations
+    from discrete_optimization.generic_tasks_tools.generic_scheduling import (
+        GenericSchedulingProblem,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +57,7 @@ class Cpm(Generic[Task, UnaryResource, CumulativeResource, NonRenewableResource]
     end lower_bounds = end upper bound for sink tasks. So sink tasks end upper bound will be set to horizon instead.
 
     For each task, we take best of propagated bound and existing problem bound on start/end
-    (via `problem.get_task_start_or_end_lower_bound()`).
+    (via `problem.get_task_start_or_end_tighter_lower_bound()` and `problem.get_task_start_or_end_tighter_upper_bound()`).
 
     Attributes:
         horizon: if set, override `problem.get_makespan_upper_bound()`.
@@ -246,8 +250,8 @@ class Cpm(Generic[Task, UnaryResource, CumulativeResource, NonRenewableResource]
             # update time to take into account problem bound
             time = max(
                 time,
-                self.problem.get_task_start_or_end_lower_bound(
-                    task=node, start_or_end=StartOrEnd.START
+                self.problem.get_task_start_or_end_tighter_lower_bound(
+                    task=node, start_or_end=StartOrEnd.START, use_cpm=False
                 ),
             )
             self.map_node[node].start_lower_bound = time
@@ -258,8 +262,8 @@ class Cpm(Generic[Task, UnaryResource, CumulativeResource, NonRenewableResource]
             # end lower bound : best of start lower bound + min duration and problem bound
             self.map_node[node].end_lower_bound = max(
                 time + min_duration,
-                self.problem.get_task_start_or_end_lower_bound(
-                    task=node, start_or_end=StartOrEnd.END
+                self.problem.get_task_start_or_end_tighter_lower_bound(
+                    task=node, start_or_end=StartOrEnd.END, use_cpm=False
                 ),
             )
             done.add(node)
@@ -287,8 +291,8 @@ class Cpm(Generic[Task, UnaryResource, CumulativeResource, NonRenewableResource]
             # update time to take into account problem bound
             eub = min(
                 -time,
-                self.problem.get_task_start_or_end_upper_bound(
-                    task=node, start_or_end=StartOrEnd.END
+                self.problem.get_task_start_or_end_tighter_upper_bound(
+                    task=node, start_or_end=StartOrEnd.END, use_cpm=False
                 ),
             )
             self.map_node[node].end_upper_bound = eub
@@ -299,8 +303,8 @@ class Cpm(Generic[Task, UnaryResource, CumulativeResource, NonRenewableResource]
             # start upper bound: best of end upper bound - min_duration and problem bound
             self.map_node[node].start_upper_bound = min(
                 eub - min_duration,
-                self.problem.get_task_start_or_end_upper_bound(
-                    task=node, start_or_end=StartOrEnd.START
+                self.problem.get_task_start_or_end_tighter_upper_bound(
+                    task=node, start_or_end=StartOrEnd.START, use_cpm=False
                 ),
             )
             done.add(node)

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto.py
@@ -35,7 +35,6 @@ from discrete_optimization.generic_tasks_tools.skill import (
     NonSkillCumulativeResource,
     Skill,
 )
-from discrete_optimization.generic_tasks_tools.solvers.cpm import Cpm
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.generic_scheduling import (
     GenericSchedulingCpSatSolver,
 )
@@ -259,47 +258,10 @@ class GenericSchedulingAutoCpSatSolver(
         - else only use min possible duration with 0, new_horizon (set by the solver in `self.get_makespan_upper_bound()`)
 
         """
-        if self.use_cpm_for_task_bounds:
-            cpm = Cpm(problem=self.problem, horizon=self.get_makespan_upper_bound())
-            cpm.compute_task_bounds()
-            self.tasks_bounds = cpm.get_task_bounds()
-        else:
-            self.tasks_bounds = {}
-            for task in self.problem.tasks_list:
-                start_lower_bound = self.problem.get_task_start_or_end_lower_bound(
-                    task=task, start_or_end=StartOrEnd.START
-                )
-                end_upper_bound = min(
-                    # use current bound + new "horizon"
-                    self.problem.get_task_start_or_end_upper_bound(
-                        task=task, start_or_end=StartOrEnd.END
-                    ),
-                    self.get_makespan_upper_bound(),
-                )
-                min_duration = min(
-                    self.problem.get_task_mode_duration(task=task, mode=mode)
-                    for mode in self.problem.get_task_modes(task=task)
-                )
-                end_lower_bound = max(
-                    # use start_lower bound + min_durations
-                    self.problem.get_task_start_or_end_lower_bound(
-                        task=task, start_or_end=StartOrEnd.END
-                    ),
-                    start_lower_bound + min_duration,
-                )
-                start_upper_bound = min(
-                    # use end_upper_bound - min_durations
-                    self.problem.get_task_start_or_end_upper_bound(
-                        task=task, start_or_end=StartOrEnd.START
-                    ),
-                    end_upper_bound - min_duration,
-                )
-                self.tasks_bounds[task] = (
-                    start_lower_bound,
-                    end_lower_bound,
-                    start_upper_bound,
-                    end_upper_bound,
-                )
+        self.tasks_bounds = self.problem.compute_tighter_task_bounds(
+            use_cpm=self.use_cpm_for_task_bounds,
+            horizon=self.get_makespan_upper_bound(),
+        )
 
     def get_task_start_or_end_lower_bound(
         self, task: Task, start_or_end: StartOrEnd

--- a/src/discrete_optimization/generic_tasks_tools/timewindow.py
+++ b/src/discrete_optimization/generic_tasks_tools/timewindow.py
@@ -1,0 +1,84 @@
+#  Copyright (c) 2026 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+import logging
+from typing import Generic
+
+from discrete_optimization.generic_tasks_tools.base import Task
+from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
+from discrete_optimization.generic_tasks_tools.scheduling import (
+    SchedulingProblem,
+    SchedulingSolution,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TimewindowProblem(SchedulingProblem[Task], Generic[Task]):
+    """Class for problem having time windows between tasks."""
+
+    def get_task_start_or_end_lower_bound(
+        self, task: Task, start_or_end: StartOrEnd
+    ) -> int:
+        """Get a lower bound on start or end of a given task as specified by the problem.
+
+        For tighter computed bounds, see `GenericSchedulingProblem.get_tight_task_start_or_end_lower_bound()` and
+        `GenericSchedulingProblem.compute_task_bounds()`.
+
+        Default implementation: 0
+
+        Args:
+            task:
+            start_or_end:
+
+        Returns:
+
+        """
+        return 0
+
+    def get_task_start_or_end_upper_bound(
+        self, task: Task, start_or_end: StartOrEnd
+    ) -> int:
+        """Get an upper bound on start or end of a given task as specified by the problem.
+
+        For tighter computed bounds, see `GenericSchedulingProblem.get_tight_task_start_or_end_upper_bound()` and
+        `GenericSchedulingProblem.compute_task_bounds()`.
+
+        Default implementation: makespan upper bound
+
+        Args:
+            task:
+            start_or_end:
+
+        Returns:
+
+        """
+        return self.get_makespan_upper_bound()
+
+
+class TimewindowSolution(SchedulingSolution[Task], Generic[Task]):
+    """Class for solution of problems having time windows between tasks."""
+
+    problem: TimewindowProblem[Task]
+
+    def check_time_windows(self) -> bool:
+        """check whether time windows are respected."""
+        for task in self.problem.tasks_list:
+            start = self.get_start_time(task)
+            if start < self.problem.get_task_start_or_end_lower_bound(
+                task=task, start_or_end=StartOrEnd.START
+            ) or start > self.problem.get_task_start_or_end_upper_bound(
+                task=task, start_or_end=StartOrEnd.START
+            ):
+                logger.debug(f"Window for start of {task} is not respected.")
+                return False
+            end = self.get_end_time(task)
+            if end < self.problem.get_task_start_or_end_lower_bound(
+                task=task, start_or_end=StartOrEnd.END
+            ) or end > self.problem.get_task_start_or_end_upper_bound(
+                task=task, start_or_end=StartOrEnd.END
+            ):
+                logger.debug(f"Window for end of {task} is not respected.")
+                return False
+
+        return True

--- a/src/discrete_optimization/rcpsp/problem.py
+++ b/src/discrete_optimization/rcpsp/problem.py
@@ -57,8 +57,6 @@ from discrete_optimization.rcpsp.special_constraints import (
     SpecialConstraintsDescription,
 )
 from discrete_optimization.rcpsp.utils import (
-    get_end_bounds_from_additional_constraint,
-    get_start_bounds_from_additional_constraint,
     intersect,
 )
 
@@ -294,6 +292,7 @@ class RcpspProblem(
         """
         self.update_calendars()
         self.update_special_constraints()
+        self.update_task_bounds()
         self.update_functions()
 
     def update_special_constraints(self):
@@ -459,30 +458,68 @@ class RcpspProblem(
     def get_task_start_or_end_lower_bound(
         self, task: Task, start_or_end: StartOrEnd
     ) -> int:
-        match start_or_end:
-            case StartOrEnd.START:
-                lb, ub = get_start_bounds_from_additional_constraint(
-                    rcpsp_problem=self, activity=task
-                )
-            case _:
-                lb, ub = get_end_bounds_from_additional_constraint(
-                    rcpsp_problem=self, activity=task
-                )
-        return lb
+        lb: int | None = None
+        if self.includes_special_constraint():
+            # special constraints
+            match start_or_end:
+                case StartOrEnd.START:  # start
+                    if (
+                        self.special_constraints.start_times is not None
+                        and task in self.special_constraints.start_times
+                    ):
+                        # lb = ub = forced start time
+                        lb = self.special_constraints.start_times[task]
+                    elif task in self.special_constraints.start_times_window:
+                        # start window
+                        lb, ub = self.special_constraints.start_times_window[task]
+
+                case _:  # end
+                    if (
+                        self.special_constraints.end_times is not None
+                        and task in self.special_constraints.end_times
+                    ):
+                        # lb = ub = forced end time
+                        lb = self.special_constraints.end_times[task]
+                    elif task in self.special_constraints.end_times_window:
+                        # end window
+                        lb, ub = self.special_constraints.end_times_window[task]
+        if lb is not None:
+            return lb
+        else:
+            return 0  # default lower bound
 
     def get_task_start_or_end_upper_bound(
         self, task: Task, start_or_end: StartOrEnd
     ) -> int:
-        match start_or_end:
-            case StartOrEnd.START:
-                lb, ub = get_start_bounds_from_additional_constraint(
-                    rcpsp_problem=self, activity=task
-                )
-            case _:
-                lb, ub = get_end_bounds_from_additional_constraint(
-                    rcpsp_problem=self, activity=task
-                )
-        return ub
+        ub: int | None = None
+        if self.includes_special_constraint():
+            # special constraints
+            match start_or_end:
+                case StartOrEnd.START:  # start
+                    if (
+                        self.special_constraints.start_times is not None
+                        and task in self.special_constraints.start_times
+                    ):
+                        # lb = ub = forced start time
+                        ub = self.special_constraints.start_times[task]
+                    elif task in self.special_constraints.start_times_window:
+                        # start window
+                        lb, ub = self.special_constraints.start_times_window[task]
+
+                case _:  # end
+                    if (
+                        self.special_constraints.end_times is not None
+                        and task in self.special_constraints.end_times
+                    ):
+                        # lb = ub = forced end time
+                        ub = self.special_constraints.end_times[task]
+                    elif task in self.special_constraints.end_times_window:
+                        # end window
+                        lb, ub = self.special_constraints.end_times_window[task]
+        if ub is not None:
+            return ub
+        else:
+            return self.get_makespan_upper_bound()  # default upper bound
 
     def update_functions(self) -> None:
         (

--- a/src/discrete_optimization/rcpsp_multiskill/problem.py
+++ b/src/discrete_optimization/rcpsp_multiskill/problem.py
@@ -24,6 +24,7 @@ from discrete_optimization.generic_tasks_tools.calendar_resource import (
     convert_calendar_to_availability_intervals,
     merge_resources_calendars,
 )
+from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
 from discrete_optimization.generic_tasks_tools.generic_scheduling import (
     GenericSchedulingProblem,
     GenericSchedulingSolution,
@@ -2109,7 +2110,12 @@ class MultiskillRcpspProblem(
             self.employees_list[i]: i for i in range(len(self.employees_list))
         }
         self.nb_employees = len(self.employees_list)
-        self.special_constraints = special_constraints
+        if special_constraints is None:
+            self.special_constraints = SpecialConstraintsDescription(
+                skip_special_constraints=True
+            )
+        else:
+            self.special_constraints = special_constraints
         self.partial_preemption_data = partial_preemption_data
         self.always_releasable_resources = always_releasable_resources
         self.never_releasable_resources = never_releasable_resources
@@ -2142,6 +2148,7 @@ class MultiskillRcpspProblem(
         self.create_employee_task_compatibility()
         self.update_calendars()
         self.update_special_constraints()
+        self.update_task_bounds()
         self.update_functions()
 
     def update_resource_sets(self):
@@ -2201,27 +2208,28 @@ class MultiskillRcpspProblem(
                     self.always_releasable_resources.add(r)
 
     def update_special_constraints(self):
-        self.do_special_constraints = self.special_constraints is not None
-        if self.special_constraints is None:
-            self.special_constraints = SpecialConstraintsDescription()
-        self.predecessors_dict = {task: [] for task in self.successors}
-        for task in self.successors:
-            for stask in self.successors[task]:
-                self.predecessors_dict[stask] += [task]
-        if self.do_special_constraints:
-            for t1, t2 in self.special_constraints.start_at_end:
-                if t2 not in self.successors[t1]:
-                    self.successors[t1].append(t2)
-            for t1, t2, off in self.special_constraints.start_at_end_plus_offset:
-                if t2 not in self.successors[t1]:
-                    self.successors[t1].append(t2)
-            for t1, t2 in self.special_constraints.start_together:
-                for predt1 in self.predecessors_dict[t1]:
-                    if t2 not in self.successors[predt1]:
-                        self.successors[predt1] += [t2]
-                for predt2 in self.predecessors_dict[t2]:
-                    if t1 not in self.successors[predt2]:
-                        self.successors[predt2] += [t1]
+        if self.special_constraints.skip_special_constraints:
+            self.do_special_constraints = False
+        else:
+            self.do_special_constraints = True
+            predecessors_dict = {task: [] for task in self.successors}
+            for task in self.successors:
+                for stask in self.successors[task]:
+                    predecessors_dict[stask] += [task]
+            if self.do_special_constraints:
+                for t1, t2 in self.special_constraints.start_at_end:
+                    if t2 not in self.successors[t1]:
+                        self.successors[t1].append(t2)
+                for t1, t2, off in self.special_constraints.start_at_end_plus_offset:
+                    if t2 not in self.successors[t1]:
+                        self.successors[t1].append(t2)
+                for t1, t2 in self.special_constraints.start_together:
+                    for predt1 in predecessors_dict[t1]:
+                        if t2 not in self.successors[predt1]:
+                            self.successors[predt1] += [t2]
+                    for predt2 in predecessors_dict[t2]:
+                        if t1 not in self.successors[predt2]:
+                            self.successors[predt2] += [t1]
         self.graph = self.compute_graph()
         self.predecessors = self.graph.predecessors_dict
 
@@ -2462,6 +2470,72 @@ class MultiskillRcpspProblem(
     ) -> bool:
         return self.compatibility_task_employee[task][unary_resource]
 
+    def get_task_start_or_end_lower_bound(
+        self, task: Task, start_or_end: StartOrEnd
+    ) -> int:
+        lb: int | None = None
+        if self.includes_special_constraint():
+            # special constraints
+            match start_or_end:
+                case StartOrEnd.START:  # start
+                    if (
+                        self.special_constraints.start_times is not None
+                        and task in self.special_constraints.start_times
+                    ):
+                        # lb = ub = forced start time
+                        lb = self.special_constraints.start_times[task]
+                    elif task in self.special_constraints.start_times_window:
+                        # start window
+                        lb, ub = self.special_constraints.start_times_window[task]
+
+                case _:  # end
+                    if (
+                        self.special_constraints.end_times is not None
+                        and task in self.special_constraints.end_times
+                    ):
+                        # lb = ub = forced end time
+                        lb = self.special_constraints.end_times[task]
+                    elif task in self.special_constraints.end_times_window:
+                        # end window
+                        lb, ub = self.special_constraints.end_times_window[task]
+        if lb is not None:
+            return lb
+        else:
+            return 0  # default lower bound
+
+    def get_task_start_or_end_upper_bound(
+        self, task: Task, start_or_end: StartOrEnd
+    ) -> int:
+        ub: int | None = None
+        if self.includes_special_constraint():
+            # special constraints
+            match start_or_end:
+                case StartOrEnd.START:  # start
+                    if (
+                        self.special_constraints.start_times is not None
+                        and task in self.special_constraints.start_times
+                    ):
+                        # lb = ub = forced start time
+                        ub = self.special_constraints.start_times[task]
+                    elif task in self.special_constraints.start_times_window:
+                        # start window
+                        lb, ub = self.special_constraints.start_times_window[task]
+
+                case _:  # end
+                    if (
+                        self.special_constraints.end_times is not None
+                        and task in self.special_constraints.end_times
+                    ):
+                        # lb = ub = forced end time
+                        ub = self.special_constraints.end_times[task]
+                    elif task in self.special_constraints.end_times_window:
+                        # end window
+                        lb, ub = self.special_constraints.end_times_window[task]
+        if ub is not None:
+            return ub
+        else:
+            return self.get_makespan_upper_bound()  # default upper bound
+
     def get_resource_available(self, res, time):
         return self.resources_availability[res][time]
 
@@ -2609,9 +2683,11 @@ class MultiskillRcpspProblem(
             and rcpsp_sol.check_skill_constraints()
             # Check consistency between compatibility/allocation/skill usage
             and rcpsp_sol.check_skill_usage_and_allocation_consistency()
-            and rcpsp_sol.check_allocation_consistency
+            and rcpsp_sol.check_allocation_consistency()
             # Check time lags
             and rcpsp_sol.check_time_lags()
+            # Check time window
+            and rcpsp_sol.check_time_windows()
         )
 
     def satisfy_preemptive(self, rcpsp_sol: PreemptiveMultiskillRcpspSolution) -> bool:

--- a/src/discrete_optimization/workforce/scheduling/problem.py
+++ b/src/discrete_optimization/workforce/scheduling/problem.py
@@ -270,6 +270,7 @@ class AllocSchedulingProblem(
             add_additional_constraint=True,
         )
         self.update_tasks_list()
+        self.update_task_bounds()
         self.update_resource_availabilities()
         self.compatible_teams_per_activity = self.compatible_teams_all_activity()
 
@@ -624,28 +625,7 @@ def satisfy_time_window(
     solution: AllocSchedulingSolution,
     partial_solution: bool = False,
 ):
-    for t in range(solution.schedule.shape[0]):
-        tsk = problem.tasks_list[t]
-        lb_s, ub_s = problem.start_window.get(tsk, (None, None))
-        lb_e, ub_e = problem.end_window.get(tsk, (None, None))
-        st, end = solution.schedule[t, :]
-        if lb_s is not None:
-            if st < lb_s:
-                ##logger.info(f"Task {t} starting before {lb_s}")
-                return False
-        if ub_s is not None:
-            if st > ub_s:
-                ##logger.info(f"Task {t} starting after {ub_s}")
-                return False
-        if lb_e is not None:
-            if end < lb_e:
-                ##logger.info(f"Task {t} ending before {lb_e}")
-                return False
-        if ub_e is not None:
-            if end > ub_e:
-                ##logger.info(f"Task {t} ending after {ub_e}")
-                return False
-    return True
+    return solution.check_time_windows()
 
 
 def full_satisfy(

--- a/tests/rcpsp/solvers/test_cpsat_auto.py
+++ b/tests/rcpsp/solvers/test_cpsat_auto.py
@@ -378,9 +378,10 @@ def test_special_constraints():
 
     resources = {"R1": 2}
 
-    # Test 1: start_together constraint
+    # Test 1: start_together constraint + start times
     special_constraints_1 = SpecialConstraintsDescription(
         start_together=[(2, 3)],  # tasks 2 and 3 start together
+        start_times={4: 10},  # task 4 should start at 10
     )
 
     problem_1 = RcpspProblem(
@@ -402,11 +403,13 @@ def test_special_constraints():
         f"task 2 starts at {solution_1.get_start_time(2)}, "
         f"task 3 starts at {solution_1.get_start_time(3)}"
     )
+    assert solution_1.get_start_time(4) == 10
     assert problem_1.satisfy(solution_1), "Solution should satisfy all constraints"
 
-    # Test 2: start_at_end constraint
+    # Test 2: start_at_end constraint + end times
     special_constraints_2 = SpecialConstraintsDescription(
         start_at_end=[(3, 4)],  # task 4 starts when task 3 ends
+        end_times={5: 20},  # task 5 ends at 20
     )
 
     problem_2 = RcpspProblem(
@@ -428,6 +431,7 @@ def test_special_constraints():
         f"task 3 ends at {solution_2.get_end_time(3)}, "
         f"task 4 starts at {solution_2.get_start_time(4)}"
     )
+    assert solution_2.get_end_time(5) == 20
     assert problem_2.satisfy(solution_2), "Solution should satisfy all constraints"
 
     # Test 3: start_times_window constraint


### PR DESCRIPTION
- dedicated mixin for lower/upper bound on tasks start/end
- check in solution
- compute tighter bounds in genericscheduling problems using min/max duration of each task and/or cpm
- use these tighter bounds in cpm itself
- use it in workforce/scheduling and rcpsp/rcpsp_ms + special constraints