### PR TITLE
Replace use of functools.cache/lru_cache by wrapt.lru_cache on methods

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     "didppy>=0.8.0",
     "setuptools",
     "pandas>=2",
+    "wrapt>=2.2.1",
 ]
 dynamic = ["version"]
 

--- a/src/discrete_optimization/generic_tasks_tools/calendar_resource.py
+++ b/src/discrete_optimization/generic_tasks_tools/calendar_resource.py
@@ -154,6 +154,19 @@ class CalendarResourceProblem(SchedulingProblem[Task], Generic[Task, Resource]):
             if (consumption := max_capacity - value) > 0
         ]
 
+    def __getstate__(self):
+        """Get state for pickle.
+
+        Solve issue when instance has cached methods called. (And thus unpickable cache created.)
+        See https://github.com/GrahamDumpleton/wrapt/issues/343
+
+        """
+        return {
+            key: value
+            for key, value in self.__dict__.items()
+            if not key.startswith("_lru_cache_")
+        }
+
 
 class CalendarResourceSolution(SchedulingSolution[Task], Generic[Task, Resource]):
     problem: CalendarResourceProblem[Task, Resource]

--- a/src/discrete_optimization/generic_tasks_tools/calendar_resource.py
+++ b/src/discrete_optimization/generic_tasks_tools/calendar_resource.py
@@ -6,10 +6,10 @@ from __future__ import annotations
 import logging
 from abc import abstractmethod
 from collections.abc import Hashable, Iterable
-from functools import cache
 from typing import Generic, Optional, TypeVar
 
 import numpy as np
