### PR TITLE
Use precedence constraints to enrich timelag constraints and vice versa 

### DIFF
--- a/src/discrete_optimization/generic_rcpsp_tools/graph_tools.py
+++ b/src/discrete_optimization/generic_rcpsp_tools/graph_tools.py
@@ -107,7 +107,7 @@ class GraphSpecialConstraintsRcpsp(GraphRcpsp):
         for K in (
             self.special_constraints.start_together
             + self.special_constraints.start_at_end
-            + self.special_constraints.start_at_end_plus_offset
+            + self.special_constraints.start_after_end_plus_offset
             + self.special_constraints.start_to_start_min_time_lag
             + self.special_constraints.disjunctive_tasks
         ):

--- a/src/discrete_optimization/generic_tasks_tools/enums.py
+++ b/src/discrete_optimization/generic_tasks_tools/enums.py
@@ -4,3 +4,8 @@ from enum import Enum
 class StartOrEnd(Enum):
     START = "start"
     END = "end"
+
+
+class MinOrMax(Enum):
+    MIN = "min"
+    MAX = "max"

--- a/src/discrete_optimization/generic_tasks_tools/generic_scheduling.py
+++ b/src/discrete_optimization/generic_tasks_tools/generic_scheduling.py
@@ -1,6 +1,7 @@
 #  Copyright (c) 2026 AIRBUS and its affiliates.
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
+from collections import defaultdict
 from functools import cache
 from typing import Generic, Optional
 
@@ -8,7 +9,7 @@ from discrete_optimization.generic_tasks_tools.allocation import (
     UnaryResource,
 )
 from discrete_optimization.generic_tasks_tools.base import Task
-from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
+from discrete_optimization.generic_tasks_tools.enums import MinOrMax, StartOrEnd
 from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
     NonRenewableResource,
     NonRenewableResourceProblem,
@@ -28,6 +29,7 @@ from discrete_optimization.generic_tasks_tools.solvers.cpm import Cpm
 from discrete_optimization.generic_tasks_tools.timelag import (
     TimelagProblem,
     TimelagSolution,
+    consolidate_min_time_lags,
 )
 from discrete_optimization.generic_tasks_tools.timewindow import (
     TimewindowProblem,
@@ -304,6 +306,135 @@ class GenericSchedulingProblem(
                 )
                 for task in self.tasks_list
             }
+
+    @cache
+    def get_consolidated_time_lags(
+        self,
+        task1_start_or_end: StartOrEnd,
+        task2_start_or_end: StartOrEnd,
+        min_or_max: MinOrMax,
+    ):
+        """Get consolidated time lags.
+
+        Same normalization as in `TimelagProblem` parent class.
+        Also taking into account precedence constraints to enrich end to start min time lags.
+
+        Args:
+            task1_start_or_end:
+            task2_start_or_end:
+            min_or_max:
+
+        Returns:
+
+        """
+        timelags = super().get_consolidated_time_lags(
+            task1_start_or_end=task1_start_or_end,
+            task2_start_or_end=task2_start_or_end,
+            min_or_max=min_or_max,
+        )
+        if (task1_start_or_end, task2_start_or_end, min_or_max) == (
+            StartOrEnd.END,
+            StartOrEnd.START,
+            MinOrMax.MIN,
+        ):
+            # end to start min time lags: we add precedence constraints and keep only max(resulting offsets)
+            timelags = consolidate_min_time_lags(
+                timelags
+                + [
+                    (task1, task2, 0)
+                    for task1, next_tasks in self.get_precedence_constraints().items()
+                    for task2 in next_tasks
+                ]
+            )
+        return timelags
+
+    @cache
+    def get_consolidated_precedence_constraints(self) -> dict[Task, set[Task]]:
+        """Consolidate precedence constraints defined by problem.
+
+        It takes into account time lags constraints.
+        - end to start min constraint with non-negative offsets => precedence constraint
+        - start synchronization => corresponding tasks should appear together in successors
+        - end synchornization => corresponding tasks should share their successors
+
+        """
+        successors = defaultdict(set)
+
+        # end to task min timelag with offset >=0  => precedence constraint
+        # (original ones already included in consolidated time lags)
+        for task1, task2, offset in self.get_consolidated_time_lags(
+            task1_start_or_end=StartOrEnd.END,
+            task2_start_or_end=StartOrEnd.START,
+            min_or_max=MinOrMax.MIN,
+        ):
+            if offset >= 0:
+                successors[task1].add(task2)
+
+        # end together => same successors
+        min_end_to_end_timelags_0_offset = [
+            (t1, t2)
+            for t1, t2, offset in self.get_consolidated_time_lags(
+                task1_start_or_end=StartOrEnd.END,
+                task2_start_or_end=StartOrEnd.END,
+                min_or_max=MinOrMax.MIN,
+            )
+            if offset == 0
+        ]
+        max_end_to_end_timelags_0_offset = [
+            (t1, t2) for t2, t1 in min_end_to_end_timelags_0_offset
+        ]
+        end_together = set(min_end_to_end_timelags_0_offset).intersection(
+            max_end_to_end_timelags_0_offset
+        )
+        for task1, task2 in end_together:
+            successors[task1].update(successors[task2])
+            # the reverse will be done during the loop as (task2, task1) should also be in end_together
+
+        # start together => same predecessors
+        min_start_to_start_timelags_0_offset = [
+            (t1, t2)
+            for t1, t2, offset in self.get_consolidated_time_lags(
+                task1_start_or_end=StartOrEnd.START,
+                task2_start_or_end=StartOrEnd.START,
+                min_or_max=MinOrMax.MIN,
+            )
+            if offset == 0
+        ]
+        max_start_to_start_timelags_0_offset = [
+            (t1, t2) for t2, t1 in min_start_to_start_timelags_0_offset
+        ]
+        start_together = set(min_start_to_start_timelags_0_offset).intersection(
+            max_start_to_start_timelags_0_offset
+        )
+        for task, next_tasks in successors.items():
+            for task1, task2 in start_together:
+                if task1 in next_tasks:
+                    next_tasks.add(task2)
+
+        return successors
+
+    def update_time_lags(self) -> None:
+        """Method to call when time lags have been updated.
+
+        Clear cache from consolidated precedence constraints and time lags.
+
+        Returns:
+
+        """
+        self.get_consolidated_time_lags.cache_clear()
+        super().get_consolidated_time_lags.cache_clear()  # beware: parent class method also using cache !
+        self.get_consolidated_precedence_constraints.cache_clear()
+
+    def update_precedence_constraints(self) -> None:
+        """Method to call when precedence constraints have been updated.
+
+        Clear cache from consolidated precedence constraints and time lags.
+
+        Returns:
+
+        """
+        self.get_consolidated_precedence_constraints.cache_clear()
+        self.get_consolidated_time_lags.cache_clear()
 
 
 class GenericSchedulingSolution(

--- a/src/discrete_optimization/generic_tasks_tools/precedence.py
+++ b/src/discrete_optimization/generic_tasks_tools/precedence.py
@@ -22,10 +22,32 @@ class PrecedenceProblem(TasksProblem[Task]):
         """Map each task to the tasks that need to be performed after it."""
         ...
 
+    def get_consolidated_precedence_constraints(self) -> dict[Task, set[Task]]:
+        """Consolidate precedence constraints defined by problem.
+
+        In GenericSchedulingProblem it will also take into account time lags constraints.
+        Default implementation is only taking get_precededence_constraints, removing the potential duplicates.
+
+        """
+        return {
+            task: set(next_tasks)
+            for task, next_tasks in self.get_precedence_constraints().items()
+        }
+
+    def update_precedence_constraints(self) -> None:
+        """Method to call when precedence constraints have been updated.
+
+        To be overriden in child classes.
+
+        Returns:
+
+        """
+        pass
+
     def get_precedence_graph(self) -> Graph:
         nodes = [(task, {}) for task in self.tasks_list]
         edges = []
-        successors = self.get_precedence_constraints()
+        successors = self.get_consolidated_precedence_constraints()
         for n in successors:
             for succ in successors[n]:
                 edges += [(n, succ, {})]

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto.py
@@ -913,8 +913,7 @@ class GenericSchedulingAutoCpSatSolver(
                 resource
             ) or self.include_constraint_on_cumulative_resource(resource=resource):
                 self.create_calendar_resources_constraint(resource=resource)
-        # precedence
-        self.create_precedence_constraints()
+        # precedence: already included in time lag constraints
         # at most or exactly one resource allocated per task?
         self.add_unary_resources_per_task_constraints()
         # skill value per task constraints

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/timelag.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/timelag.py
@@ -2,7 +2,7 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 from discrete_optimization.generic_tasks_tools.base import Task
-from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
+from discrete_optimization.generic_tasks_tools.enums import MinOrMax, StartOrEnd
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.scheduling import (
     SchedulingCpSatSolver,
 )
@@ -16,21 +16,51 @@ class TimelagCpSatSolver(SchedulingCpSatSolver[Task]):
 
     def _create_timelag_constraints(
         self,
-        tasks_n_offsets_min: list[tuple[Task, Task, int]],
-        tasks_n_offsets_max: list[tuple[Task, Task, int]],
         task1_start_or_end: StartOrEnd,
         task2_start_or_end: StartOrEnd,
     ) -> None:
-        tasks_n_offsets_common = set(tasks_n_offsets_min).intersection(
-            set(tasks_n_offsets_max)
+        # after normalization only offsets >=0 (min time lags) or >0 (max time lags)
+        min_timelags = self.problem.get_consolidated_time_lags(
+            task1_start_or_end=task1_start_or_end,
+            task2_start_or_end=task2_start_or_end,
+            min_or_max=MinOrMax.MIN,
         )
-        tasks_n_offsets_min_only = set(tasks_n_offsets_min).difference(
-            set(tasks_n_offsets_max)
+        max_timelags = self.problem.get_consolidated_time_lags(
+            task1_start_or_end=task1_start_or_end,
+            task2_start_or_end=task2_start_or_end,
+            min_or_max=MinOrMax.MAX,
         )
-        tasks_n_offsets_max_only = set(tasks_n_offsets_max).difference(
-            set(tasks_n_offsets_min)
+
+        # equality constraints: two cases with consolidated time lags
+        # - offset > 0: (t1, t2, offset) in min and max time lags
+        # - offset==0: (t1, t2, 0) in min time lags and (t2, t1, 0) in reversed tasks min time lags
+        # set computation
+        equality_timelags_positive_offset = set(min_timelags).intersection(max_timelags)
+        min_timelags_0_offset = [
+            (t1, t2, 0) for (t1, t2, offset) in min_timelags if offset == 0
+        ]
+        max_timelags_0_offset = [
+            (t1, t2, 0)
+            for (t2, t1, offset) in self.problem.get_consolidated_time_lags(
+                task1_start_or_end=task2_start_or_end,
+                task2_start_or_end=task1_start_or_end,
+                min_or_max=MinOrMax.MIN,
+            )
+            if offset == 0
+        ]
+        equality_timelags_0_offset = set()
+        for t1, t2, _ in min_timelags_0_offset:
+            if (t1, t2, 0) in max_timelags_0_offset and (
+                # avoid adding twice an equality (start(t1) == start(t2) and start(t2) == start(t1))
+                task1_start_or_end != task2_start_or_end
+                or (t2, t1, 0) not in equality_timelags_0_offset
+            ):
+                equality_timelags_0_offset.add((t1, t2, 0))
+        equality_timelags = equality_timelags_positive_offset.union(
+            equality_timelags_0_offset
         )
-        for task1, task2, offset in tasks_n_offsets_common:
+        # add corresponding constraints to cp_model
+        for task1, task2, offset in equality_timelags:
             self.cp_model.add(
                 self.get_task_start_or_end_variable(
                     task=task1, start_or_end=task1_start_or_end
@@ -40,7 +70,12 @@ class TimelagCpSatSolver(SchedulingCpSatSolver[Task]):
                     task=task2, start_or_end=task2_start_or_end
                 )
             )
-        for task1, task2, offset in tasks_n_offsets_min_only:
+
+        # min only constraints
+        min_only_timelags = set(min_timelags).difference(
+            set(max_timelags).union(max_timelags_0_offset)
+        )
+        for task1, task2, offset in min_only_timelags:
             self.cp_model.add(
                 self.get_task_start_or_end_variable(
                     task=task1, start_or_end=task1_start_or_end
@@ -50,7 +85,9 @@ class TimelagCpSatSolver(SchedulingCpSatSolver[Task]):
                     task=task2, start_or_end=task2_start_or_end
                 )
             )
-        for task1, task2, offset in tasks_n_offsets_max_only:
+        # max only constraints
+        max_only_timelags = set(max_timelags).difference(min_timelags)
+        for task1, task2, offset in max_only_timelags:
             self.cp_model.add(
                 self.get_task_start_or_end_variable(
                     task=task1, start_or_end=task1_start_or_end
@@ -63,27 +100,15 @@ class TimelagCpSatSolver(SchedulingCpSatSolver[Task]):
 
     def create_timelag_constraints(self) -> None:
         """Add precedence constraints to cp model."""
-        self._create_timelag_constraints(
-            tasks_n_offsets_min=self.problem.get_start_to_start_min_time_lags(),
-            tasks_n_offsets_max=self.problem.get_start_to_start_max_time_lags(),
-            task1_start_or_end=StartOrEnd.START,
-            task2_start_or_end=StartOrEnd.START,
-        )
-        self._create_timelag_constraints(
-            tasks_n_offsets_min=self.problem.get_end_to_start_min_time_lags(),
-            tasks_n_offsets_max=self.problem.get_end_to_start_max_time_lags(),
-            task1_start_or_end=StartOrEnd.END,
-            task2_start_or_end=StartOrEnd.START,
-        )
-        self._create_timelag_constraints(
-            tasks_n_offsets_min=self.problem.get_end_to_end_min_time_lags(),
-            tasks_n_offsets_max=self.problem.get_end_to_end_max_time_lags(),
-            task1_start_or_end=StartOrEnd.END,
-            task2_start_or_end=StartOrEnd.END,
-        )
-        self._create_timelag_constraints(
-            tasks_n_offsets_min=self.problem.get_start_to_end_min_time_lags(),
-            tasks_n_offsets_max=self.problem.get_start_to_end_max_time_lags(),
-            task1_start_or_end=StartOrEnd.START,
-            task2_start_or_end=StartOrEnd.END,
-        )
+        for task1_start_or_end in StartOrEnd:
+            for task2_start_or_end in StartOrEnd:
+                if (task1_start_or_end, task2_start_or_end) == (
+                    StartOrEnd.START,
+                    StartOrEnd.END,
+                ):
+                    # already covered by (StartOrEnd.END, StartOrEnd.START)
+                    continue
+                self._create_timelag_constraints(
+                    task1_start_or_end=task1_start_or_end,
+                    task2_start_or_end=task2_start_or_end,
+                )

--- a/src/discrete_optimization/generic_tasks_tools/timelag.py
+++ b/src/discrete_optimization/generic_tasks_tools/timelag.py
@@ -2,9 +2,12 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 import logging
+from collections import defaultdict
+from functools import cache
 from typing import Generic
 
 from discrete_optimization.generic_tasks_tools.base import Task
+from discrete_optimization.generic_tasks_tools.enums import MinOrMax, StartOrEnd
 from discrete_optimization.generic_tasks_tools.scheduling import (
     SchedulingProblem,
     SchedulingSolution,
@@ -111,6 +114,187 @@ class TimelagProblem(SchedulingProblem[Task], Generic[Task]):
 
         """
         return []
+
+    def get_original_time_lags(
+        self,
+        task1_start_or_end: StartOrEnd,
+        task2_start_or_end: StartOrEnd,
+        min_or_max: MinOrMax,
+    ) -> list[tuple[Task, Task, int]]:
+        """Maps strt/end/min/max choices to corresponding list of timelags
+
+        Args:
+            task1_start_or_end:
+            task2_start_or_end:
+            min_or_max:
+
+        Returns:
+
+        """
+        match task1_start_or_end, task2_start_or_end, min_or_max:
+            case StartOrEnd.START, StartOrEnd.START, MinOrMax.MIN:
+                timelags = self.get_start_to_start_min_time_lags()
+            case StartOrEnd.START, StartOrEnd.START, MinOrMax.MAX:
+                timelags = self.get_start_to_start_max_time_lags()
+            case StartOrEnd.START, StartOrEnd.END, MinOrMax.MIN:
+                timelags = self.get_start_to_end_min_time_lags()
+            case StartOrEnd.START, StartOrEnd.END, MinOrMax.MAX:
+                timelags = self.get_start_to_end_max_time_lags()
+            case StartOrEnd.END, StartOrEnd.START, MinOrMax.MIN:
+                timelags = self.get_end_to_start_min_time_lags()
+            case StartOrEnd.END, StartOrEnd.START, MinOrMax.MAX:
+                timelags = self.get_end_to_start_max_time_lags()
+            case StartOrEnd.END, StartOrEnd.END, MinOrMax.MIN:
+                timelags = self.get_end_to_end_min_time_lags()
+            case StartOrEnd.END, StartOrEnd.END, MinOrMax.MAX:
+                timelags = self.get_end_to_end_max_time_lags()
+            case _:
+                timelags = []
+        return timelags
+
+    @cache
+    def get_consolidated_time_lags(
+        self,
+        task1_start_or_end: StartOrEnd,
+        task2_start_or_end: StartOrEnd,
+        min_or_max: MinOrMax,
+    ) -> list[tuple[Task, Task, int]]:
+        """Get consolidated time lags.
+
+        The goal is to normalize the time lags list to avoid having duplicates or constraints implied by others.
+        Note that it encompasses
+        - same tuples in one of the lists
+        - (t1, t2, offset) in end_to_start_min_time_lags and (t2, t1, -offset) in start_to_end_max_time_lags
+        - several offsets for the same tasks (t1, t2)
+
+        The choices made here to normalize are:
+        1. keep only positive offsets in max time lags (the others are converted to min time lags)
+        2. keep only non-negative offsets in min time lags (the others are converted to max time lags)
+        3. take max(offsets) in min time lags when several offsets are available for the same tasks (t1, t2)
+        4. take min(offsets) in max time lags when several offsets are available for the same tasks (t1, t2)
+        5. drop (t1, t2, offset) in max time lag (with offset>0) if (t2, t1, offset') with offset'>=0 is already in corresponding min time lag
+          as the latter implies trivially the other
+
+        Note that points 1, 4, and 5 amounts to taking min(offsets) on all tuples in max time lags
+        + converted ones from min time lags (t2,t1 -offset), whichever the sign, and drop it if this min(offsets) is non-negative
+        (whhich corresponds to the existence of (t2, t1, offset') with offset'>=0 in min time lags.
+
+        Moreover this method makes the mapping between all methods according to start/end/min/max.
+
+        Args:
+            task1_start_or_end:
+            task2_start_or_end:
+            min_or_max:
+
+        Returns:
+
+        """
+        if min_or_max == MinOrMax.MAX:
+            # max time lags from original + converted min time lags
+            timelags = consolidate_max_time_lags(
+                self.get_original_time_lags(
+                    task1_start_or_end=task1_start_or_end,
+                    task2_start_or_end=task2_start_or_end,
+                    min_or_max=MinOrMax.MAX,
+                )
+                + [
+                    (t2, t1, -offset)
+                    for t1, t2, offset in self.get_original_time_lags(
+                        task1_start_or_end=task2_start_or_end,
+                        task2_start_or_end=task1_start_or_end,
+                        min_or_max=MinOrMax.MIN,
+                    )
+                ]
+            )
+            # consolidate by taking min(offsets) for each tuple (t1, t2) + drop it if resulting offset <=0
+            # (see docstring for explanation)
+            return [
+                (t1, t2, offset)
+                for t1, t2, offset in consolidate_max_time_lags(timelags)
+                if offset > 0
+            ]
+        else:
+            # min time lags with non-negative offsets + converted max time lags with non-positive offsets
+            timelags = (
+                # original min time lag with
+                [
+                    (t1, t2, offset)
+                    for t1, t2, offset in self.get_original_time_lags(
+                        task1_start_or_end=task1_start_or_end,
+                        task2_start_or_end=task2_start_or_end,
+                        min_or_max=MinOrMax.MIN,
+                    )
+                    if offset >= 0
+                ]
+                # corresponding original max time lags tranformed into min time lags
+                + [
+                    (task2, task1, -offset)
+                    for task1, task2, offset in self.get_original_time_lags(
+                        task1_start_or_end=task2_start_or_end,
+                        task2_start_or_end=task1_start_or_end,
+                        min_or_max=MinOrMax.MAX,
+                    )
+                    if offset <= 0
+                ]
+            )
+            # take max(offsets) for each tuple (t1, t2)
+            return consolidate_min_time_lags(timelags=timelags)
+
+    def update_time_lags(self) -> None:
+        """Method to call when time lags have been updated.
+
+        Clear cache from consolidated precedence constraints.
+
+        Returns:
+
+        """
+        self.get_consolidated_time_lags.cache_clear()
+
+
+def consolidate_min_time_lags(
+    timelags: list[tuple[Task, Task, int]],
+) -> list[tuple[Task, Task, int]]:
+    """Get consolidated min time lags.
+
+    It merges min time lags targeting same tasks, taking the most restrictive offset.
+
+     Args:
+         timelags:
+
+     Returns:
+
+    """
+    offsets_per_tasks: dict[tuple[Task, Task], set[int]] = defaultdict(set)
+    for task1, task2, offset in timelags:
+        offsets_per_tasks[task1, task2].add(offset)
+
+    return [
+        (task1, task2, max(offsets))
+        for (task1, task2), offsets in offsets_per_tasks.items()
+    ]
+
+
+def consolidate_max_time_lags(
+    timelags: list[tuple[Task, Task, int]],
+) -> list[tuple[Task, Task, int]]:
+    """Get consolidated min time lags.
+
+    It merges min time lags targeting same tasks, taking the most restrictive offset.
+
+     Args:
+         timelags:
+
+     Returns:
+
+    """
+    offsets_per_tasks: dict[tuple[Task, Task], set[int]] = defaultdict(set)
+    for task1, task2, offset in timelags:
+        offsets_per_tasks[task1, task2].add(offset)
+
+    return [
+        (task1, task2, min(offsets))
+        for (task1, task2), offsets in offsets_per_tasks.items()
+    ]
 
 
 class TimelagSolution(SchedulingSolution[Task], Generic[Task]):

--- a/src/discrete_optimization/rcpsp/fast_function.py
+++ b/src/discrete_optimization/rcpsp/fast_function.py
@@ -267,7 +267,7 @@ def sgs_fast_preemptive_some_special_constraints(
     preemptive_tag: npt.NDArray[np.bool_],  # array(task)->bool
     predecessors: npt.NDArray[np.int_],  # array(task, task) -> bool
     successors: npt.NDArray[np.int_],  # array(task, task)->bool
-    start_at_end_plus_offset: npt.NDArray[
+    start_after_end_plus_offset: npt.NDArray[
         np.int_
     ],  # array(N, 3) -> (task1, task2, offset)
     start_to_start_min_time_lag: npt.NDArray[
@@ -303,10 +303,10 @@ def sgs_fast_preemptive_some_special_constraints(
         start_to_start_min_time_lag_links[task] = np.sum(
             start_to_start_min_time_lag[:, 1] == task
         )
-    start_at_end_plus_offset_links = np.zeros(nb_task)
+    start_after_end_plus_offset_links = np.zeros(nb_task)
     for task in range(nb_task):
-        start_at_end_plus_offset_links[task] = np.sum(
-            start_at_end_plus_offset[:, 1] == task
+        start_after_end_plus_offset_links[task] = np.sum(
+            start_after_end_plus_offset[:, 1] == task
         )
 
     done = 0
@@ -322,7 +322,7 @@ def sgs_fast_preemptive_some_special_constraints(
                 pred_links[permutation_task[i]] == 0
                 and done_np[permutation_task[i]] == 0
                 and start_to_start_min_time_lag_links[permutation_task[i]] == 0
-                and start_at_end_plus_offset_links[permutation_task[i]] == 0
+                and start_after_end_plus_offset_links[permutation_task[i]] == 0
             ):
                 act_id = permutation_task[i]
                 found = True
@@ -436,15 +436,15 @@ def sgs_fast_preemptive_some_special_constraints(
                         int(minimum_starting_time[task]), starts_dict[act_id][0] + off
                     )
                     start_to_start_min_time_lag_links[task] -= 1
-            for t in range(start_at_end_plus_offset.shape[0]):
-                if start_at_end_plus_offset[t, 0] == act_id:
-                    task = start_at_end_plus_offset[t, 1]
-                    off = start_at_end_plus_offset[t, 2]
+            for t in range(start_after_end_plus_offset.shape[0]):
+                if start_after_end_plus_offset[t, 0] == act_id:
+                    task = start_after_end_plus_offset[t, 1]
+                    off = start_after_end_plus_offset[t, 2]
                     minimum_starting_time[task] = max(
                         int(minimum_starting_time[task]),
                         activity_end_times[act_id] + off,
                     )
-                    start_at_end_plus_offset_links[task] -= 1
+                    start_after_end_plus_offset_links[task] -= 1
     return starts_dict, ends_dict, unfeasible_non_renewable_resources
 
 

--- a/src/discrete_optimization/rcpsp/problem.py
+++ b/src/discrete_optimization/rcpsp/problem.py
@@ -110,7 +110,6 @@ class RcpspProblem(
         index_task_non_dummy (dict[Hashable, int]): mapping task id to index among all non-dummy tasks (from 0 to n_jobs_non_dummy)
         special_constraints (SpecialConstraintsDescription): special additional constraints
         do_special_constraints (bool): True if they are special constraints to take into account
-        relax_the_start_at_end (bool): relax some conditions, only if do_special_constraints.
         fixed_permutation (Optional[list[int]]): To be used by solutions specifying only `rcpsp_modes`,
             e.g. in alternating genetic algorithms, that are updating only one solution attribute at a time.
             See `RcpspSolution` for more details.
@@ -188,7 +187,6 @@ class RcpspProblem(
         name_task: Optional[dict[Hashable, str]] = None,
         calendar_details: Optional[dict[str, list[list[int]]]] = None,
         special_constraints: Optional[SpecialConstraintsDescription] = None,
-        relax_the_start_at_end: bool = True,
         fixed_permutation: Optional[list[int]] = None,
         fixed_modes: Optional[list[int]] = None,
         **kwargs: Any,
@@ -207,7 +205,6 @@ class RcpspProblem(
             name_task:
             calendar_details:
             special_constraints:
-            relax_the_start_at_end:
             fixed_permutation:
             fixed_modes:
             **kwargs:
@@ -262,7 +259,6 @@ class RcpspProblem(
             "makespan": True,
             "mean_resource_reserve": kwargs.get("mean_resource_reserve", False),
         }
-        self.relax_the_start_at_end = relax_the_start_at_end
         self.fixed_permutation = fixed_permutation
         self.fixed_modes = fixed_modes
 
@@ -634,7 +630,6 @@ class RcpspProblem(
             if not check_solution_with_special_constraints(
                 problem=self,
                 solution=variable,
-                relax_the_start_at_end=self.relax_the_start_at_end,
             ):
                 return False
 
@@ -1077,7 +1072,6 @@ def compute_constraints_details(
 def check_solution_with_special_constraints(
     problem: RcpspProblem,
     solution: RcpspSolution,
-    relax_the_start_at_end: bool = True,
 ) -> bool:
     if not solution.rcpsp_schedule_feasible:
         return False
@@ -1128,56 +1122,38 @@ def check_solution_with_special_constraints(
             )
             return False
     for t1, t2 in start_together:
-        if not relax_the_start_at_end:
-            b = solution.get_start_time(t1) == solution.get_start_time(t2)
-            if not b:
-                logger.debug(("start_together NOT respected: ", t1, t2))
-                logger.debug(
-                    (
-                        "start(",
-                        t1,
-                        ") = ",
-                        solution.get_start_time(t1),
-                        " should be == start(",
-                        t2,
-                        ") = ",
-                        solution.get_start_time(t2),
-                    )
+        b = solution.get_start_time(t1) == solution.get_start_time(t2)
+        if not b:
+            logger.debug(("start_together NOT respected: ", t1, t2))
+            logger.debug(
+                (
+                    "start(",
+                    t1,
+                    ") = ",
+                    solution.get_start_time(t1),
+                    " should be == start(",
+                    t2,
+                    ") = ",
+                    solution.get_start_time(t2),
                 )
-                return False
+            )
+            return False
     for t1, t2 in start_at_end:
-        if relax_the_start_at_end:
-            b = solution.get_start_time(t2) >= solution.get_end_time(t1)
-        else:
-            b = solution.get_start_time(t2) == solution.get_end_time(t1)
+        b = solution.get_start_time(t2) == solution.get_end_time(t1)
         if not b:
             logger.debug(("start_at_end NOT respected: ", t1, t2))
-            if relax_the_start_at_end:
-                logger.debug(
-                    (
-                        "start(",
-                        t2,
-                        ") = ",
-                        solution.get_start_time(t2),
-                        " should be >= end(",
-                        t1,
-                        ") = ",
-                        solution.get_end_time(t1),
-                    )
+            logger.debug(
+                (
+                    "start(",
+                    t2,
+                    ") = ",
+                    solution.get_start_time(t2),
+                    " should be == end(",
+                    t1,
+                    ") = ",
+                    solution.get_end_time(t1),
                 )
-            else:
-                logger.debug(
-                    (
-                        "start(",
-                        t2,
-                        ") = ",
-                        solution.get_start_time(t2),
-                        " should be == end(",
-                        t1,
-                        ") = ",
-                        solution.get_end_time(t1),
-                    )
-                )
+            )
             return False
     for t1, t2, off in start_after_end_plus_offset:
         b = solution.get_start_time(t2) >= solution.get_end_time(t1) + off

--- a/src/discrete_optimization/rcpsp/problem.py
+++ b/src/discrete_optimization/rcpsp/problem.py
@@ -300,25 +300,8 @@ class RcpspProblem(
             self.do_special_constraints = False
         else:
             self.do_special_constraints = True
-            predecessors_dict: dict[Hashable, list[Hashable]] = {
-                task: [] for task in self.successors
-            }
-            for task in self.successors:
-                for stask in self.successors[task]:
-                    predecessors_dict[stask] += [task]
-            for t1, t2 in self.special_constraints.start_at_end:
-                if t2 not in self.successors[t1]:
-                    self.successors[t1].append(t2)
-            for t1, t2, off in self.special_constraints.start_at_end_plus_offset:
-                if t2 not in self.successors[t1]:
-                    self.successors[t1].append(t2)
-            for t1, t2 in self.special_constraints.start_together:
-                for predt1 in predecessors_dict[t1]:
-                    if t2 not in self.successors[predt1]:
-                        self.successors[predt1] += [t2]
-                for predt2 in predecessors_dict[t2]:
-                    if t1 not in self.successors[predt2]:
-                        self.successors[predt2] += [t1]
+        self.update_time_lags()
+        self.update_precedence_constraints()
         self.graph = self.compute_graph(
             compute_predecessors=self.do_special_constraints
         )
@@ -368,7 +351,7 @@ class RcpspProblem(
         return self._tasks_list
 
     def get_start_to_start_min_time_lags(self) -> list[tuple[Task, Task, int]]:
-        timelags = self.special_constraints.start_to_start_min_time_lag
+        timelags = list(self.special_constraints.start_to_start_min_time_lag)
         for task1, task2 in self.special_constraints.start_together:
             timelag = (task1, task2, 0)
             if timelag not in timelags:
@@ -376,7 +359,7 @@ class RcpspProblem(
         return timelags
 
     def get_start_to_start_max_time_lags(self) -> list[tuple[Task, Task, int]]:
-        timelags = self.special_constraints.start_to_start_max_time_lag
+        timelags = list(self.special_constraints.start_to_start_max_time_lag)
         for task1, task2 in self.special_constraints.start_together:
             timelag = (task1, task2, 0)
             if timelag not in timelags:
@@ -384,7 +367,7 @@ class RcpspProblem(
         return timelags
 
     def get_end_to_start_min_time_lags(self) -> list[tuple[Task, Task, int]]:
-        timelags = self.special_constraints.start_at_end_plus_offset
+        timelags = list(self.special_constraints.start_after_end_plus_offset)
         for task1, task2 in self.special_constraints.start_at_end:
             timelag = (task1, task2, 0)
             if timelag not in timelags:
@@ -578,9 +561,9 @@ class RcpspProblem(
             for n in self.tasks_list
         ]
         edges: list[tuple[Hashable, Hashable, dict[str, Any]]] = []
-        for n in self.successors:
-            for succ in self.successors[n]:
-                edges += [(n, succ, {})]
+        for task, next_tasks in self.get_consolidated_precedence_constraints().items():
+            for succ in next_tasks:
+                edges += [(task, succ, {})]
         return Graph(
             nodes, edges, compute_predecessors=compute_predecessors, undirected=False
         )
@@ -948,7 +931,7 @@ def compute_constraints_details(
         return []
     start_together = constraints.start_together
     start_at_end = constraints.start_at_end
-    start_at_end_plus_offset = constraints.start_at_end_plus_offset
+    start_after_end_plus_offset = constraints.start_after_end_plus_offset
     disjunctive = constraints.disjunctive_tasks
     list_constraints_not_respected: list[
         tuple[str, Hashable, Hashable, Optional[int], Optional[int], int]
@@ -1005,13 +988,20 @@ def compute_constraints_details(
             list_constraints_not_respected += [
                 ("start_at_end", t1, t2, time1, time2, abs(time2 - time1))
             ]
-    for t1, t2, off in start_at_end_plus_offset:
+    for t1, t2, off in start_after_end_plus_offset:
         time1 = solution.get_end_time(t1) + off
         time2 = solution.get_start_time(t2)
         b = time2 >= time1
         if not b:
             list_constraints_not_respected += [
-                ("start_at_end_plus_offset", t1, t2, time1, time2, abs(time2 - time1))
+                (
+                    "start_after_end_plus_offset",
+                    t1,
+                    t2,
+                    time1,
+                    time2,
+                    abs(time2 - time1),
+                )
             ]
     for t1, t2 in disjunctive:
         segt = intersect(
@@ -1093,7 +1083,9 @@ def check_solution_with_special_constraints(
         return False
     start_together = problem.special_constraints.start_together
     start_at_end = problem.special_constraints.start_at_end
-    start_at_end_plus_offset = problem.special_constraints.start_at_end_plus_offset
+    start_after_end_plus_offset = (
+        problem.special_constraints.start_after_end_plus_offset
+    )
     disjunctive = problem.special_constraints.disjunctive_tasks
     for t1, t2, off in problem.special_constraints.start_to_start_min_time_lag:
         b = solution.get_start_time(t1) + off <= solution.get_start_time(t2)
@@ -1187,10 +1179,10 @@ def check_solution_with_special_constraints(
                     )
                 )
             return False
-    for t1, t2, off in start_at_end_plus_offset:
+    for t1, t2, off in start_after_end_plus_offset:
         b = solution.get_start_time(t2) >= solution.get_end_time(t1) + off
         if not b:
-            logger.debug(("start_at_end_plus_offset NOT respected: ", t1, t2, off))
+            logger.debug(("start_after_end_plus_offset NOT respected: ", t1, t2, off))
             logger.debug(
                 (
                     solution.get_start_time(t2),

--- a/src/discrete_optimization/rcpsp/problem_preemptive.py
+++ b/src/discrete_optimization/rcpsp/problem_preemptive.py
@@ -387,7 +387,7 @@ class PartialPreemptiveRcpspSolution:
         list_partial_order: list[list[int]] = None,
         start_together: list[tuple[int, int]] = None,
         start_at_end: list[tuple[int, int]] = None,
-        start_at_end_plus_offset: list[tuple[int, int, int]] = None,
+        start_after_end_plus_offset: list[tuple[int, int, int]] = None,
         start_to_start_min_time_lag: list[tuple[int, int, int]] = None,
         start_to_start_max_time_lag: list[tuple[int, int, int]] = None,
         disjunctive_tasks: list[tuple[int, int]] = None,
@@ -401,7 +401,7 @@ class PartialPreemptiveRcpspSolution:
         self.list_partial_order = list_partial_order
         self.start_together = start_together
         self.start_at_end = start_at_end
-        self.start_at_end_plus_offset = start_at_end_plus_offset
+        self.start_after_end_plus_offset = start_after_end_plus_offset
         self.start_to_start_min_time_lag = start_to_start_min_time_lag
         self.start_to_start_max_time_lag = start_to_start_max_time_lag
         self.disjunctive_tasks = disjunctive_tasks

--- a/src/discrete_optimization/rcpsp/problem_robust.py
+++ b/src/discrete_optimization/rcpsp/problem_robust.py
@@ -48,7 +48,6 @@ class AggregRcpspProblem(RobustProblem, RcpspProblem):
             special_constraints=list_problem[0].special_constraints
             if list_problem[0].do_special_constraints
             else None,
-            relax_the_start_at_end=list_problem[0].relax_the_start_at_end,
             fixed_permutation=list_problem[0].fixed_permutation,
             fixed_modes=list_problem[0].fixed_modes,
         )

--- a/src/discrete_optimization/rcpsp/problem_specialized_constraints.py
+++ b/src/discrete_optimization/rcpsp/problem_specialized_constraints.py
@@ -165,7 +165,7 @@ class SpecialConstraintsPreemptiveRcpspProblem(PreemptiveRcpspProblem):
             for t1, t2 in self.special_constraints.start_at_end:
                 if t2 not in self.successors[t1]:
                     self.successors[t1].append(t2)
-            for t1, t2, off in self.special_constraints.start_at_end_plus_offset:
+            for t1, t2, off in self.special_constraints.start_after_end_plus_offset:
                 if t2 not in self.successors[t1]:
                     self.successors[t1].append(t2)
             for t1, t2 in self.special_constraints.start_together:
@@ -309,7 +309,7 @@ def compute_constraints_details(
         return []
     start_together = constraints.start_together
     start_at_end = constraints.start_at_end
-    start_at_end_plus_offset = constraints.start_at_end_plus_offset
+    start_after_end_plus_offset = constraints.start_after_end_plus_offset
     start_to_start_min_time_lag = constraints.start_to_start_min_time_lag
     start_to_start_max_time_lag = constraints.start_to_start_max_time_lag
     disjunctive = constraints.disjunctive_tasks
@@ -330,13 +330,20 @@ def compute_constraints_details(
             list_constraints_not_respected += [
                 ("start_at_end", t1, t2, time1, time2, abs(time2 - time1))
             ]
-    for t1, t2, off in start_at_end_plus_offset:
+    for t1, t2, off in start_after_end_plus_offset:
         time1 = solution.get_end_time(t1) + off
         time2 = solution.get_start_time(t2)
         b = time2 >= time1
         if not b:
             list_constraints_not_respected += [
-                ("start_at_end_plus_offset", t1, t2, time1, time2, abs(time2 - time1))
+                (
+                    "start_after_end_plus_offset",
+                    t1,
+                    t2,
+                    time1,
+                    time2,
+                    abs(time2 - time1),
+                )
             ]
     for t1, t2, off in start_to_start_min_time_lag:
         time1 = solution.get_start_time(t1) + off
@@ -448,7 +455,9 @@ def check_solution(
         return False
     start_together = problem.special_constraints.start_together
     start_at_end = problem.special_constraints.start_at_end
-    start_at_end_plus_offset = problem.special_constraints.start_at_end_plus_offset
+    start_after_end_plus_offset = (
+        problem.special_constraints.start_after_end_plus_offset
+    )
     disjunctive = problem.special_constraints.disjunctive_tasks
     for t1, t2 in start_together:
         if not relax_the_start_at_end:
@@ -462,10 +471,10 @@ def check_solution(
             b = solution.get_start_time(t2) == solution.get_end_time(t1)
         if not b:
             return False
-    for t1, t2, off in start_at_end_plus_offset:
+    for t1, t2, off in start_after_end_plus_offset:
         b = solution.get_start_time(t2) >= solution.get_end_time(t1) + off
         if not b:
-            logger.debug(("start_at_end_plus_offset NOT respected: ", t1, t2, off))
+            logger.debug(("start_after_end_plus_offset NOT respected: ", t1, t2, off))
             logger.debug(
                 (
                     solution.get_start_time(t2),
@@ -1357,15 +1366,15 @@ def create_np_data_and_jit_functions(
                 rcpsp_problem.special_constraints.start_times_window[t][0]
             )
 
-    start_at_end_plus_offset = np.zeros(
-        (len(rcpsp_problem.special_constraints.start_at_end_plus_offset), 3),
+    start_after_end_plus_offset = np.zeros(
+        (len(rcpsp_problem.special_constraints.start_after_end_plus_offset), 3),
         dtype=np.int_,
     )
     j = 0
-    for t1, t2, off in rcpsp_problem.special_constraints.start_at_end_plus_offset:
-        start_at_end_plus_offset[j, 0] = rcpsp_problem.index_task[t1]
-        start_at_end_plus_offset[j, 1] = rcpsp_problem.index_task[t2]
-        start_at_end_plus_offset[j, 2] = off
+    for t1, t2, off in rcpsp_problem.special_constraints.start_after_end_plus_offset:
+        start_after_end_plus_offset[j, 0] = rcpsp_problem.index_task[t1]
+        start_after_end_plus_offset[j, 1] = rcpsp_problem.index_task[t2]
+        start_after_end_plus_offset[j, 2] = off
         j += 1
     start_to_start_min_time_lag = np.zeros(
         (len(rcpsp_problem.special_constraints.start_to_start_min_time_lag), 3),
@@ -1382,7 +1391,7 @@ def create_np_data_and_jit_functions(
             sgs_fast_preemptive_some_special_constraints,
             consumption_array=consumption_array,
             preemptive_tag=preemptive_tag,
-            start_at_end_plus_offset=start_at_end_plus_offset,
+            start_after_end_plus_offset=start_after_end_plus_offset,
             start_to_start_min_time_lag=start_to_start_min_time_lag,
             minimum_starting_time_array=minimum_starting_time_array,
             duration_array=duration_array,

--- a/src/discrete_optimization/rcpsp/problem_specialized_constraints.py
+++ b/src/discrete_optimization/rcpsp/problem_specialized_constraints.py
@@ -133,7 +133,6 @@ class SpecialConstraintsPreemptiveRcpspProblem(PreemptiveRcpspProblem):
         horizon,
         special_constraints: SpecialConstraintsDescription = None,
         preemptive_indicator: dict[Hashable, bool] = None,
-        relax_the_start_at_end: bool = True,
         tasks_list: list[Union[int, str]] = None,
         source_task=None,
         sink_task=None,
@@ -181,7 +180,6 @@ class SpecialConstraintsPreemptiveRcpspProblem(PreemptiveRcpspProblem):
         self.sgs_func_partial = (
             generate_schedule_from_permutation_serial_sgs_partial_schedule_preempptive
         )
-        self.relax_the_start_at_end = relax_the_start_at_end
         (
             self.func_sgs,
             self.func_sgs_2,
@@ -213,7 +211,6 @@ class SpecialConstraintsPreemptiveRcpspProblem(PreemptiveRcpspProblem):
             horizon=self.horizon,
             special_constraints=deepcopy(self.special_constraints),
             preemptive_indicator=deepcopy(self.preemptive_indicator),
-            relax_the_start_at_end=self.relax_the_start_at_end,
             tasks_list=deepcopy(self.tasks_list),
             source_task=self.source_task,
             sink_task=self.sink_task,
@@ -229,7 +226,6 @@ class SpecialConstraintsPreemptiveRcpspProblem(PreemptiveRcpspProblem):
             horizon=self.horizon,
             special_constraints=self.special_constraints,
             preemptive_indicator=self.preemptive_indicator,
-            relax_the_start_at_end=self.relax_the_start_at_end,
             tasks_list=self.tasks_list,
             source_task=self.source_task,
             sink_task=self.sink_task,
@@ -269,7 +265,6 @@ class SpecialConstraintsPreemptiveRcpspProblem(PreemptiveRcpspProblem):
         s = check_solution(
             problem=self,
             solution=variable,
-            relax_the_start_at_end=self.relax_the_start_at_end,
         )
         if not s:
             return s
@@ -449,7 +444,6 @@ def check_solution(
         RcpspSolution,
         PreemptiveRcpspSolution,
     ],
-    relax_the_start_at_end: bool = True,
 ):
     if not solution.rcpsp_schedule_feasible:
         return False
@@ -460,15 +454,11 @@ def check_solution(
     )
     disjunctive = problem.special_constraints.disjunctive_tasks
     for t1, t2 in start_together:
-        if not relax_the_start_at_end:
-            b = solution.get_start_time(t1) == solution.get_start_time(t2)
-            if not b:
-                return False
+        b = solution.get_start_time(t1) == solution.get_start_time(t2)
+        if not b:
+            return False
     for t1, t2 in start_at_end:
-        if relax_the_start_at_end:
-            b = solution.get_start_time(t2) >= solution.get_end_time(t1)
-        else:
-            b = solution.get_start_time(t2) == solution.get_end_time(t1)
+        b = solution.get_start_time(t2) == solution.get_end_time(t1)
         if not b:
             return False
     for t1, t2, off in start_after_end_plus_offset:

--- a/src/discrete_optimization/rcpsp/solution.py
+++ b/src/discrete_optimization/rcpsp/solution.py
@@ -1731,7 +1731,7 @@ class PartialSolution:
         list_partial_order: Optional[list[list[int]]] = None,
         start_together: Optional[list[tuple[int, int]]] = None,
         start_at_end: Optional[list[tuple[int, int]]] = None,
-        start_at_end_plus_offset: Optional[list[tuple[int, int, int]]] = None,
+        start_after_end_plus_offset: Optional[list[tuple[int, int, int]]] = None,
         start_to_start_min_time_lag: Optional[list[tuple[int, int, int]]] = None,
         start_to_start_max_time_lag: Optional[list[tuple[int, int, int]]] = None,
         disjunctive_tasks: Optional[list[tuple[int, int]]] = None,
@@ -1745,7 +1745,7 @@ class PartialSolution:
         self.list_partial_order = list_partial_order
         self.start_together = start_together
         self.start_at_end = start_at_end
-        self.start_at_end_plus_offset = start_at_end_plus_offset
+        self.start_after_end_plus_offset = start_after_end_plus_offset
         self.start_to_start_min_time_lag = start_to_start_min_time_lag
         self.start_to_start_max_time_lag = start_to_start_max_time_lag
         self.disjunctive_tasks = disjunctive_tasks

--- a/src/discrete_optimization/rcpsp/solvers/cp_mzn.py
+++ b/src/discrete_optimization/rcpsp/solvers/cp_mzn.py
@@ -2364,8 +2364,8 @@ def soft_start_to_start_max_time_lag_mrcpsp(
     return [s], ["penalty_start_to_start_max_time_lag"]
 
 
-def hard_start_at_end_plus_offset_mrcpsp(
-    list_start_at_end_plus_offset,
+def hard_start_after_end_plus_offset_mrcpsp(
+    list_start_after_end_plus_offset,
     cp_solver: Union[
         CpMultimodeRcpspSolver,
         CPMultimodeWithFakeTaskRcpspSolver,
@@ -2373,7 +2373,7 @@ def hard_start_at_end_plus_offset_mrcpsp(
     ],
 ):
     constraint_strings = []
-    for t1, t2, delta in list_start_at_end_plus_offset:
+    for t1, t2, delta in list_start_after_end_plus_offset:
         string = (
             "constraint start["
             + str(cp_solver.index_in_minizinc[t2])
@@ -2389,14 +2389,14 @@ def hard_start_at_end_plus_offset_mrcpsp(
     return constraint_strings
 
 
-def hard_start_at_end_plus_offset(
-    list_start_at_end_plus_offset,
+def hard_start_after_end_plus_offset(
+    list_start_after_end_plus_offset,
     cp_solver: Union[
         CpPreemptiveRcpspSolver, CpMultimodePreemptiveRcpspSolver, CpRcpspSolver
     ],
 ):
     constraint_strings = []
-    for t1, t2, delta in list_start_at_end_plus_offset:
+    for t1, t2, delta in list_start_after_end_plus_offset:
         if isinstance(cp_solver, CpRcpspSolver):
             string = (
                 "constraint s["
@@ -2423,8 +2423,8 @@ def hard_start_at_end_plus_offset(
     return constraint_strings
 
 
-def soft_start_at_end_plus_offset_mrcpsp(
-    list_start_at_end_plus_offset: list[tuple[Hashable, Hashable, int]],
+def soft_start_after_end_plus_offset_mrcpsp(
+    list_start_after_end_plus_offset: list[tuple[Hashable, Hashable, int]],
     cp_solver: Union[
         CpMultimodeRcpspSolver,
         CPMultimodeWithFakeTaskRcpspSolver,
@@ -2433,83 +2433,83 @@ def soft_start_at_end_plus_offset_mrcpsp(
 ):
     s = (
         """
-        var 0..max_time*nb_start_at_end_plus_offset: penalty_start_at_end_plus_offset;\n
-        int: nb_start_at_end_plus_offset="""
-        + str(len(list_start_at_end_plus_offset))
+        var 0..max_time*nb_start_after_end_plus_offset: penalty_start_after_end_plus_offset;\n
+        int: nb_start_after_end_plus_offset="""
+        + str(len(list_start_after_end_plus_offset))
         + """;\n"""
         + """
-        array[1..nb_start_at_end_plus_offset] of Act: st1_6="""
+        array[1..nb_start_after_end_plus_offset] of Act: st1_6="""
         + str(
             [
                 cp_solver.index_in_minizinc[t1]
-                for t1, t2, delta in list_start_at_end_plus_offset
+                for t1, t2, delta in list_start_after_end_plus_offset
             ]
         )
         + """;\n"""
         + """
-        array[1..nb_start_at_end_plus_offset] of Act: st2_6="""
+        array[1..nb_start_after_end_plus_offset] of Act: st2_6="""
         + str(
             [
                 cp_solver.index_in_minizinc[t2]
-                for t1, t2, delta in list_start_at_end_plus_offset
+                for t1, t2, delta in list_start_after_end_plus_offset
             ]
         )
         + """;\n"""
         + """
-        array[1..nb_start_at_end_plus_offset] of int: nunits_6="""
-        + str([delta for t1, t2, delta in list_start_at_end_plus_offset])
+        array[1..nb_start_after_end_plus_offset] of int: nunits_6="""
+        + str([delta for t1, t2, delta in list_start_after_end_plus_offset])
         + """;\n"""
         + """
-        constraint sum(i in 1..nb_start_at_end_plus_offset)(max([0, start[st1_6[i]]+adur[st1_6[i]+nunits_6[i]-start[st2_6[i]]]))==penalty_start_at_end_plus_offset;\n
+        constraint sum(i in 1..nb_start_after_end_plus_offset)(max([0, start[st1_6[i]]+adur[st1_6[i]+nunits_6[i]-start[st2_6[i]]]))==penalty_start_after_end_plus_offset;\n
         """
     )
-    return [s], ["penalty_start_at_end_plus_offset"]
+    return [s], ["penalty_start_after_end_plus_offset"]
 
 
-def soft_start_at_end_plus_offset(
-    list_start_at_end_plus_offset: list[tuple[Hashable, Hashable, int]],
+def soft_start_after_end_plus_offset(
+    list_start_after_end_plus_offset: list[tuple[Hashable, Hashable, int]],
     cp_solver: Union[
         CpPreemptiveRcpspSolver, CpMultimodePreemptiveRcpspSolver, CpRcpspSolver
     ],
 ):
     s = (
         """
-        var 0..max_time*nb_start_at_end_plus_offset: penalty_start_at_end_plus_offset;\n
-        int: nb_start_at_end_plus_offset="""
-        + str(len(list_start_at_end_plus_offset))
+        var 0..max_time*nb_start_after_end_plus_offset: penalty_start_after_end_plus_offset;\n
+        int: nb_start_after_end_plus_offset="""
+        + str(len(list_start_after_end_plus_offset))
         + """;\n"""
         + """
-        array[1..nb_start_at_end_plus_offset] of Tasks: st1_7="""
+        array[1..nb_start_after_end_plus_offset] of Tasks: st1_7="""
         + str(
             [
                 cp_solver.index_in_minizinc[t1]
-                for t1, t2, delta in list_start_at_end_plus_offset
+                for t1, t2, delta in list_start_after_end_plus_offset
             ]
         )
         + """;\n"""
         + """
-        array[1..nb_start_at_end_plus_offset] of Tasks: st2_7="""
+        array[1..nb_start_after_end_plus_offset] of Tasks: st2_7="""
         + str(
             [
                 cp_solver.index_in_minizinc[t2]
-                for t1, t2, delta in list_start_at_end_plus_offset
+                for t1, t2, delta in list_start_after_end_plus_offset
             ]
         )
         + """;\n"""
         + """
-        array[1..nb_start_at_end_plus_offset] of int: nunits="""
-        + str([delta for t1, t2, delta in list_start_at_end_plus_offset])
+        array[1..nb_start_after_end_plus_offset] of int: nunits="""
+        + str([delta for t1, t2, delta in list_start_after_end_plus_offset])
         + """;\n"""
     )
     if isinstance(cp_solver, CpRcpspSolver):
         s += """
-             constraint sum(i in 1..nb_start_at_end_plus_offset)(max([0, s[st1_7[i]]+d[st1_7[i]]+nunits[i]-s[st2_7[i]]]))==penalty_start_at_end_plus_offset;\n
+             constraint sum(i in 1..nb_start_after_end_plus_offset)(max([0, s[st1_7[i]]+d[st1_7[i]]+nunits[i]-s[st2_7[i]]]))==penalty_start_after_end_plus_offset;\n
              """
     else:
         s += """
-             constraint sum(i in 1..nb_start_at_end_plus_offset)(max([0, s_preemptive[st1_7[i], nb_preemptive]+nunits[i]-s[st2_7[i]]]))==penalty_start_at_end_plus_offset;\n
+             constraint sum(i in 1..nb_start_after_end_plus_offset)(max([0, s_preemptive[st1_7[i], nb_preemptive]+nunits[i]-s[st2_7[i]]]))==penalty_start_after_end_plus_offset;\n
              """
-    return [s], ["penalty_start_at_end_plus_offset"]
+    return [s], ["penalty_start_after_end_plus_offset"]
 
 
 def hard_start_at_end_mrcpsp(
@@ -2971,9 +2971,9 @@ def add_hard_special_constraints_mrcpsp(
                 list_start_to_start_max_time_lag=partial_solution.start_to_start_max_time_lag,
                 cp_solver=cp_solver,
             )
-        if partial_solution.start_at_end_plus_offset is not None:
-            constraint_strings += hard_start_at_end_plus_offset_mrcpsp(
-                list_start_at_end_plus_offset=partial_solution.start_at_end_plus_offset,
+        if partial_solution.start_after_end_plus_offset is not None:
+            constraint_strings += hard_start_after_end_plus_offset_mrcpsp(
+                list_start_after_end_plus_offset=partial_solution.start_after_end_plus_offset,
                 cp_solver=cp_solver,
             )
         if partial_solution.start_at_end is not None:
@@ -3063,9 +3063,9 @@ def add_soft_special_constraints_mrcpsp(
             )
             constraint_strings += c
             name_penalty += n
-        if partial_solution.start_at_end_plus_offset is not None:
-            c, n = soft_start_at_end_plus_offset_mrcpsp(
-                list_start_at_end_plus_offset=partial_solution.start_at_end_plus_offset,
+        if partial_solution.start_after_end_plus_offset is not None:
+            c, n = soft_start_after_end_plus_offset_mrcpsp(
+                list_start_after_end_plus_offset=partial_solution.start_after_end_plus_offset,
                 cp_solver=cp_solver,
             )
             constraint_strings += c
@@ -3142,9 +3142,9 @@ def add_hard_special_constraints(
             list_start_to_start_max_time_lag=partial_solution.start_to_start_max_time_lag,
             cp_solver=cp_solver,
         )
-    if partial_solution.start_at_end_plus_offset is not None:
-        constraint_strings += hard_start_at_end_plus_offset(
-            list_start_at_end_plus_offset=partial_solution.start_at_end_plus_offset,
+    if partial_solution.start_after_end_plus_offset is not None:
+        constraint_strings += hard_start_after_end_plus_offset(
+            list_start_after_end_plus_offset=partial_solution.start_after_end_plus_offset,
             cp_solver=cp_solver,
         )
     if partial_solution.start_at_end is not None:
@@ -3223,9 +3223,9 @@ def add_soft_special_constraints(
         constraint_strings += c
         name_penalty += n
 
-    if partial_solution.start_at_end_plus_offset is not None:
-        c, n = soft_start_at_end_plus_offset(
-            list_start_at_end_plus_offset=partial_solution.start_at_end_plus_offset,
+    if partial_solution.start_after_end_plus_offset is not None:
+        c, n = soft_start_after_end_plus_offset(
+            list_start_after_end_plus_offset=partial_solution.start_after_end_plus_offset,
             cp_solver=cp_solver,
         )
         constraint_strings += c

--- a/src/discrete_optimization/rcpsp/solvers/cpsat.py
+++ b/src/discrete_optimization/rcpsp/solvers/cpsat.py
@@ -241,8 +241,12 @@ class CpSatRcpspSolver(
         for t1, t2 in self.problem.special_constraints.start_at_end:
             model.Add(ends_var[t1] == starts_var[t2])
 
-        # start_at_end_plus_offset: end(t1) + offset <= start(t2)
-        for t1, t2, offset in self.problem.special_constraints.start_at_end_plus_offset:
+        # start_after_end_plus_offset: end(t1) + offset <= start(t2)
+        for (
+            t1,
+            t2,
+            offset,
+        ) in self.problem.special_constraints.start_after_end_plus_offset:
             model.Add(ends_var[t1] + offset <= starts_var[t2])
 
         # disjunctive_tasks: tasks cannot overlap (pairwise)

--- a/src/discrete_optimization/rcpsp/solvers/lns_cp.py
+++ b/src/discrete_optimization/rcpsp/solvers/lns_cp.py
@@ -31,7 +31,9 @@ class PostProcessLeftShift(PostProcessSolution):
             def check_solution(problem, solution):
                 start_together = partial_solution.start_together
                 start_at_end = partial_solution.start_at_end
-                start_at_end_plus_offset = partial_solution.start_at_end_plus_offset
+                start_after_end_plus_offset = (
+                    partial_solution.start_after_end_plus_offset
+                )
                 start_to_start_min_time_lag = (
                     partial_solution.start_to_start_min_time_lag
                 )
@@ -52,7 +54,7 @@ class PostProcessLeftShift(PostProcessSolution):
                     )
                     if not b:
                         return False
-                for t1, t2, off in start_at_end_plus_offset:
+                for t1, t2, off in start_after_end_plus_offset:
                     b = (
                         solution.rcpsp_schedule[t2]["start_time"]
                         >= solution.rcpsp_schedule[t1]["end_time"] + off

--- a/src/discrete_optimization/rcpsp/solvers/lp.py
+++ b/src/discrete_optimization/rcpsp/solvers/lp.py
@@ -244,8 +244,8 @@ class _BaseLpRcpspSolver(MilpSolver, RcpspSolver):
                             <= self.starts[self.index_in_var[t1]] + offset
                         )
                     ]
-            if p_s.start_at_end_plus_offset is not None:
-                for t1, t2, delta in p_s.start_at_end_plus_offset:
+            if p_s.start_after_end_plus_offset is not None:
+                for t1, t2, delta in p_s.start_after_end_plus_offset:
                     constraints += [
                         self.add_linear_constraint(
                             self.starts[self.index_in_var[t2]]
@@ -577,8 +577,8 @@ class _BaseLpMultimodeRcpspSolver(MilpSolver, RcpspSolver):
                             self.starts[t2] <= self.starts[t1] + offset
                         )
                     ]
-            if p_s.start_at_end_plus_offset is not None:
-                for t1, t2, delta in p_s.start_at_end_plus_offset:
+            if p_s.start_after_end_plus_offset is not None:
+                for t1, t2, delta in p_s.start_after_end_plus_offset:
                     constraints += [
                         self.add_linear_constraint(
                             self.starts[t2] >= self.starts[t1] + delta + durations[t1]

--- a/src/discrete_optimization/rcpsp/special_constraints.py
+++ b/src/discrete_optimization/rcpsp/special_constraints.py
@@ -56,7 +56,9 @@ class SpecialConstraintsDescription:
         list_partial_order: Optional[list[list[Hashable]]] = None,
         start_together: Optional[list[tuple[Hashable, Hashable]]] = None,
         start_at_end: Optional[list[tuple[Hashable, Hashable]]] = None,
-        start_at_end_plus_offset: Optional[list[tuple[Hashable, Hashable, int]]] = None,
+        start_after_end_plus_offset: Optional[
+            list[tuple[Hashable, Hashable, int]]
+        ] = None,
         start_to_start_min_time_lag: Optional[
             list[tuple[Hashable, Hashable, int]]
         ] = None,
@@ -100,10 +102,10 @@ class SpecialConstraintsDescription:
             self.start_at_end = []
         else:
             self.start_at_end = start_at_end
-        if start_at_end_plus_offset is None:
-            self.start_at_end_plus_offset = []
+        if start_after_end_plus_offset is None:
+            self.start_after_end_plus_offset = []
         else:
-            self.start_at_end_plus_offset = start_at_end_plus_offset
+            self.start_after_end_plus_offset = start_after_end_plus_offset
         if start_to_start_min_time_lag is None:
             self.start_to_start_min_time_lag = []
         else:
@@ -142,7 +144,7 @@ class SpecialConstraintsDescription:
 
         self.dict_start_at_end_offset: dict[Hashable, dict[Hashable, int]] = {}
         self.dict_start_at_end_offset_reverse: dict[Hashable, dict[Hashable, int]] = {}
-        for i, j, off in self.start_at_end_plus_offset:
+        for i, j, off in self.start_after_end_plus_offset:
             if i not in self.dict_start_at_end_offset:
                 self.dict_start_at_end_offset[i] = {}
             if j not in self.dict_start_at_end_offset_reverse:

--- a/src/discrete_optimization/rcpsp_multiskill/fast_function_ms_rcpsp.py
+++ b/src/discrete_optimization/rcpsp_multiskill/fast_function_ms_rcpsp.py
@@ -749,7 +749,7 @@ def sgs_fast_ms_preemptive_some_special_constraints(
     preemptive_tag,  # array(task)->bool
     predecessors,  # array(task, task) -> bool
     successors,  # array(task, task)->bool
-    start_at_end_plus_offset,  # array(N, 3) -> (task1, task2, offset)
+    start_after_end_plus_offset,  # array(N, 3) -> (task1, task2, offset)
     start_after_nunit,  # array(N, 3) -> (task1, task2, offset)
     horizon,
     ressource_available,
@@ -792,10 +792,10 @@ def sgs_fast_ms_preemptive_some_special_constraints(
     for task in range(nb_task):
         start_after_nunit_links[task] = np.sum(start_after_nunit[:, 1] == task)
 
-    start_at_end_plus_offset_links = np.zeros(nb_task)
+    start_after_end_plus_offset_links = np.zeros(nb_task)
     for task in range(nb_task):
-        start_at_end_plus_offset_links[task] = np.sum(
-            start_at_end_plus_offset[:, 1] == task
+        start_after_end_plus_offset_links[task] = np.sum(
+            start_after_end_plus_offset[:, 1] == task
         )
 
     skills_usage = {}
@@ -807,7 +807,7 @@ def sgs_fast_ms_preemptive_some_special_constraints(
                 pred_links[permutation_task[i]] == 0
                 and done_np[permutation_task[i]] == 0
                 and start_after_nunit_links[permutation_task[i]] == 0
-                and start_at_end_plus_offset_links[permutation_task[i]] == 0
+                and start_after_end_plus_offset_links[permutation_task[i]] == 0
             ):
                 act_id = permutation_task[i]
                 break
@@ -1050,15 +1050,15 @@ def sgs_fast_ms_preemptive_some_special_constraints(
                         int(minimum_starting_time[task]), starts_dict[act_id][0] + off
                     )
                     start_after_nunit_links[task] -= 1
-            for t in range(start_at_end_plus_offset.shape[0]):
-                if start_at_end_plus_offset[t, 0] == act_id:
-                    task = start_at_end_plus_offset[t, 1]
-                    off = start_at_end_plus_offset[t, 2]
+            for t in range(start_after_end_plus_offset.shape[0]):
+                if start_after_end_plus_offset[t, 0] == act_id:
+                    task = start_after_end_plus_offset[t, 1]
+                    off = start_after_end_plus_offset[t, 2]
                     minimum_starting_time[task] = max(
                         int(minimum_starting_time[task]),
                         activity_end_times[act_id] + off,
                     )
-                    start_at_end_plus_offset_links[task] -= 1
+                    start_after_end_plus_offset_links[task] -= 1
 
     return starts_dict, ends_dict, skills_usage, unfeasible_non_renewable_resources
 

--- a/src/discrete_optimization/rcpsp_multiskill/problem.py
+++ b/src/discrete_optimization/rcpsp_multiskill/problem.py
@@ -2215,24 +2215,8 @@ class MultiskillRcpspProblem(
             self.do_special_constraints = False
         else:
             self.do_special_constraints = True
-            predecessors_dict = {task: [] for task in self.successors}
-            for task in self.successors:
-                for stask in self.successors[task]:
-                    predecessors_dict[stask] += [task]
-            if self.do_special_constraints:
-                for t1, t2 in self.special_constraints.start_at_end:
-                    if t2 not in self.successors[t1]:
-                        self.successors[t1].append(t2)
-                for t1, t2, off in self.special_constraints.start_at_end_plus_offset:
-                    if t2 not in self.successors[t1]:
-                        self.successors[t1].append(t2)
-                for t1, t2 in self.special_constraints.start_together:
-                    for predt1 in predecessors_dict[t1]:
-                        if t2 not in self.successors[predt1]:
-                            self.successors[predt1] += [t2]
-                    for predt2 in predecessors_dict[t2]:
-                        if t1 not in self.successors[predt2]:
-                            self.successors[predt2] += [t1]
+        self.update_time_lags()
+        self.update_precedence_constraints()
         self.graph = self.compute_graph()
         self.predecessors = self.graph.predecessors_dict
 
@@ -2269,7 +2253,7 @@ class MultiskillRcpspProblem(
         return self._tasks_list
 
     def get_start_to_start_min_time_lags(self) -> list[tuple[Task, Task, int]]:
-        timelags = self.special_constraints.start_to_start_min_time_lag
+        timelags = list(self.special_constraints.start_to_start_min_time_lag)
         for task1, task2 in self.special_constraints.start_together:
             timelag = (task1, task2, 0)
             if timelag not in timelags:
@@ -2277,7 +2261,7 @@ class MultiskillRcpspProblem(
         return timelags
 
     def get_start_to_start_max_time_lags(self) -> list[tuple[Task, Task, int]]:
-        timelags = self.special_constraints.start_to_start_max_time_lag
+        timelags = list(self.special_constraints.start_to_start_max_time_lag)
         for task1, task2 in self.special_constraints.start_together:
             timelag = (task1, task2, 0)
             if timelag not in timelags:
@@ -2285,7 +2269,7 @@ class MultiskillRcpspProblem(
         return timelags
 
     def get_end_to_start_min_time_lags(self) -> list[tuple[Task, Task, int]]:
-        timelags = self.special_constraints.start_at_end_plus_offset
+        timelags = list(self.special_constraints.start_after_end_plus_offset)
         for task1, task2 in self.special_constraints.start_at_end:
             timelag = (task1, task2, 0)
             if timelag not in timelags:
@@ -2622,16 +2606,16 @@ class MultiskillRcpspProblem(
             (
                 n,
                 {
-                    mode: self.mode_details[n][mode]["duration"]
+                    str(mode): self.mode_details[n][mode]["duration"]
                     for mode in self.mode_details[n]
                 },
             )
             for n in self.tasks_list
         ]
         edges = []
-        for n in self.successors:
-            for succ in self.successors[n]:
-                edges += [(n, succ, {})]
+        for task, next_tasks in self.get_consolidated_precedence_constraints().items():
+            for succ in next_tasks:
+                edges += [(task, succ, {})]
         return Graph(nodes, edges, False)
 
     def build_mode_dict(self, rcpsp_modes_from_solution):
@@ -3428,8 +3412,8 @@ def create_np_data_and_jit_functions(
             successors[i, index_s] = 1
 
     if rcpsp_problem.includes_special_constraint():
-        start_at_end_plus_offset = np.zeros(
-            (len(rcpsp_problem.special_constraints.start_at_end_plus_offset), 3),
+        start_after_end_plus_offset = np.zeros(
+            (len(rcpsp_problem.special_constraints.start_after_end_plus_offset), 3),
             dtype=np.int_,
         )
         start_after_nunit = np.zeros(
@@ -3437,10 +3421,14 @@ def create_np_data_and_jit_functions(
             dtype=np.int_,
         )
         j = 0
-        for t1, t2, off in rcpsp_problem.special_constraints.start_at_end_plus_offset:
-            start_at_end_plus_offset[j, 0] = rcpsp_problem.index_task[t1]
-            start_at_end_plus_offset[j, 1] = rcpsp_problem.index_task[t2]
-            start_at_end_plus_offset[j, 2] = off
+        for (
+            t1,
+            t2,
+            off,
+        ) in rcpsp_problem.special_constraints.start_after_end_plus_offset:
+            start_after_end_plus_offset[j, 0] = rcpsp_problem.index_task[t1]
+            start_after_end_plus_offset[j, 1] = rcpsp_problem.index_task[t2]
+            start_after_end_plus_offset[j, 2] = off
             j += 1
         j = 0
         for (
@@ -3472,7 +3460,7 @@ def create_np_data_and_jit_functions(
     # worker_skills         # array(workers, skills)->int
     if rcpsp_problem.preemptive:
         if rcpsp_problem.includes_special_constraint() and (
-            start_after_nunit.shape[0] > 0 or start_at_end_plus_offset.shape[0] > 0
+            start_after_nunit.shape[0] > 0 or start_after_end_plus_offset.shape[0] > 0
         ):
             func_sgs = partial(
                 sgs_fast_ms_preemptive_some_special_constraints,
@@ -3482,7 +3470,7 @@ def create_np_data_and_jit_functions(
                 worker_available=worker_available,
                 duration_array=duration_array,
                 minimum_starting_time_array=minimum_starting_time_array,
-                start_at_end_plus_offset=start_at_end_plus_offset,
+                start_after_end_plus_offset=start_after_end_plus_offset,
                 start_after_nunit=start_after_nunit,
                 predecessors=predecessors,
                 preemptive_tag=preemptive_tag,
@@ -3602,7 +3590,7 @@ def compute_constraints_details(
 ):
     start_together = constraints.start_together
     start_at_end = constraints.start_at_end
-    start_at_end_plus_offset = constraints.start_at_end_plus_offset
+    start_after_end_plus_offset = constraints.start_after_end_plus_offset
     start_after_nunit = constraints.start_to_start_min_time_lag
     disjunctive = constraints.disjunctive_tasks
     list_constraints_not_respected = []
@@ -3622,13 +3610,20 @@ def compute_constraints_details(
             list_constraints_not_respected += [
                 ("start_at_end", t1, t2, time1, time2, abs(time2 - time1))
             ]
-    for t1, t2, off in start_at_end_plus_offset:
+    for t1, t2, off in start_after_end_plus_offset:
         time1 = solution.get_end_time(t1) + off
         time2 = solution.get_start_time(t2)
         b = time2 >= time1
         if not b:
             list_constraints_not_respected += [
-                ("start_at_end_plus_offset", t1, t2, time1, time2, abs(time2 - time1))
+                (
+                    "start_after_end_plus_offset",
+                    t1,
+                    t2,
+                    time1,
+                    time2,
+                    abs(time2 - time1),
+                )
             ]
     for t1, t2, off in start_after_nunit:
         time1 = solution.get_start_time(t1) + off
@@ -3746,7 +3741,9 @@ def check_solution(
 ):
     start_together = problem.special_constraints.start_together
     start_at_end = problem.special_constraints.start_at_end
-    start_at_end_plus_offset = problem.special_constraints.start_at_end_plus_offset
+    start_after_end_plus_offset = (
+        problem.special_constraints.start_after_end_plus_offset
+    )
     start_after_nunit = problem.special_constraints.start_to_start_min_time_lag
     disjunctive = problem.special_constraints.disjunctive_tasks
     for t1, t2 in start_together:
@@ -3761,7 +3758,7 @@ def check_solution(
             b = solution.get_start_time(t2) == solution.get_end_time(t1)
         if not b:
             return False
-    for t1, t2, off in start_at_end_plus_offset:
+    for t1, t2, off in start_after_end_plus_offset:
         b = solution.get_start_time(t2) >= solution.get_end_time(t1) + off
         if not b:
             return False

--- a/src/discrete_optimization/rcpsp_multiskill/problem.py
+++ b/src/discrete_optimization/rcpsp_multiskill/problem.py
@@ -3737,7 +3737,6 @@ def start_together_problem_description(
 def check_solution(
     problem: Union[MultiskillRcpspProblem],
     solution: Union[MultiskillRcpspSolution, PreemptiveMultiskillRcpspSolution],
-    relax_the_start_at_end: bool = True,
 ):
     start_together = problem.special_constraints.start_together
     start_at_end = problem.special_constraints.start_at_end
@@ -3747,15 +3746,11 @@ def check_solution(
     start_after_nunit = problem.special_constraints.start_to_start_min_time_lag
     disjunctive = problem.special_constraints.disjunctive_tasks
     for t1, t2 in start_together:
-        if not relax_the_start_at_end:
-            b = solution.get_start_time(t1) == solution.get_start_time(t2)
-            if not b:
-                return False
+        b = solution.get_start_time(t1) == solution.get_start_time(t2)
+        if not b:
+            return False
     for t1, t2 in start_at_end:
-        if relax_the_start_at_end:
-            b = solution.get_start_time(t2) >= solution.get_end_time(t1)
-        else:
-            b = solution.get_start_time(t2) == solution.get_end_time(t1)
+        b = solution.get_start_time(t2) == solution.get_end_time(t1)
         if not b:
             return False
     for t1, t2, off in start_after_end_plus_offset:

--- a/src/discrete_optimization/rcpsp_multiskill/solvers/cp_mzn.py
+++ b/src/discrete_optimization/rcpsp_multiskill/solvers/cp_mzn.py
@@ -1600,12 +1600,12 @@ def soft_start_after_nunit(
     return [s], ["penalty_start_after_nunit"]
 
 
-def hard_start_at_end_plus_offset(
-    list_start_at_end_plus_offset,
+def hard_start_after_end_plus_offset(
+    list_start_after_end_plus_offset,
     cp_solver: Union[CpMultiskillRcpspSolver, CpPreemptiveMultiskillRcpspSolver],
 ):
     constraint_strings = []
-    for t1, t2, delta in list_start_at_end_plus_offset:
+    for t1, t2, delta in list_start_after_end_plus_offset:
         if isinstance(cp_solver, CpMultiskillRcpspSolver):
             string = (
                 "constraint s["
@@ -1632,48 +1632,48 @@ def hard_start_at_end_plus_offset(
     return constraint_strings
 
 
-def soft_start_at_end_plus_offset(
-    list_start_at_end_plus_offset: list[tuple[Hashable, Hashable, int]],
+def soft_start_after_end_plus_offset(
+    list_start_after_end_plus_offset: list[tuple[Hashable, Hashable, int]],
     cp_solver: Union[CpMultiskillRcpspSolver, CpPreemptiveMultiskillRcpspSolver],
 ):
     s = (
         """
-        var 0..max_time*nb_start_at_end_plus_offset: penalty_start_at_end_plus_offset;\n
-        int: nb_start_at_end_plus_offset="""
-        + str(len(list_start_at_end_plus_offset))
+        var 0..max_time*nb_start_after_end_plus_offset: penalty_start_after_end_plus_offset;\n
+        int: nb_start_after_end_plus_offset="""
+        + str(len(list_start_after_end_plus_offset))
         + """;\n"""
         + """
-        array[1..nb_start_at_end_plus_offset] of Tasks: st1_7="""
+        array[1..nb_start_after_end_plus_offset] of Tasks: st1_7="""
         + str(
             [
                 cp_solver.index_in_minizinc[t1]
-                for t1, t2, delta in list_start_at_end_plus_offset
+                for t1, t2, delta in list_start_after_end_plus_offset
             ]
         )
         + """;\n"""
         + """
-        array[1..nb_start_at_end_plus_offset] of Tasks: st2_7="""
+        array[1..nb_start_after_end_plus_offset] of Tasks: st2_7="""
         + str(
             [
                 cp_solver.index_in_minizinc[t2]
-                for t1, t2, delta in list_start_at_end_plus_offset
+                for t1, t2, delta in list_start_after_end_plus_offset
             ]
         )
         + """;\n"""
         + """
-        array[1..nb_start_at_end_plus_offset] of int: nunits="""
-        + str([delta for t1, t2, delta in list_start_at_end_plus_offset])
+        array[1..nb_start_after_end_plus_offset] of int: nunits="""
+        + str([delta for t1, t2, delta in list_start_after_end_plus_offset])
         + """;\n"""
     )
     if isinstance(cp_solver, CpMultiskillRcpspSolver):
         s += """
-             constraint sum(i in 1..nb_start_at_end_plus_offset)(max([0, s[st1_7[i]]+adur[st1_7[i]]+nunits[i]-s[st2_7[i]]]))==penalty_start_at_end_plus_offset;\n
+             constraint sum(i in 1..nb_start_after_end_plus_offset)(max([0, s[st1_7[i]]+adur[st1_7[i]]+nunits[i]-s[st2_7[i]]]))==penalty_start_after_end_plus_offset;\n
              """
     else:
         s += """
-             constraint sum(i in 1..nb_start_at_end_plus_offset)(max([0, s_preemptive[st1_7[i], nb_preemptive]+nunits[i]-s[st2_7[i]]]))==penalty_start_at_end_plus_offset;\n
+             constraint sum(i in 1..nb_start_after_end_plus_offset)(max([0, s_preemptive[st1_7[i], nb_preemptive]+nunits[i]-s[st2_7[i]]]))==penalty_start_after_end_plus_offset;\n
              """
-    return [s], ["penalty_start_at_end_plus_offset"]
+    return [s], ["penalty_start_after_end_plus_offset"]
 
 
 def hard_start_at_end(
@@ -1924,9 +1924,9 @@ def add_hard_special_constraints(
             list_start_after_nunit=partial_solution.start_to_start_min_time_lag,
             cp_solver=cp_solver,
         )
-    if partial_solution.start_at_end_plus_offset is not None:
-        constraint_strings += hard_start_at_end_plus_offset(
-            list_start_at_end_plus_offset=partial_solution.start_at_end_plus_offset,
+    if partial_solution.start_after_end_plus_offset is not None:
+        constraint_strings += hard_start_after_end_plus_offset(
+            list_start_after_end_plus_offset=partial_solution.start_after_end_plus_offset,
             cp_solver=cp_solver,
         )
     if partial_solution.start_at_end is not None:
@@ -1995,9 +1995,9 @@ def add_soft_special_constraints(
         )
         constraint_strings += c
         name_penalty += n
-    if partial_solution.start_at_end_plus_offset is not None:
-        c, n = soft_start_at_end_plus_offset(
-            list_start_at_end_plus_offset=partial_solution.start_at_end_plus_offset,
+    if partial_solution.start_after_end_plus_offset is not None:
+        c, n = soft_start_after_end_plus_offset(
+            list_start_after_end_plus_offset=partial_solution.start_after_end_plus_offset,
             cp_solver=cp_solver,
         )
         constraint_strings += c

--- a/tests/generic_rcpsp_tools/test_graph_tools.py
+++ b/tests/generic_rcpsp_tools/test_graph_tools.py
@@ -31,6 +31,7 @@ def test_graph_tools(rcpsp_problem_file):
     )
     some_successor_task = random.choice(rcpsp_problem.successors[some_task])
     rcpsp_problem_copy.successors[some_successor_task].append(some_task)
+    rcpsp_problem.update_problem()
     graph_rcpsp_with_loop = build_graph_rcpsp_object(rcpsp_problem_copy)
     cycles = graph_rcpsp_with_loop.check_loop()
     # With this precedence graph, the rcpsp is no longer feasible.

--- a/tests/rcpsp/solvers/test_cpsat_auto.py
+++ b/tests/rcpsp/solvers/test_cpsat_auto.py
@@ -391,7 +391,6 @@ def test_special_constraints():
         successors=successors,
         horizon=100,
         special_constraints=special_constraints_1,
-        relax_the_start_at_end=False,
     )
 
     solver_1 = CpSatAutoRcpspSolver(problem=problem_1)

--- a/tests/rcpsp/solvers/test_cpsat_auto.py
+++ b/tests/rcpsp/solvers/test_cpsat_auto.py
@@ -391,6 +391,7 @@ def test_special_constraints():
         successors=successors,
         horizon=100,
         special_constraints=special_constraints_1,
+        relax_the_start_at_end=False,
     )
 
     solver_1 = CpSatAutoRcpspSolver(problem=problem_1)


### PR DESCRIPTION
- Normalization of timelag constraints: with negative offsets it is possible to express the same constraints with time lag in min or max list. Moreover duplicates or implied constraints can exist => we normalize the constraints via `get_consolidated_time_lags()`.  Thus we update cpsat-auto:
  - how it finds equality timelags, and avoid adding two equivalent equality constraints
  - avoid adding start_to_end timelags constraints, already encompassed by end_to_start timelags constraints

- Precedence constraints can be seen as end to start min time lags constraints => we add them to consolidated time lags, and we stop adding precedence constraints in cpsat auto to avoid duplicate constraints. We use that normalization in rcpsp/rcpsp_ms when constructing graph

- Conversely, time lag constraints imply precedence constraints and thus should be taken into account into the precedence graph => `get_consolidated_precedence_constraints()`

In the meantime
- We fix timelag constraints implementation in rcpsp/rcpsp_ms which were
  modifying the original list of timelags given in constructor.
- We remove `relax_the_start_at_end` parameter used in rcpsp(_ms) satisfy