+import wrapt
 
 from discrete_optimization.generic_tasks_tools.base import Task
 from discrete_optimization.generic_tasks_tools.scheduling import (
@@ -60,7 +60,7 @@ class CalendarResourceProblem(SchedulingProblem[Task], Generic[Task, Resource]):
         """
         ...
 
-    @cache
+    @wrapt.lru_cache(maxsize=None)
     def get_resource_consolidated_availabilities(
         self, resource: Resource, horizon: Optional[int] = None
     ) -> list[tuple[int, int, int]]:
@@ -86,7 +86,7 @@ class CalendarResourceProblem(SchedulingProblem[Task], Generic[Task, Resource]):
             horizon=horizon,
         )
 
-    @cache
+    @wrapt.lru_cache(maxsize=None)
     def get_resource_calendar(
         self, resource: Resource, horizon: Optional[int] = None
     ) -> list[int]:
@@ -107,7 +107,7 @@ class CalendarResourceProblem(SchedulingProblem[Task], Generic[Task, Resource]):
             horizon=horizon,
         )
 
-    @cache
+    @wrapt.lru_cache(maxsize=None)
     def get_resource_max_capacity(self, resource: Resource) -> int:
         """Get max capacity of the given resource
 

--- a/src/discrete_optimization/generic_tasks_tools/generic_scheduling.py
+++ b/src/discrete_optimization/generic_tasks_tools/generic_scheduling.py
@@ -434,6 +434,19 @@ class GenericSchedulingProblem(
         """
         self.update_time_lags()
 
+    def __getstate__(self):
+        """Get state for pickle.
+
+        Solve issue when instance has cached methods called. (And thus unpickable cache created.)
+        See https://github.com/GrahamDumpleton/wrapt/issues/343
+
+        """
+        return {
+            key: value
+            for key, value in super().__getstate__().items()
+            if not key.startswith("_lru_cache_")
+        }
+
 
 class GenericSchedulingSolution(
     SkillSolution[

--- a/src/discrete_optimization/generic_tasks_tools/generic_scheduling.py
+++ b/src/discrete_optimization/generic_tasks_tools/generic_scheduling.py
@@ -2,8 +2,9 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 from collections import defaultdict
-from functools import cache
 from typing import Generic, Optional
+
+import wrapt
 
 from discrete_optimization.generic_tasks_tools.allocation import (
     UnaryResource,
@@ -108,7 +109,7 @@ class GenericSchedulingProblem(
         """Check if given resource is a unary resource."""
         return resource in self.unary_resources_list
 
-    @cache
+    @wrapt.lru_cache(maxsize=None)
     def get_task_start_or_end_tighter_lower_bound(
         self,
         task: Task,
@@ -177,7 +178,7 @@ class GenericSchedulingProblem(
                     ),
                 )
 
-    @cache
+    @wrapt.lru_cache(maxsize=None)
     def get_task_start_or_end_tighter_upper_bound(
         self,
         task: Task,
@@ -255,7 +256,7 @@ class GenericSchedulingProblem(
         self.get_task_start_or_end_tighter_lower_bound.cache_clear()
         self.compute_tighter_task_bounds.cache_clear()
 
-    @cache
+    @wrapt.lru_cache(maxsize=None)
     def compute_tighter_task_bounds(
         self, use_cpm: bool = False, horizon: Optional[int] = None
     ) -> dict[Task, tuple[int, int, int, int]]:
@@ -307,7 +308,7 @@ class GenericSchedulingProblem(
                 for task in self.tasks_list
             }
 
-    @cache
+    @wrapt.lru_cache(maxsize=None)
     def get_consolidated_time_lags(
         self,
         task1_start_or_end: StartOrEnd,
@@ -348,7 +349,7 @@ class GenericSchedulingProblem(
             )
         return timelags
 
-    @cache
+    @wrapt.lru_cache(maxsize=None)
     def get_consolidated_precedence_constraints(self) -> dict[Task, set[Task]]:
         """Consolidate precedence constraints defined by problem.
 

--- a/src/discrete_optimization/generic_tasks_tools/generic_scheduling.py
+++ b/src/discrete_optimization/generic_tasks_tools/generic_scheduling.py
@@ -308,7 +308,6 @@ class GenericSchedulingProblem(
                 for task in self.tasks_list
             }
 
-    @wrapt.lru_cache(maxsize=None)
     def get_consolidated_time_lags(
         self,
         task1_start_or_end: StartOrEnd,
@@ -422,7 +421,6 @@ class GenericSchedulingProblem(
         Returns:
 
         """
-        self.get_consolidated_time_lags.cache_clear()
         super().get_consolidated_time_lags.cache_clear()  # beware: parent class method also using cache !
         self.get_consolidated_precedence_constraints.cache_clear()
 
@@ -434,8 +432,7 @@ class GenericSchedulingProblem(
         Returns:
 
         """
-        self.get_consolidated_precedence_constraints.cache_clear()
-        self.get_consolidated_time_lags.cache_clear()
+        self.update_time_lags()
 
 
 class GenericSchedulingSolution(

--- a/src/discrete_optimization/generic_tasks_tools/skill.py
+++ b/src/discrete_optimization/generic_tasks_tools/skill.py
@@ -10,8 +10,9 @@ A skill is a cumulative resource which is attached to a unary resource.
 import logging
 from abc import abstractmethod
 from collections.abc import Hashable
-from functools import cache
 from typing import Generic, TypeVar
+
+import wrapt
 
 from discrete_optimization.generic_tasks_tools.allocation import (
     AllocationProblem,
@@ -69,7 +70,7 @@ class SkillProblem(
         """Skill value of given resource for given skill."""
         ...
 
-    @cache
+    @wrapt.lru_cache(maxsize=None)
     def get_skills_of_task(self, task: Task) -> set[Skill]:
         return {
             skill
@@ -83,7 +84,7 @@ class SkillProblem(
             )
         }
 
-    @cache
+    @wrapt.lru_cache(maxsize=None)
     def get_unary_resource_with_skill(self, skill: Skill) -> set[UnaryResource]:
         return {
             unary_resource
@@ -94,7 +95,7 @@ class SkillProblem(
             > 0
         }
 
-    @cache
+    @wrapt.lru_cache(maxsize=None)
     def get_skills_of_unary_resource(self, unary_resource: UnaryResource) -> set[Skill]:
         return {
             skill

--- a/src/discrete_optimization/generic_tasks_tools/skill.py
+++ b/src/discrete_optimization/generic_tasks_tools/skill.py
@@ -132,6 +132,19 @@ class SkillProblem(
         self.get_unary_resource_with_skill.cache_clear()
         self.get_skills_of_unary_resource.cache_clear()
 
+    def __getstate__(self):
+        """Get state for pickle.
+
+        Solve issue when instance has cached methods called. (And thus unpickable cache created.)
+        See https://github.com/GrahamDumpleton/wrapt/issues/343
+
+        """
+        return {
+            key: value
+            for key, value in super().__getstate__().items()
+            if not key.startswith("_lru_cache_")
+        }
+
 
 class SkillSolution(
     CumulativeResourceSolution[Task, CumulativeResource, OtherCalendarResource],

--- a/src/discrete_optimization/generic_tasks_tools/timelag.py
+++ b/src/discrete_optimization/generic_tasks_tools/timelag.py
@@ -3,8 +3,9 @@
 #  LICENSE file in the root directory of this source tree.
 import logging
 from collections import defaultdict
-from functools import cache
 from typing import Generic
+
+import wrapt
 
 from discrete_optimization.generic_tasks_tools.base import Task
 from discrete_optimization.generic_tasks_tools.enums import MinOrMax, StartOrEnd
@@ -152,7 +153,7 @@ class TimelagProblem(SchedulingProblem[Task], Generic[Task]):
                 timelags = []
         return timelags
 
-    @cache
+    @wrapt.lru_cache(maxsize=None)
     def get_consolidated_time_lags(
         self,
         task1_start_or_end: StartOrEnd,

--- a/src/discrete_optimization/generic_tasks_tools/timelag.py
+++ b/src/discrete_optimization/generic_tasks_tools/timelag.py
@@ -251,6 +251,19 @@ class TimelagProblem(SchedulingProblem[Task], Generic[Task]):
         """
         self.get_consolidated_time_lags.cache_clear()
 
+    def __getstate__(self):
+        """Get state for pickle.
+
+        Solve issue when instance has cached methods called. (And thus unpickable cache created.)
+        See https://github.com/GrahamDumpleton/wrapt/issues/343
+
+        """
+        return {
+            key: value
+            for key, value in super().__getstate__().items()
+            if not key.startswith("_lru_cache_")
+        }
+
 
 def consolidate_min_time_lags(
     timelags: list[tuple[Task, Task, int]],

--- a/src/discrete_optimization/rcpsp/problem.py
+++ b/src/discrete_optimization/rcpsp/problem.py
@@ -6,12 +6,13 @@ import logging
 from collections.abc import Callable, Hashable, Iterable
 from copy import deepcopy
 from enum import Enum
-from functools import cache, partial
+from functools import partial
 from typing import Any, Optional, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
+import wrapt
 
 from discrete_optimization.generic_rcpsp_tools.attribute_type import (
     ListIntegerRcpsp,
@@ -402,7 +403,7 @@ class RcpspProblem(
         mode_detail = self.mode_details[task][mode]
         return mode_detail.get(resource, 0)
 
-    @cache
+    @wrapt.lru_cache(maxsize=None)
     def get_resource_availabilities(
         self, resource: Resource
     ) -> list[tuple[int, int, int]]:

--- a/src/discrete_optimization/rcpsp_multiskill/problem.py
+++ b/src/discrete_optimization/rcpsp_multiskill/problem.py
@@ -10,11 +10,12 @@ from collections import defaultdict
 from collections.abc import Hashable
 from copy import deepcopy
 from enum import Enum
-from functools import cache, partial
+from functools import partial
 from typing import Optional, Union
 
 import numpy as np
 import scipy.stats as ss
+import wrapt
 
 from discrete_optimization.generic_rcpsp_tools.attribute_type import (
     ListIntegerRcpsp,
@@ -2349,7 +2350,7 @@ class MultiskillRcpspProblem(
         else:
             raise ValueError(f"{resource} is not a cumulative resource of the problem.")
 
-    @cache
+    @wrapt.lru_cache(maxsize=None)
     def get_resource_availabilities(
         self, resource: Resource
     ) -> list[tuple[int, int, int]]:

--- a/tests/generic_rcpsp_tools/test_graph_tools.py
+++ b/tests/generic_rcpsp_tools/test_graph_tools.py
@@ -31,7 +31,7 @@ def test_graph_tools(rcpsp_problem_file):
     )
     some_successor_task = random.choice(rcpsp_problem.successors[some_task])
     rcpsp_problem_copy.successors[some_successor_task].append(some_task)
-    rcpsp_problem.update_problem()
+    rcpsp_problem_copy.update_problem()
     graph_rcpsp_with_loop = build_graph_rcpsp_object(rcpsp_problem_copy)
     cycles = graph_rcpsp_with_loop.check_loop()
     # With this precedence graph, the rcpsp is no longer feasible.


### PR DESCRIPTION
It avoids some pitfalls. See more about it here:
- https://wrapt.readthedocs.io/en/master/bundled.html#lru-cache
- https://docs.python.org/3/library/functools.html#functools.lru_cache
- https://docs.python.org/3/faq/programming.html#faq-cache-method-calls
- https://github.com/python/cpython/issues/102618