### PR TITLE
Implement a generic scheduling problem and corresponding auto-cpsat

### DIFF
--- a/src/discrete_optimization/fjsp/solvers/cpsat_auto.py
+++ b/src/discrete_optimization/fjsp/solvers/cpsat_auto.py
@@ -60,8 +60,8 @@ class CpSatAutoFjspSolver(
     def init_model(self, **kwargs: Any) -> None:
         # optional parameters
         kwargs = self.complete_with_default_hyperparameters(kwargs)
-        self._max_time = kwargs.get(
-            "max_time", self.problem.get_makespan_upper_bound()
+        self._max_time: int | None = kwargs.get(
+            "max_time", None
         )  # update the upper bound for makespan
         self.duplicate_start_var_per_mode = kwargs["duplicate_temporal_var"]
         # whether to add cumulative constraint on top of no_overlap constraint
@@ -71,7 +71,10 @@ class CpSatAutoFjspSolver(
         super().init_model(**kwargs)
 
     def get_makespan_upper_bound(self) -> int:
-        return self._max_time
+        if self._max_time is None:
+            return super().get_makespan_upper_bound()
+        else:
+            return min(self._max_time, super().get_makespan_upper_bound())
 
     def convert_task_variables_to_solution(
         self, raw_sol: RawSolution[Task, UnaryResource, NoSkill]

--- a/src/discrete_optimization/fjsp/solvers/cpsat_auto.py
+++ b/src/discrete_optimization/fjsp/solvers/cpsat_auto.py
@@ -15,13 +15,15 @@ from discrete_optimization.generic_tasks_tools.allocation import (
     NoUnaryResource,
     UnaryResource,
 )
+from discrete_optimization.generic_tasks_tools.generic_scheduling_utils import (
+    RawSolution,
+)
 from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
     NoNonRenewableResource,
 )
 from discrete_optimization.generic_tasks_tools.skill import NoSkill
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.auto import (
     GenericSchedulingAutoCpSatSolver,
-    TemporarySolution,
 )
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.skill import (
     WithoutSkillSchedulingCpSatSolver,
@@ -72,12 +74,12 @@ class CpSatAutoFjspSolver(
         return self._max_time
 
     def convert_task_variables_to_solution(
-        self, temp_sol: TemporarySolution[Task, UnaryResource, NoSkill]
+        self, raw_sol: RawSolution[Task, UnaryResource, NoSkill]
     ) -> FJobShopSolution:
         schedule = [
             [
                 (
-                    (task_var := temp_sol.task_variables[j, k]).start,
+                    (task_var := raw_sol.task_variables[j, k]).start,
                     task_var.end,
                     self.problem.mode2machine[j, k][task_var.mode],
                     task_var.mode,

--- a/src/discrete_optimization/generic_tasks_tools/generic_scheduling.py
+++ b/src/discrete_optimization/generic_tasks_tools/generic_scheduling.py
@@ -348,6 +348,57 @@ class GenericSchedulingProblem(
             )
         return timelags
 
+    def get_makespan_lower_bound(self) -> int:
+        """Get a lower bound on global makespan.
+
+        Computed tighter lower bounds on last tasks can be used to get a better makespan lower bound.
+
+        """
+        return max(
+            self.get_task_start_or_end_tighter_lower_bound(
+                task=task, start_or_end=StartOrEnd.END
+            )
+            for task in self.get_last_tasks()
+        )
+
+    def get_makespan_tighter_lower_bound(
+        self, use_cpm: bool = False, horizon: Optional[int] = None
+    ) -> int:
+        """Get a tighter lower bound on global makespan.
+
+        Args:
+            use_cpm: whether to use CPM bound propagation through precedence graph to improve tightness
+            horizon: new horizon to take into account when computing tighter bounds,
+                default to problem horizon.
+                NB: The choice of horizon should not affect the result for the lower bound, but it could avoid
+                CPM complete recomputation thanks to caching if it was already launched with same horizon.
+
+        """
+        if horizon is None:
+            horizon = self.get_makespan_tighter_upper_bound()
+        return max(
+            self.get_task_start_or_end_tighter_lower_bound(
+                task=task, start_or_end=StartOrEnd.END, use_cpm=use_cpm, horizon=horizon
+            )
+            for task in self.get_last_tasks()
+        )
+
+    def get_makespan_tighter_upper_bound(self) -> int:
+        """Compute a tighter upper bound on makespan.
+
+        The original makespan upper bound is used when computing tighter bounds for tasks starts and ends,
+        via `self.compute_tighter_task_bounds()` or `self.get_task_start_or_end_tighter_upper_bound()`.
+        From that tighter bounds, we can derive a new makespan upper bound.
+
+        """
+        return max(
+            # do not use CPM (not necessary as last tasks horizon are just computed from horizon + time windows even in CPM)
+            self.get_task_start_or_end_tighter_upper_bound(
+                task=task, start_or_end=StartOrEnd.END, use_cpm=False
+            )
+            for task in self.get_last_tasks()
+        )
+
     @wrapt.lru_cache(maxsize=None)
     def get_consolidated_precedence_constraints(self) -> dict[Task, set[Task]]:
         """Consolidate precedence constraints defined by problem.

--- a/src/discrete_optimization/generic_tasks_tools/generic_scheduling_impl.py
+++ b/src/discrete_optimization/generic_tasks_tools/generic_scheduling_impl.py
@@ -29,8 +29,6 @@ from discrete_optimization.generic_tools.do_problem import (
 )
 from discrete_optimization.generic_tools.encoding_register import EncodingRegister
 
-DURATION = "duration"
-
 # types for annotations
 Skill = str
 NonSkillCumulativeResource = str
@@ -40,8 +38,6 @@ Task = Hashable
 CumulativeResource = NonSkillCumulativeResource | Skill
 Resource = CumulativeResource | UnaryResource  # calendar resources
 AnyResource = NonRenewableResource | Resource
-DurationKey = type(DURATION)
-ModeDetailKey = Resource | DurationKey
 UnaryAvailabilityIntervals = list[tuple[int, int]]  # start, end
 AvailabilityIntervals = list[tuple[int, int, int]]  # start, end, value
 
@@ -60,7 +56,10 @@ class GenericSchedulingImplProblem(
     def __init__(
         self,
         horizon: int,
-        mode_details: dict[Task, dict[int, dict[ModeDetailKey, int]]],
+        durations_per_mode: dict[Task, dict[int, int]],
+        resource_consumptions: Optional[
+            dict[Task, dict[int, dict[CumulativeResource | NonRenewableResource, int]]]
+        ] = None,
         successors: Optional[dict[Task, Iterable[Task]]] = None,
         unary_resources: Optional[set[UnaryResource]] = None,
         unary_resources_skills: Optional[dict[UnaryResource, dict[Skill, int]]] = None,
@@ -89,7 +88,11 @@ class GenericSchedulingImplProblem(
 
         Args:
             horizon: max allowed time to finish the tasks
-            mode_details: details tasks by task, mode by mode of task duration and resource consumption
+            durations_per_mode: task -> mode -> duration. Tasks durations, mode by mode.
+                This is used to know all available tasks, all available modes for a given task, and corresponding durations.
+            resource_consumptions: task -> mode -> resource -> conso.
+                Cumulative or non-renewable resource consumption, task by task, mode by mode. The resource can be a skill.
+                Missing key => conso = 0
             successors: maps a task to its successors in the precedence graph.
                 Each successor task must start after the given task ends.
                 Default to no precedence constraints. Note that a consolidated version of it will
@@ -132,8 +135,14 @@ class GenericSchedulingImplProblem(
 
         """
         self.horizon = horizon
-        self.mode_details = mode_details
+        self.durations_per_mode = durations_per_mode
         # default values
+        if resource_consumptions is None:
+            self.resource_consumptions: dict[
+                Task, dict[int, dict[CumulativeResource | NonRenewableResource, int]]
+            ] = {}
+        else:
+            self.resource_consumptions = resource_consumptions
         if successors is None:
             self.successors: dict[Task, Iterable[Task]] = {}
         else:
@@ -203,7 +212,7 @@ class GenericSchedulingImplProblem(
 
     def update_problem(self):
         """Method to call when some attributes of the problem are modified."""
-        self._tasks_list = list(self.mode_details)
+        self._tasks_list = list(self.durations_per_mode)
         self._skills_list = list(self.skills)
         self._non_skill_cumulative_resources_list = list(
             self.non_skill_cumulative_resources
@@ -261,7 +270,7 @@ class GenericSchedulingImplProblem(
         self, resource: CumulativeResource, task: Task, mode: int
     ) -> int:
         try:
-            return self.mode_details[task][mode][resource]
+            return self.resource_consumptions[task][mode][resource]
         except KeyError:
             return 0
 
@@ -291,12 +300,7 @@ class GenericSchedulingImplProblem(
             )
 
     def get_task_mode_duration(self, task: Task, mode: int) -> int:
-        try:
-            return self.mode_details[task][mode][DURATION]
-        except KeyError:
-            raise ValueError(
-                f"No duration specified in mode_details for task, mode = {task, mode}"
-            )
+        return self.durations_per_mode[task][mode]
 
     @property
     def non_renewable_resources_list(self) -> list[NonRenewableResource]:
@@ -311,7 +315,7 @@ class GenericSchedulingImplProblem(
         self, resource: NonRenewableResource, task: Task, mode: int
     ) -> int:
         try:
-            return self.mode_details[task][mode][resource]
+            return self.resource_consumptions[task][mode][resource]
         except KeyError:
             return 0
 
@@ -364,7 +368,7 @@ class GenericSchedulingImplProblem(
         return self.horizon
 
     def get_task_modes(self, task: Task) -> set[int]:
-        return set(self.mode_details[task])
+        return set(self.durations_per_mode[task])
 
     @property
     def unary_resources_list(self) -> list[UnaryResource]:

--- a/src/discrete_optimization/generic_tasks_tools/generic_scheduling_impl.py
+++ b/src/discrete_optimization/generic_tasks_tools/generic_scheduling_impl.py
@@ -1,0 +1,555 @@
+#  Copyright (c) 2026 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+from collections.abc import Callable, Hashable, Iterable
+from copy import deepcopy
+from typing import Optional
+
+import wrapt
+
+from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
+from discrete_optimization.generic_tasks_tools.generic_scheduling import (
+    GenericSchedulingProblem,
+    GenericSchedulingSolution,
+)
+from discrete_optimization.generic_tasks_tools.generic_scheduling_utils import (
+    OBJECTIVE_DEFAULT_WEIGHTS,
+    Objective,
+    RawSolution,
+)
+from discrete_optimization.generic_tools.do_problem import (
+    ModeOptim,
+    ObjectiveDoc,
+    ObjectiveHandling,
+    ObjectiveRegister,
+    Solution,
+    TypeObjective,
+)
+from discrete_optimization.generic_tools.encoding_register import EncodingRegister
+
+DURATION = "duration"
+
+# types for annotations
+Skill = str
+NonSkillCumulativeResource = str
+NonRenewableResource = str
+UnaryResource = str
+Task = Hashable
+CumulativeResource = NonSkillCumulativeResource | Skill
+Resource = CumulativeResource | UnaryResource  # calendar resources
+AnyResource = NonRenewableResource | Resource
+DurationKey = type(DURATION)
+ModeDetailKey = Resource | DurationKey
+UnaryAvailabilityIntervals = list[tuple[int, int]]  # start, end
+AvailabilityIntervals = list[tuple[int, int, int]]  # start, end, value
+
+
+class GenericSchedulingImplProblem(
+    GenericSchedulingProblem[
+        Task, UnaryResource, Skill, NonSkillCumulativeResource, NonRenewableResource
+    ]
+):
+    """Generic implementation of a scheduling problem.
+
+    It implements the abstract class `GenericSchedulingProblem`.
+
+    """
+
+    def __init__(
+        self,
+        horizon: int,
+        mode_details: dict[Task, dict[int, dict[ModeDetailKey, int]]],
+        successors: Optional[dict[Task, Iterable[Task]]] = None,
+        unary_resources: Optional[set[UnaryResource]] = None,
+        unary_resources_skills: Optional[dict[UnaryResource, dict[Skill, int]]] = None,
+        unary_resources_availabilities: Optional[
+            dict[UnaryResource, UnaryAvailabilityIntervals]
+        ] = None,
+        skills: Optional[set[Skill]] = None,
+        non_skill_cumulative_resources: Optional[
+            dict[CumulativeResource, int | AvailabilityIntervals]
+        ] = None,
+        non_renewable_resources: Optional[dict[NonRenewableResource, int]] = None,
+        time_windows: Optional[
+            dict[Task, tuple[int | None, int | None, int | None, int | None]]
+        ] = None,
+        start_to_start_min_time_lags: Optional[list[tuple[Task, Task, int]]] = None,
+        start_to_end_min_time_lags: Optional[list[tuple[Task, Task, int]]] = None,
+        end_to_start_min_time_lags: Optional[list[tuple[Task, Task, int]]] = None,
+        end_to_end_min_time_lags: Optional[list[tuple[Task, Task, int]]] = None,
+        objective: Objective | Iterable[tuple[Objective, int]] = Objective.MAKESPAN,
+        custom_evaluate_fn: Optional[
+            Callable[[GenericSchedulingImplSolution], int]
+        ] = None,
+        objective_resource_weights: Optional[dict[AnyResource, int]] = None,
+    ):
+        """
+
+        Args:
+            horizon: max allowed time to finish the tasks
+            mode_details: details tasks by task, mode by mode of task duration and resource consumption
+            successors: maps a task to its successors in the precedence graph.
+                Each successor task must start after the given task ends.
+                Default to no precedence constraints. Note that a consolidated version of it will
+                be constructed using the time lags constraints.
+            unary_resources: available unary resources.  Default to none.
+            unary_resources_skills: skill values of each unary resource. Mssing key => skill value = 0
+            unary_resources_availabilities: availability of unary resources on the form of list of intervals (start, end)
+                Missing key => always available.
+            skills: available skills
+            non_skill_cumulative_resources: cumulative resources (excluding skills) availabilities.
+                Format: either int => always available at the given max capacity,
+                or list of intervals + capacity (start, end, value)
+            non_renewable_resources: non-renewable resources max capacities
+            time_windows: maps task to start_lb, end_lb, start_ub, end_ub s.t.
+                start_lb <= start(task) <= start_ub and end_lb <= end(task) <= end_ub
+                missing or none value means 0 (lb) or self.horizon (ub)
+            start_to_start_min_time_lags: min time lags constraints between task starts.
+                task1, task2, offset meaning start(task1) + offset <= start(task2)
+                Note that using negative offset can model start-to-start max time lags.
+            start_to_end_min_time_lags: min time lags constraints first task start and second task end.
+                task1, task2, offset meaning start(task1) + offset <= end(task2)
+                Note that using negative offset can model end-to-start max time lags.
+            end_to_start_min_time_lags: min time lags constraints between first task end and second task start.
+                task1, task2, offset meaning end(task1) + offset <= start(task2)
+                Note that using negative offset can model start-to-end max time lags.
+            end_to_end_min_time_lags: min time lags constraints between task ends.
+                task1, task2, offset meaning end(task1) + offset <= end(task2)
+                Note that using negative offset can model end-to-end max time lags.
+            objective: objective for the problem. Default to minimization of makespan.
+                Either an iterable of (objective, weight) so that the problem should *maximize* the aggregated objective
+                resulting from weighted sum of objectives, or a single objective in which case we use the corresponding
+                default weight from
+                `discrete_optimization.generic_tasks_tools.generic_scheduling_utils.OBJECTIVE_DEFAULT_WEIGHTS`
+                and maximize it. For instance the default weight for makespan is -1 so that it will
+                actually minimize the makespan.
+            custom_evaluate_fn: function used to evaluate the "custom" objective (to be maximized).
+            objective_resource_weights: Weights to be used by the objective when summing used resources
+                (`Objective.NB_RESOURCES_USED`) or resources consumption (`Objective.RESOURCES_CONSUMPTION`).
+                Default to 1 for resources not mentioned.
+
+        """
+        self.horizon = horizon
+        self.mode_details = mode_details
+        # default values
+        if successors is None:
+            self.successors: dict[Task, Iterable[Task]] = {}
+        else:
+            self.successors = successors
+        if unary_resources is None:
+            self.unary_resources: set[UnaryResource] = set()
+        else:
+            self.unary_resources = unary_resources
+        if unary_resources_skills is None:
+            self.unary_resources_skills: dict[UnaryResource, dict[Skill, int]] = {}
+        else:
+            self.unary_resources_skills = unary_resources_skills
+        if unary_resources_availabilities is None:
+            self.unary_resources_availabilities: dict[
+                UnaryResource, UnaryAvailabilityIntervals
+            ] = {}
+        else:
+            self.unary_resources_availabilities = unary_resources_availabilities
+        if skills is None:
+            self.skills: set[Skill] = set()
+        else:
+            self.skills = skills
+        if non_skill_cumulative_resources is None:
+            self.non_skill_cumulative_resources: dict[
+                CumulativeResource, int | AvailabilityIntervals
+            ] = {}
+        else:
+            self.non_skill_cumulative_resources = non_skill_cumulative_resources
+        if non_renewable_resources is None:
+            self.non_renewable_resources: dict[NonRenewableResource, int] = {}
+        else:
+            self.non_renewable_resources = non_renewable_resources
+        if time_windows is None:
+            self.time_windows: dict[
+                Task, tuple[int | None, int | None, int | None, int | None]
+            ] = {}
+        else:
+            self.time_windows = time_windows
+        if start_to_start_min_time_lags is None:
+            self.start_to_start_min_time_lags: list[tuple[Task, Task, int]] = []
+        else:
+            self.start_to_start_min_time_lags = start_to_start_min_time_lags
+        if start_to_end_min_time_lags is None:
+            self.start_to_end_min_time_lags: list[tuple[Task, Task, int]] = []
+        else:
+            self.start_to_end_min_time_lags = start_to_end_min_time_lags
+        if end_to_start_min_time_lags is None:
+            self.end_to_start_min_time_lags: list[tuple[Task, Task, int]] = []
+        else:
+            self.end_to_start_min_time_lags = end_to_start_min_time_lags
+        if end_to_end_min_time_lags is None:
+            self.end_to_end_min_time_lags: list[tuple[Task, Task, int]] = []
+        else:
+            self.end_to_end_min_time_lags = end_to_end_min_time_lags
+        if isinstance(objective, Objective):
+            self.weighted_objectives: tuple[tuple[Objective, int], ...] = (
+                (objective, OBJECTIVE_DEFAULT_WEIGHTS[objective]),
+            )
+        else:
+            self.weighted_objectives = tuple(objective)
+        self.custom_evaluate_fn = custom_evaluate_fn
+        if objective_resource_weights is None:
+            self.objective_resource_weights: dict[AnyResource, int] = {}
+        else:
+            self.objective_resource_weights = objective_resource_weights
+        self.update_problem()
+
+    def update_problem(self):
+        """Method to call when some attributes of the problem are modified."""
+        self._tasks_list = list(self.mode_details)
+        self._skills_list = list(self.skills)
+        self._non_skill_cumulative_resources_list = list(
+            self.non_skill_cumulative_resources
+        )
+        self._non_renewable_resources_list = list(self.non_renewable_resources)
+        self._unary_resources_list = list(self.unary_resources)
+
+        self.check_resources_lists()
+        self.update_tasks_list()
+        self.update_skills()
+        self.update_resource_availabilities()
+        self.update_task_bounds()
+        self.update_time_lags()
+        self.update_precedence_constraints()
+
+        if (
+            Objective.CUSTOM in {objective for objective, _ in self.weighted_objectives}
+            and self.custom_evaluate_fn is None
+        ):
+            raise RuntimeError(
+                "self.custom_evaluate_fn is not defined but custom objective used."
+            )
+
+    def update_resource_availabilities(self) -> None:
+        self.get_resource_availabilities.cache_clear()
+        super().update_resource_availabilities()
+
+    def check_resources_lists(self) -> None:
+        """Check duplicates in resources."""
+        resources_list = (
+            self.calendar_resources_list + self.non_renewable_resources_list
+        )
+        assert len(resources_list) == len(set(resources_list)), (
+            "There are duplicates in resources list, "
+            "potentially because calendar and non-renewable resources intersect."
+        )
+
+    @property
+    def skills_list(self) -> list[Skill]:
+        return self._skills_list
+
+    @property
+    def non_skill_cumulative_resources_list(self) -> list[Skill]:
+        return self._non_skill_cumulative_resources_list
+
+    def get_unary_resource_skill_value(
+        self, unary_resource: UnaryResource, skill: Skill
+    ) -> int:
+        try:
+            return self.unary_resources_skills[unary_resource][skill]
+        except KeyError:
+            return 0
+
+    def get_cumulative_resource_consumption(
+        self, resource: CumulativeResource, task: Task, mode: int
+    ) -> int:
+        try:
+            return self.mode_details[task][mode][resource]
+        except KeyError:
+            return 0
+
+    @wrapt.lru_cache(maxsize=None)
+    def get_resource_availabilities(
+        self, resource: Resource
+    ) -> list[tuple[int, int, int]]:
+        if resource in self.skills:
+            return self.compute_skill_availabilities(resource)
+        elif resource in self.unary_resources:
+            try:
+                return [
+                    (start, end, 1)
+                    for start, end in self.unary_resources_availabilities[resource]
+                ]
+            except KeyError:
+                return [(0, self.horizon, 1)]
+        elif resource in self.non_skill_cumulative_resources:
+            intervals_or_max_capacity = self.non_skill_cumulative_resources[resource]
+            if isinstance(intervals_or_max_capacity, int):
+                return [(0, self.horizon, intervals_or_max_capacity)]
+            else:
+                return intervals_or_max_capacity
+        else:
+            raise ValueError(
+                f"{resource} is neither an actual cumulative resource, nor a skill, nor a unary resource."
+            )
+
+    def get_task_mode_duration(self, task: Task, mode: int) -> int:
+        try:
+            return self.mode_details[task][mode][DURATION]
+        except KeyError:
+            raise ValueError(
+                f"No duration specified in mode_details for task, mode = {task, mode}"
+            )
+
+    @property
+    def non_renewable_resources_list(self) -> list[NonRenewableResource]:
+        return self._non_renewable_resources_list
+
+    def get_non_renewable_resource_capacity(
+        self, resource: NonRenewableResource
+    ) -> int:
+        return self.non_renewable_resources[resource]
+
+    def get_non_renewable_resource_consumption(
+        self, resource: NonRenewableResource, task: Task, mode: int
+    ) -> int:
+        try:
+            return self.mode_details[task][mode][resource]
+        except KeyError:
+            return 0
+
+    def get_start_to_start_min_time_lags(self) -> list[tuple[Task, Task, int]]:
+        return self.start_to_start_min_time_lags
+
+    def get_end_to_start_min_time_lags(self) -> list[tuple[Task, Task, int]]:
+        return self.end_to_start_min_time_lags
+
+    def get_end_to_end_min_time_lags(self) -> list[tuple[Task, Task, int]]:
+        return self.end_to_end_min_time_lags
+
+    def get_start_to_end_min_time_lags(self) -> list[tuple[Task, Task, int]]:
+        return self.start_to_end_min_time_lags
+
+    def get_task_start_or_end_lower_bound(
+        self, task: Task, start_or_end: StartOrEnd
+    ) -> int:
+        try:
+            start_lb, end_lb, start_ub, end_ub = self.time_windows[task]
+            if start_or_end == StartOrEnd.START:
+                lb = start_lb
+            else:
+                lb = end_lb
+            if lb is not None:
+                return lb
+        except KeyError:
+            pass
+        return super().get_task_start_or_end_lower_bound(task, start_or_end)
+
+    def get_task_start_or_end_upper_bound(
+        self, task: Task, start_or_end: StartOrEnd
+    ) -> int:
+        try:
+            start_lb, end_lb, start_ub, end_ub = self.time_windows[task]
+            if start_or_end == StartOrEnd.START:
+                ub = start_ub
+            else:
+                ub = end_ub
+            if ub is not None:
+                return ub
+        except KeyError:
+            pass
+        return super().get_task_start_or_end_upper_bound(task, start_or_end)
+
+    def get_precedence_constraints(self) -> dict[Task, Iterable[Task]]:
+        return self.successors
+
+    def get_makespan_upper_bound(self) -> int:
+        return self.horizon
+
+    def get_task_modes(self, task: Task) -> set[int]:
+        return set(self.mode_details[task])
+
+    @property
+    def unary_resources_list(self) -> list[UnaryResource]:
+        return self._unary_resources_list
+
+    @property
+    def tasks_list(self) -> list[Task]:
+        return self._tasks_list
+
+    def satisfy(self, variable: Solution) -> bool:
+        assert isinstance(variable, GenericSchedulingImplSolution)
+        return self.satisfy_partial(variable=variable)
+
+    def satisfy_partial(
+        self,
+        variable: GenericSchedulingImplSolution,
+        duration: bool = True,
+        calendar: bool = True,
+        non_renewable_capacity: bool = True,
+        precedence: bool = True,
+        skill: bool = True,
+        allocation: bool = True,
+        time_lags: bool = True,
+        time_windows: bool = True,
+    ) -> bool:
+        """Partial checks on solution.
+
+        One can switch off some checks by setting the corresponding parameter to False.
+
+        Args:
+            variable:
+            duration:
+            calendar:
+            non_renewable_capacity:
+            precedence:
+            skill:
+            allocation:
+            time_lags:
+            time_windows:
+
+        Returns:
+
+        """
+        return (
+            # duration consistency
+            (not duration or variable.check_duration_constraints())
+            # calendar resources capacity violations (unary resources + skills + cumulative resources)
+            and (
+                not calendar
+                or variable.check_all_calendar_resource_capacity_constraints()
+            )
+            # non-renewable resource violation
+            and (
+                not non_renewable_capacity
+                or variable.check_all_non_renewable_resource_capacity_constraints()
+            )
+            # precedence relations
+            and (not precedence or variable.check_precedence_constraints())
+            # skill constraints
+            and (
+                not skill
+                or (
+                    variable.check_skill_constraints()
+                    and variable.check_only_one_skill_per_task_and_unary_resource()
+                    # Check consistency between compatibility/allocation/skill usage
+                    and variable.check_skill_usage_and_allocation_consistency()
+                )
+            )
+            and (not allocation or variable.check_allocation_consistency())
+            # time lags
+            and (not time_lags or variable.check_time_lags())
+            # time window
+            and (not time_windows or variable.check_time_windows())
+        )
+
+    def get_solution_type(self) -> type[Solution]:
+        return GenericSchedulingImplSolution
+
+    def get_attribute_register(self) -> EncodingRegister:
+        raise NotImplementedError()
+
+    def set_fixed_attributes(self, attribute_name: str, solution: Solution) -> None:
+        raise NotImplementedError()
+
+    def evaluate(self, variable: Solution) -> dict[str, float]:
+        return {
+            objective.value: self.compute_subobjective(
+                variable=variable, objective=objective
+            )
+            for objective, _ in self.weighted_objectives
+        }
+
+    def compute_subobjective(
+        self, variable: GenericSchedulingImplSolution, objective: Objective
+    ) -> int:
+        match objective:
+            case Objective.MAKESPAN:
+                return variable.get_max_end_time()
+            case Objective.NB_TASKS_DONE:
+                return variable.compute_nb_tasks_done()
+            case Objective.NB_UNARY_RESOURCES_USED:
+                return variable.compute_nb_unary_resources_used()
+            case Objective.NB_RESOURCES_USED:
+                return variable.compute_nb_calendar_resources_used(
+                    weights=self.objective_resource_weights
+                ) + variable.compute_nb_non_renewable_resources_used(
+                    weights=self.objective_resource_weights
+                )
+            case Objective.RESOURCES_CONSUMPTION:
+                return variable.compute_aggregated_calendar_resources_consumptions(
+                    weights=self.objective_resource_weights
+                ) + variable.compute_aggregated_non_renewable_resources_consumptions(
+                    weights=self.objective_resource_weights
+                )
+            case Objective.CUSTOM:
+                if self.custom_evaluate_fn is None:
+                    raise RuntimeError(
+                        "self.custom_evaluate_fn is not defined but custom objective used."
+                    )
+                return self.custom_evaluate_fn(variable)
+            case _:
+                raise NotImplementedError()
+
+    def get_objective_register(self) -> ObjectiveRegister:
+        if len(self.weighted_objectives) == 1:
+            handling = ObjectiveHandling.SINGLE
+        else:
+            handling = ObjectiveHandling.AGGREGATE
+        dict_objective = {
+            objective.value: ObjectiveDoc(
+                type=TypeObjective.OBJECTIVE, default_weight=weight
+            )
+            for objective, weight in self.weighted_objectives
+        }
+        return ObjectiveRegister(
+            objective_sense=ModeOptim.MAXIMIZATION,
+            objective_handling=handling,
+            dict_objective_to_doc=dict_objective,
+        )
+
+    def get_dummy_solution(self) -> Solution:
+        raise NotImplementedError()
+
+
+class GenericSchedulingImplSolution(
+    GenericSchedulingSolution[
+        Task, UnaryResource, Skill, NonSkillCumulativeResource, NonRenewableResource
+    ]
+):
+    """Generic implementation of a solution to a scheduling problem.
+
+    It implements the abstract class `GenericSchedulingSolution`.
+
+    """
+
+    problem: GenericSchedulingImplProblem
+
+    def __init__(self, problem: GenericSchedulingImplProblem, raw_sol: RawSolution):
+        super().__init__(problem)
+        self.raw_sol = raw_sol
+
+    def is_skill_used(
+        self, task: Task, unary_resource: UnaryResource, skill: Skill
+    ) -> bool:
+        try:
+            return skill in self.raw_sol.task_variables[task].allocated[unary_resource]
+        except KeyError:
+            return False
+
+    def get_end_time(self, task: Task) -> int:
+        return self.raw_sol.task_variables[task].end
+
+    def get_start_time(self, task: Task) -> int:
+        return self.raw_sol.task_variables[task].start
+
+    def get_mode(self, task: Task) -> int:
+        return self.raw_sol.task_variables[task].mode
+
+    def is_allocated(self, task: Task, unary_resource: UnaryResource) -> bool:
+        return unary_resource in self.raw_sol.task_variables[task].allocated
+
+    def copy(self) -> Solution:
+        return GenericSchedulingImplSolution(
+            problem=self.problem, raw_sol=deepcopy(self.raw_sol)
+        )
+
+    def lazy_copy(self) -> Solution:
+        return GenericSchedulingImplSolution(problem=self.problem, raw_sol=self.raw_sol)

--- a/src/discrete_optimization/generic_tasks_tools/generic_scheduling_utils.py
+++ b/src/discrete_optimization/generic_tasks_tools/generic_scheduling_utils.py
@@ -1,0 +1,77 @@
+#  Copyright (c) 2026 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Generic
+
+from discrete_optimization.generic_tasks_tools.allocation import UnaryResource
+from discrete_optimization.generic_tasks_tools.base import Task
+from discrete_optimization.generic_tasks_tools.skill import Skill
+
+
+@dataclass
+class TaskVariable(Generic[UnaryResource, Skill]):
+    """Task characteristics found in a generic scheduling solution."""
+
+    start: int  # start time of the task
+    end: int  # end time of the task
+    mode: int  # chosen mode for the task
+    allocated: dict[UnaryResource, set[Skill]] = field(
+        default_factory=dict
+    )  # resources allocated to the task
+    info: dict[str, Any] = field(
+        default_factory=dict
+    )  # additional information if needed
+
+
+@dataclass
+class RawSolution(Generic[Task, UnaryResource, Skill]):
+    """Raw format for a generic scheduling solution
+
+    Does not inherit from d-o `Solution` class.
+
+    ."""
+
+    task_variables: dict[Task, TaskVariable[UnaryResource, Skill]]
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class Objective(Enum):
+    """Objective for a generic scheduling problem."""
+
+    MAKESPAN = "makespan"
+    """Global makespan of the schedule, to minimize."""
+    NB_TASKS_DONE = "nb_tasks_done"
+    """Number of tasks with at least one resource allocated, to maximize."""
+    NB_UNARY_RESOURCES_USED = "nb_unary_resources_used"
+    """Number of allocated unary resources, to minimize."""
+    NB_RESOURCES_USED = "nb_resources_used"
+    """Weighted sum of resources used, to minimize.
+
+    Include non-renewable, cumulative, and unary resources.
+    The weigths are to be defined in `solver.objective_resource_weights`.
+
+    """
+    RESOURCES_CONSUMPTION = "resources_consumption"
+    """Weighted sum of resources consumptions, to minimize.
+
+    Include non-renewable, cumulative, and unary resources.
+    The weigths are to be defined in `solver.objective_resource_weights`.
+
+    """
+    CUSTOM = "custom_objective"
+
+
+OBJECTIVE_DEFAULT_WEIGHTS: dict[Objective, int] = {
+    Objective.MAKESPAN: -1,
+    Objective.NB_TASKS_DONE: 1,
+    Objective.NB_UNARY_RESOURCES_USED: -1,
+    Objective.NB_RESOURCES_USED: -1,
+    Objective.RESOURCES_CONSUMPTION: -1,
+    Objective.CUSTOM: 1,
+}
+"""Default weight applied to a given objective so that it will be *maximized*."""

--- a/src/discrete_optimization/generic_tasks_tools/precedence_scheduling.py
+++ b/src/discrete_optimization/generic_tasks_tools/precedence_scheduling.py
@@ -20,7 +20,13 @@ logger = logging.Logger(__name__)
 class PrecedenceSchedulingProblem(PrecedenceProblem[Task], SchedulingProblem[Task]):
     """Scheduling problem with precedence constraints on tasks."""
 
-    ...
+    def get_last_tasks(self) -> list[Task]:
+        precedence_graph = self.get_precedence_graph()
+        return [
+            task
+            for task, n_successors in precedence_graph.graph_nx.out_degree
+            if n_successors == 0
+        ]
 
 
 class PrecedenceSchedulingSolution(PrecedenceSolution[Task], SchedulingSolution[Task]):

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/allocation.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/allocation.py
@@ -313,11 +313,11 @@ class AllocationCpSatSolver(
                 ):
                     self.cp_model.add_at_most_one(list_is_present_variables)
 
-    def get_nb_tasks_done_variable(self) -> Any:
+    def get_nb_tasks_done_variable(self) -> LinearExprT:
         self.create_done_variables()
         return sum(self.done_variables.values())
 
-    def get_nb_unary_resources_used_variable(self) -> Any:
+    def get_nb_unary_resources_used_variable(self) -> LinearExprT:
         self.create_used_variables()
         return sum(self.used_variables.values())
 

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto.py
@@ -4,9 +4,7 @@
 import logging
 from abc import abstractmethod
 from collections.abc import Callable
-from dataclasses import dataclass, field
-from enum import Enum
-from typing import Any, Generic, Optional
+from typing import Any, Optional
 
 import networkx as nx
 from ortools.sat.python.cp_model import (
@@ -23,6 +21,12 @@ from discrete_optimization.generic_tasks_tools.generic_scheduling import (
     CumulativeResource,
     GenericSchedulingSolution,
     Resource,
+)
+from discrete_optimization.generic_tasks_tools.generic_scheduling_utils import (
+    OBJECTIVE_DEFAULT_WEIGHTS,
+    Objective,
+    RawSolution,
+    TaskVariable,
 )
 from discrete_optimization.generic_tasks_tools.multimode import SinglemodeProblem
 from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
@@ -50,56 +54,6 @@ from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-class Objective(Enum):
-    """Objective to be used by the solver."""
-
-    MAKESPAN = "makespan"
-    """Global makespan of the schedule, to minimize."""
-    NB_TASKS_DONE = "nb_tasks_done"
-    """Number of tasks with at least one resource allocated, to maximize."""
-    NB_UNARY_RESOURCES_USED = "nb_unary_resources_used"
-    """Number of allocated unary resources, to minimize."""
-    NB_RESOURCES_USED = "nb_resources_used"
-    """Weighted sum of resources used, to minimize.
-
-    Include non-renewable, cumulative, and unary resources.
-    The weigths are to be defined in `solver.objective_resource_weights`.
-
-    """
-    RESOURCES_CONSUMPTION = "resources_consumption"
-    """Weighted sum of resources consumptions, to minimize.
-
-    Include non-renewable, cumulative, and unary resources.
-    The weigths are to be defined in `solver.objective_resource_weights`.
-
-    """
-    CUSTOM = "custom_objective"
-
-
-@dataclass
-class TaskVariable(Generic[UnaryResource, Skill]):
-    """Task characteristics found by a cpsat solution."""
-
-    start: int  # start time of the task
-    end: int  # end time of the task
-    mode: int  # chosen mode for the task
-    allocated: dict[UnaryResource, set[Skill]] = field(
-        default_factory=dict
-    )  # resources allocated to the task
-    info: dict[str, Any] = field(
-        default_factory=dict
-    )  # additional information if needed
-
-
-@dataclass
-class TemporarySolution(Generic[Task, UnaryResource, Skill]):
-    """Temporary format for a cpsat solution."""
-
-    task_variables: dict[Task, TaskVariable[UnaryResource, Skill]]
-    metadata: dict[str, Any] = field(default_factory=dict)
-
 
 AnyResource = NonRenewableResource | UnaryResource | Skill | NonSkillCumulativeResource
 
@@ -154,7 +108,7 @@ class GenericSchedulingAutoCpSatSolver(
     ]
 
     # objective settings
-    objective = Objective.MAKESPAN  # Objective set by `init_model()`
+    objective: Objective = Objective.MAKESPAN  # Objective set by `init_model()`
     objective_resource_weights: Optional[dict[AnyResource, int]] = None
     """Weights to be used by the objective when summing used resources or resources consumption.
 
@@ -875,7 +829,7 @@ class GenericSchedulingAutoCpSatSolver(
             "potentially because calendar and non-renewable resources intersect."
         )
 
-    def get_nb_resources_used_variable(self) -> Any:
+    def get_nb_resources_used_variable(self) -> LinearExprT:
         """Get cpsat variable tracking number of resources used at least in one task.
 
         If necessary, intermediate variables tracking is a specific resource is used are created.
@@ -890,7 +844,7 @@ class GenericSchedulingAutoCpSatSolver(
             for resource, used in self.all_used_variables.items()
         )
 
-    def get_aggregated_resources_consumptions_variable(self) -> Any:
+    def get_aggregated_resources_consumptions_variable(self) -> LinearExprT:
         """Get cpsat variable aggregating consumptions of each resource."""
         weights = self.objective_resource_weights
         if weights is None:
@@ -925,25 +879,29 @@ class GenericSchedulingAutoCpSatSolver(
             self.create_energy_constraints(branches=branches)
 
     def _set_objective(self) -> None:
-        objective = None
-        match self.objective:
+        if self.objective == Objective.CUSTOM:
+            # for custom objective, inheriting classes should override `init_model()` to define the objective.
+            return
+
+        objective_var = self.get_objective_variable(self.objective)
+        weight = -OBJECTIVE_DEFAULT_WEIGHTS[self.objective]
+        self.cp_model.minimize(weight * objective_var)
+
+    def get_objective_variable(self, objective: Objective) -> LinearExprT:
+        match objective:
             case Objective.MAKESPAN:
-                objective = self.get_global_makespan_variable()
+                objective_var = self.get_global_makespan_variable()
             case Objective.NB_TASKS_DONE:
-                objective = -self.get_nb_tasks_done_variable()
+                objective_var = self.get_nb_tasks_done_variable()
             case Objective.NB_UNARY_RESOURCES_USED:
-                objective = self.get_nb_unary_resources_used_variable()
+                objective_var = self.get_nb_unary_resources_used_variable()
             case Objective.NB_RESOURCES_USED:
-                objective = self.get_nb_resources_used_variable()
+                objective_var = self.get_nb_resources_used_variable()
             case Objective.RESOURCES_CONSUMPTION:
-                objective = self.get_aggregated_resources_consumptions_variable()
-            case Objective.CUSTOM:
-                # do not define it here. User will do it in overridden `init_model()`.
-                ...
+                objective_var = self.get_aggregated_resources_consumptions_variable()
             case _:
                 raise NotImplementedError()
-        if objective is not None:
-            self.cp_model.minimize(objective)
+        return objective_var
 
     def get_task_interval(self, task: Task) -> IntervalVar:
         if self.needs_task_interval:
@@ -1034,7 +992,7 @@ class GenericSchedulingAutoCpSatSolver(
 
     def retrieve_tasks_variables(
         self, cpsolvercb: CpSolverSolutionCallback
-    ) -> TemporarySolution[Task, UnaryResource, Skill]:
+    ) -> RawSolution[Task, UnaryResource, Skill]:
         """Construct each task variable from the cpsat solver internal solution.
 
         It will be called each time the cpsat solver find a new solution.
@@ -1087,13 +1045,13 @@ class GenericSchedulingAutoCpSatSolver(
             task_variables[task] = TaskVariable(
                 start=start, end=end, mode=mode, allocated=allocated
             )
-        return TemporarySolution(task_variables=task_variables)
+        return RawSolution(task_variables=task_variables)
 
     def retrieve_solution(self, cpsolvercb: CpSolverSolutionCallback) -> Solution:
         # construct generic tasks variables
-        temp_sol = self.retrieve_tasks_variables(cpsolvercb=cpsolvercb)
+        raw_sol = self.retrieve_tasks_variables(cpsolvercb=cpsolvercb)
         # convert to specific solution type
-        return self.convert_task_variables_to_solution(temp_sol=temp_sol)
+        return self.convert_task_variables_to_solution(raw_sol=raw_sol)
 
     def set_warm_start(self, solution: Solution) -> None:
         solution: GenericSchedulingSolution[
@@ -1134,7 +1092,7 @@ class GenericSchedulingAutoCpSatSolver(
 
     @abstractmethod
     def convert_task_variables_to_solution(
-        self, temp_sol: TemporarySolution[Task, UnaryResource, Skill]
+        self, raw_sol: RawSolution[Task, UnaryResource, Skill]
     ) -> GenericSchedulingSolution[
         Task, UnaryResource, Skill, NonSkillCumulativeResource, NonRenewableResource
     ]:
@@ -1143,7 +1101,7 @@ class GenericSchedulingAutoCpSatSolver(
         To be used in `self.retrieve_solution()`.
 
         Args:
-            temp_sol:
+            raw_sol:
 
         Returns:
 

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto.py
@@ -217,6 +217,12 @@ class GenericSchedulingAutoCpSatSolver(
             horizon=self.get_makespan_upper_bound(),
         )
 
+    def get_makespan_lower_bound(self) -> int:
+        return self.problem.get_makespan_tighter_lower_bound(
+            use_cpm=self.use_cpm_for_task_bounds,
+            horizon=self.get_makespan_upper_bound(),
+        )
+
     def get_task_start_or_end_lower_bound(
         self, task: Task, start_or_end: StartOrEnd
     ) -> int:

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto_impl.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto_impl.py
@@ -1,0 +1,175 @@
+#  Copyright (c) 2026 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any, Optional
+
+from ortools.sat.python.cp_model import LinearExprT
+
+from discrete_optimization.generic_tasks_tools.generic_scheduling_impl import (
+    GenericSchedulingImplProblem,
+    GenericSchedulingImplSolution,
+    NonRenewableResource,
+    NonSkillCumulativeResource,
+    Skill,
+    Task,
+    UnaryResource,
+)
+from discrete_optimization.generic_tasks_tools.generic_scheduling_utils import (
+    Objective,
+    RawSolution,
+)
+from discrete_optimization.generic_tasks_tools.solvers.cpsat.auto import (
+    GenericSchedulingAutoCpSatSolver,
+)
+from discrete_optimization.generic_tools.do_problem import (
+    ModeOptim,
+    ObjectiveHandling,
+    ParamsObjectiveFunction,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class GenericSchedulingAutoCpSatImplSolver(
+    GenericSchedulingAutoCpSatSolver[
+        Task, UnaryResource, Skill, NonSkillCumulativeResource, NonRenewableResource
+    ]
+):
+    """Generic implementation of cpsat solver for scheduling problems (with or without allocation).
+
+    It implements abstract class `GenericSchedulingAutoCpSatSolver`.
+
+    """
+
+    problem: GenericSchedulingImplProblem
+    objective = Objective.CUSTOM  # do not set the objective during super().init_model()
+
+    def __init__(
+        self,
+        problem: GenericSchedulingImplProblem,
+        params_objective_function: Optional[ParamsObjectiveFunction] = None,
+        custom_objective_factory: Optional[
+            Callable[[GenericSchedulingAutoCpSatImplSolver], LinearExprT]
+        ] = None,
+        **kwargs: Any,
+    ):
+        """
+
+        Args:
+            problem:
+            params_objective_function:
+            custom_objective_factory: callable constructing the custom objective variable using this solver variables.
+                It should correspond to `problem.custom_evaluate_fn`. It will be used as a way to compute
+                the subobjective "custom" if appearing in `params_objective_function.objectives`.
+            **kwargs:
+        """
+        super().__init__(
+            problem=problem,
+            params_objective_function=params_objective_function,
+            **kwargs,
+        )
+        self.custom_objective_factory = custom_objective_factory
+
+    def get_makespan_upper_bound(self) -> int:
+        if self.new_horizon is None:
+            return super().get_makespan_upper_bound()
+        else:
+            return min(self.new_horizon, super().get_makespan_upper_bound())
+
+    def init_model(
+        self,
+        new_horizon: Optional[int] = None,
+        tasks_bounds: Optional[dict[Task, tuple[int, int, int, int]]] = None,
+        use_cpm_for_task_bounds: Optional[bool] = None,
+        avoid_interval_optional: Optional[bool] = None,
+        duplicate_start_var_per_mode: Optional[bool] = None,
+        use_energy_constraints: Optional[bool] = None,
+        keep_only_most_nested_energy_constraints: Optional[bool] = None,
+        add_redundant_skill_cumulative_constraints: Optional[bool] = None,
+        exactly_one_unary_resource_per_task: Optional[bool] = None,
+        at_most_one_unary_resource_per_task: Optional[bool] = None,
+        use_exact_skill: Optional[bool] = None,
+        use_slack_for_skill: Optional[bool] = None,
+        max_slack_for_skill: Optional[int] = None,
+        use_only_skill_to_allocate: Optional[bool] = None,
+        use_no_overlap_for_capa_1: Optional[bool] = None,
+        use_cumulative_for_capa_1: Optional[bool] = None,
+        **kwargs: Any,
+    ) -> None:
+        self.new_horizon = new_horizon
+
+        # override default parameters if given, for those not already managed by parent class
+        if exactly_one_unary_resource_per_task is not None:
+            self.exactly_one_unary_resource_per_task = (
+                exactly_one_unary_resource_per_task
+            )
+        if at_most_one_unary_resource_per_task is not None:
+            self.at_most_one_unary_resource_per_task = (
+                at_most_one_unary_resource_per_task
+            )
+        if use_exact_skill is not None:
+            self.use_exact_skill = use_exact_skill
+        if use_slack_for_skill is not None:
+            self.use_slack_for_skill = use_slack_for_skill
+        if max_slack_for_skill is not None:
+            self.max_slack_for_skill = max_slack_for_skill
+        if use_only_skill_to_allocate is not None:
+            self.use_only_skill_to_allocate = use_only_skill_to_allocate
+        if use_no_overlap_for_capa_1 is not None:
+            self.use_no_overlap_for_capa_1 = use_no_overlap_for_capa_1
+        if use_cumulative_for_capa_1 is not None:
+            self.use_cumulative_for_capa_1 = use_cumulative_for_capa_1
+
+        super().init_model(
+            tasks_bounds=tasks_bounds,
+            use_cpm_for_task_bounds=use_cpm_for_task_bounds,
+            avoid_interval_optional=avoid_interval_optional,
+            duplicate_start_var_per_mode=duplicate_start_var_per_mode,
+            use_energy_constraints=use_energy_constraints,
+            keep_only_most_nested_energy_constraints=keep_only_most_nested_energy_constraints,
+            add_redundant_skill_cumulative_constraints=add_redundant_skill_cumulative_constraints,
+            **kwargs,
+        )
+
+        # use the params_objective_function to define the objective
+        match self.params_objective_function.objective_handling:
+            case ObjectiveHandling.SINGLE:
+                objective_var = self.params_objective_function.weights[
+                    0
+                ] * self.get_objective_variable(
+                    Objective(self.params_objective_function.objectives[0])
+                )
+            case ObjectiveHandling.AGGREGATE:
+                objective_var = sum(
+                    weight * self.get_objective_variable(Objective(objective_name))
+                    for objective_name, weight in zip(
+                        self.params_objective_function.objectives,
+                        self.params_objective_function.weights,
+                    )
+                )
+            case _:
+                raise NotImplementedError()
+        if self.params_objective_function.sense_function == ModeOptim.MAXIMIZATION:
+            self.cp_model.maximize(objective_var)
+        else:
+            self.cp_model.minimize(objective_var)
+
+    def get_objective_variable(self, objective: Objective) -> LinearExprT:
+        if objective == Objective.CUSTOM:
+            if self.custom_objective_factory is None:
+                raise RuntimeError(
+                    "`custom_objective_factory` not defined, so `Objective.CUSTOM` cannot be translated as a cpsat variable."
+                )
+            return self.custom_objective_factory(self)
+        else:
+            return super().get_objective_variable(objective)
+
+    def convert_task_variables_to_solution(
+        self, raw_sol: RawSolution[Task, UnaryResource, Skill]
+    ) -> GenericSchedulingImplSolution:
+        return GenericSchedulingImplSolution(problem=self.problem, raw_sol=raw_sol)

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/generic_scheduling.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/generic_scheduling.py
@@ -108,3 +108,6 @@ class GenericSchedulingCpSatSolver(
 
         """
         ...
+
+    def get_makespan_upper_bound(self) -> int:
+        return self.problem.get_makespan_tighter_upper_bound()

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/scheduling.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/scheduling.py
@@ -91,7 +91,7 @@ class SchedulingCpSatSolver(OrtoolsCpSatSolver, SchedulingCpSolver[Task]):
         if self.constraints_on_makespan is not None:
             self.remove_constraints(self.constraints_on_makespan)
 
-    def get_global_makespan_variable(self) -> Any:
+    def get_global_makespan_variable(self) -> LinearExprT:
         # remove previous constraints on makespan variable from cp model
         self.remove_constraints_on_objective()
         # get makespan variable
@@ -108,7 +108,7 @@ class SchedulingCpSatSolver(OrtoolsCpSatSolver, SchedulingCpSolver[Task]):
         ]
         return makespan
 
-    def get_subtasks_makespan_variable(self, subtasks: Iterable[Task]) -> Any:
+    def get_subtasks_makespan_variable(self, subtasks: Iterable[Task]) -> LinearExprT:
         # remove previous constraints on makespan variable from cp model
         self.remove_constraints_on_objective()
         # get makespan variable
@@ -125,14 +125,18 @@ class SchedulingCpSatSolver(OrtoolsCpSatSolver, SchedulingCpSolver[Task]):
         ]
         return makespan
 
-    def get_subtasks_sum_end_time_variable(self, subtasks: Iterable[Task]) -> Any:
+    def get_subtasks_sum_end_time_variable(
+        self, subtasks: Iterable[Task]
+    ) -> LinearExprT:
         self.remove_constraints_on_objective()
         return sum(
             self.get_task_start_or_end_variable(task, StartOrEnd.END)
             for task in subtasks
         )
 
-    def get_subtasks_sum_start_time_variable(self, subtasks: Iterable[Task]) -> Any:
+    def get_subtasks_sum_start_time_variable(
+        self, subtasks: Iterable[Task]
+    ) -> LinearExprT:
         self.remove_constraints_on_objective()
         return sum(
             self.get_task_start_or_end_variable(task, StartOrEnd.START)

--- a/src/discrete_optimization/generic_tasks_tools/timewindow.py
+++ b/src/discrete_optimization/generic_tasks_tools/timewindow.py
@@ -55,6 +55,19 @@ class TimewindowProblem(SchedulingProblem[Task], Generic[Task]):
         """
         return self.get_makespan_upper_bound()
 
+    def get_makespan_lower_bound(self) -> int:
+        """Get a lower bound on global makespan.
+
+        Time windows on last tasks can be used to get a better makespan lower bound.
+
+        """
+        return max(
+            self.get_task_start_or_end_lower_bound(
+                task=task, start_or_end=StartOrEnd.END
+            )
+            for task in self.get_last_tasks()
+        )
+
 
 class TimewindowSolution(SchedulingSolution[Task], Generic[Task]):
     """Class for solution of problems having time windows between tasks."""

--- a/src/discrete_optimization/jsp/solvers/cpsat_auto.py
+++ b/src/discrete_optimization/jsp/solvers/cpsat_auto.py
@@ -10,13 +10,15 @@ from discrete_optimization.generic_tasks_tools.allocation import (
     NoUnaryResource,
     UnaryResource,
 )
+from discrete_optimization.generic_tasks_tools.generic_scheduling_utils import (
+    RawSolution,
+)
 from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
     NoNonRenewableResource,
 )
 from discrete_optimization.generic_tasks_tools.skill import NoSkill
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.auto import (
     SinglemodeGenericSchedulingAutoCpSatSolver,
-    TemporarySolution,
 )
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.skill import (
     WithoutSkillSchedulingCpSatSolver,
@@ -58,11 +60,11 @@ class CpSatAutoJspSolver(
         super().init_model(**kwargs)
 
     def convert_task_variables_to_solution(
-        self, temp_sol: TemporarySolution[Task, UnaryResource, NoSkill]
+        self, raw_sol: RawSolution[Task, UnaryResource, NoSkill]
     ) -> JobShopSolution:
         schedule = [
             [
-                ((task_var := temp_sol.task_variables[j, k]).start, task_var.end)
+                ((task_var := raw_sol.task_variables[j, k]).start, task_var.end)
                 for k, sub_job in enumerate(job)
             ]
             for j, job in enumerate(self.problem.list_jobs)

--- a/src/discrete_optimization/jsp/solvers/cpsat_auto.py
+++ b/src/discrete_optimization/jsp/solvers/cpsat_auto.py
@@ -48,14 +48,16 @@ class CpSatAutoJspSolver(
     problem: JobShopProblem
 
     def get_makespan_upper_bound(self) -> int:
-        return self._max_time
+        if self._max_time is None:
+            return super().get_makespan_upper_bound()
+        else:
+            return min(self._max_time, super().get_makespan_upper_bound())
 
     def init_model(self, **kwargs: Any) -> None:
-        max_time = kwargs.get(
+        self._max_time: int | None = kwargs.get(
             "max_time",
-            self.problem.get_makespan_upper_bound(),
-        )
-        self._max_time = max_time  # will be used by the makespan variable
+            None,
+        )  # new horizon
 
         super().init_model(**kwargs)
 

--- a/src/discrete_optimization/rcpsp/solvers/cpsat.py
+++ b/src/discrete_optimization/rcpsp/solvers/cpsat.py
@@ -319,7 +319,7 @@ class CpSatRcpspSolver(
         objective = self.get_global_makespan_variable()
         self.minimize_variable(objective)
 
-    def get_global_makespan_variable(self) -> Any:
+    def get_global_makespan_variable(self) -> LinearExprT:
         self.remove_constraints_on_objective()
         return self.variables["end"][self.problem.sink_task]
 

--- a/src/discrete_optimization/rcpsp/solvers/cpsat_auto.py
+++ b/src/discrete_optimization/rcpsp/solvers/cpsat_auto.py
@@ -11,6 +11,7 @@ from typing import Any
 from ortools.sat.python.cp_model import (
     Constraint,
     CpSolverSolutionCallback,
+    LinearExprT,
     ObjLinearExprT,
 )
 
@@ -19,11 +20,13 @@ from discrete_optimization.generic_tasks_tools.allocation import (
     UnaryResource,
 )
 from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
+from discrete_optimization.generic_tasks_tools.generic_scheduling_utils import (
+    Objective,
+    RawSolution,
+)
 from discrete_optimization.generic_tasks_tools.skill import NoSkill
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.auto import (
     GenericSchedulingAutoCpSatSolver,
-    Objective,
-    TemporarySolution,
 )
 from discrete_optimization.generic_tools.result_storage.result_storage import (
     ResultStorage,
@@ -161,18 +164,18 @@ class CpSatAutoRcpspSolver(
             self.create_mode_pair_constraint()
             self.add_special_temporal_constraints()
 
-    def get_global_makespan_variable(self) -> Any:
+    def get_global_makespan_variable(self) -> LinearExprT:
         self.remove_constraints_on_objective()
         return self.get_task_start_or_end_variable(
             task=self.problem.sink_task, start_or_end=StartOrEnd.END
         )
 
     def convert_task_variables_to_solution(
-        self, temp_sol: TemporarySolution[Task, UnaryResource, NoSkill]
+        self, raw_sol: RawSolution[Task, UnaryResource, NoSkill]
     ) -> RcpspSolution:
         schedule = {}
         modes_dict = {}
-        for task, task_variable in temp_sol.task_variables.items():
+        for task, task_variable in raw_sol.task_variables.items():
             schedule[task] = {
                 "start_time": task_variable.start,
                 "end_time": task_variable.end,
@@ -251,7 +254,7 @@ class CpSatAutoResourceRcpspSolver(CpSatAutoRcpspSolver):
 
     def retrieve_tasks_variables(
         self, cpsolvercb: CpSolverSolutionCallback
-    ) -> TemporarySolution[Task, UnaryResource, NoSkill]:
+    ) -> RawSolution[Task, UnaryResource, NoSkill]:
         """Construct each task variable from the cpsat solver internal solution.
 
         It will be called each time the cpsat solver find a new solution.
@@ -266,27 +269,27 @@ class CpSatAutoResourceRcpspSolver(CpSatAutoRcpspSolver):
             the task variables for the intermediate solution
 
         """
-        temp_sol = super().retrieve_tasks_variables(cpsolvercb)
+        raw_sol = super().retrieve_tasks_variables(cpsolvercb)
 
-        temp_sol.metadata.update(
+        raw_sol.metadata.update(
             {
                 obj: cpsolvercb.value(self._internal_objective(obj))
                 for obj in self.get_lexico_objectives_available()
             }
         )
 
-        return temp_sol
+        return raw_sol
 
     def convert_task_variables_to_solution(
-        self, temp_sol: TemporarySolution[Task, UnaryResource, NoSkill]
+        self, raw_sol: RawSolution[Task, UnaryResource, NoSkill]
     ) -> RcpspSolution:
         """Convert temporary solution to rcpsp format.
 
         Add internal objectives.
 
         """
-        sol = super().convert_task_variables_to_solution(temp_sol=temp_sol)
-        sol._internal_objectives = temp_sol.metadata
+        sol = super().convert_task_variables_to_solution(raw_sol=raw_sol)
+        sol._internal_objectives = raw_sol.metadata
         return sol
 
     def get_lexico_objectives_available(self) -> list[str]:
@@ -366,7 +369,7 @@ class CpSatAutoCumulativeResourceRcpspSolver(CpSatAutoRcpspSolver):
 
     def retrieve_tasks_variables(
         self, cpsolvercb: CpSolverSolutionCallback
-    ) -> TemporarySolution[Task, UnaryResource, NoSkill]:
+    ) -> RawSolution[Task, UnaryResource, NoSkill]:
         """Construct each task variable from the cpsat solver internal solution.
 
         It will be called each time the cpsat solver find a new solution.
@@ -381,27 +384,27 @@ class CpSatAutoCumulativeResourceRcpspSolver(CpSatAutoRcpspSolver):
             the task variables for the intermediate solution
 
         """
-        temp_sol = super().retrieve_tasks_variables(cpsolvercb)
+        raw_sol = super().retrieve_tasks_variables(cpsolvercb)
 
-        temp_sol.metadata.update(
+        raw_sol.metadata.update(
             {
                 obj: cpsolvercb.value(self._internal_objective(obj))
                 for obj in self.get_lexico_objectives_available()
             }
         )
 
-        return temp_sol
+        return raw_sol
 
     def convert_task_variables_to_solution(
-        self, temp_sol: TemporarySolution[Task, UnaryResource, NoSkill]
+        self, raw_sol: RawSolution[Task, UnaryResource, NoSkill]
     ) -> RcpspSolution:
         """Convert temporary solution to rcpsp format.
 
         Add internal objectives.
 
         """
-        sol = super().convert_task_variables_to_solution(temp_sol=temp_sol)
-        sol._internal_objectives = temp_sol.metadata
+        sol = super().convert_task_variables_to_solution(raw_sol=raw_sol)
+        sol._internal_objectives = raw_sol.metadata
         return sol
 
     def get_lexico_objectives_available(self) -> list[str]:

--- a/src/discrete_optimization/rcpsp_multiskill/solvers/cpsat.py
+++ b/src/discrete_optimization/rcpsp_multiskill/solvers/cpsat.py
@@ -93,7 +93,7 @@ class CpSatMultiskillRcpspSolver(
     def get_task_mode_is_present_variable(self, task: Task, mode: int) -> LinearExprT:
         return self.variables["mode_variable"]["is_present"][task][mode]
 
-    def get_global_makespan_variable(self) -> Any:
+    def get_global_makespan_variable(self) -> LinearExprT:
         self.remove_constraints_on_objective()
         return self.variables["makespan"]
 

--- a/src/discrete_optimization/rcpsp_multiskill/solvers/cpsat_auto.py
+++ b/src/discrete_optimization/rcpsp_multiskill/solvers/cpsat_auto.py
@@ -8,9 +8,11 @@ from ortools.sat.python.cp_model import (
     CpSolverSolutionCallback,
 )
 
+from discrete_optimization.generic_tasks_tools.generic_scheduling_utils import (
+    RawSolution,
+)
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.auto import (
     GenericSchedulingAutoCpSatSolver,
-    TemporarySolution,
 )
 from discrete_optimization.generic_tools.do_problem import Solution
 from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
@@ -49,14 +51,14 @@ class CpSatAutoMultiskillRcpspSolver(
     problem: MultiskillRcpspProblem
 
     def convert_task_variables_to_solution(
-        self, temp_sol: TemporarySolution[Task, UnaryResource, Skill]
+        self, raw_sol: RawSolution[Task, UnaryResource, Skill]
     ) -> Solution:
         """Convert solution from autosolver format into do format.
 
         To be used in `self.retrieve_solution()`.
 
         Args:
-            temp_sol:
+            raw_sol:
 
         Returns:
 
@@ -64,7 +66,7 @@ class CpSatAutoMultiskillRcpspSolver(
         modes_dict = {}
         schedule = {}
         employee_usage = {}
-        for task, task_variable in temp_sol.task_variables.items():
+        for task, task_variable in raw_sol.task_variables.items():
             schedule[task] = {
                 "start_time": task_variable.start,
                 "end_time": task_variable.end,
@@ -81,12 +83,12 @@ class CpSatAutoMultiskillRcpspSolver(
             modes=modes_dict,
             employee_usage=employee_usage,
         )
-        sol._internal_obj = temp_sol.metadata
+        sol._internal_obj = raw_sol.metadata
         return sol
 
     def retrieve_tasks_variables(
         self, cpsolvercb: CpSolverSolutionCallback
-    ) -> TemporarySolution[Task, UnaryResource, Skill]:
+    ) -> RawSolution[Task, UnaryResource, Skill]:
         """Construct each task variable from the cpsat solver internal solution.
 
         It will be called each time the cpsat solver find a new solution.
@@ -101,14 +103,14 @@ class CpSatAutoMultiskillRcpspSolver(
             the task variables for the intermediate solution
 
         """
-        temp_sol = super().retrieve_tasks_variables(cpsolvercb)
+        raw_sol = super().retrieve_tasks_variables(cpsolvercb)
 
         # internal objective
-        temp_sol.metadata["makespan"] = cpsolvercb.value(
+        raw_sol.metadata["makespan"] = cpsolvercb.value(
             self.get_global_makespan_variable()
         )
 
-        return temp_sol
+        return raw_sol
 
     def include_constraint_on_cumulative_resource(
         self, resource: CumulativeResource

--- a/src/discrete_optimization/workforce/scheduling/problem.py
+++ b/src/discrete_optimization/workforce/scheduling/problem.py
@@ -245,11 +245,8 @@ class AllocSchedulingProblem(
     ) -> bool:
         return unary_resource in self.compatible_teams_per_activity[task]
 
-    def get_makespan_lower_bound(self) -> int:
-        return max(int(self.get_lb_end_window(t)) for t in self.tasks_list)
-
     def get_makespan_upper_bound(self) -> int:
-        return max(int(self.get_ub_end_window(t)) for t in self.tasks_list)
+        return self.horizon
 
     def set_objective_handling(self, objective_handling: ObjectiveHandling):
         self.objective_handling = objective_handling

--- a/src/discrete_optimization/workforce/scheduling/solvers/cpsat_auto.py
+++ b/src/discrete_optimization/workforce/scheduling/solvers/cpsat_auto.py
@@ -13,14 +13,16 @@ from ortools.sat.python.cp_model import (
 )
 
 from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
+from discrete_optimization.generic_tasks_tools.generic_scheduling_utils import (
+    Objective,
+    RawSolution,
+)
 from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
     NoNonRenewableResource,
 )
 from discrete_optimization.generic_tasks_tools.skill import NoSkill
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.auto import (
-    Objective,
     SinglemodeGenericSchedulingAutoCpSatSolver,
-    TemporarySolution,
 )
 from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
     CategoricalHyperparameter,
@@ -178,13 +180,13 @@ class CPSatAutoAllocSchedulingSolver(
         )
 
     def convert_task_variables_to_solution(
-        self, temp_sol: TemporarySolution[Task, UnaryResource, NoSkill]
+        self, raw_sol: RawSolution[Task, UnaryResource, NoSkill]
     ) -> AllocSchedulingSolution:
         schedule = np.zeros((self.problem.number_tasks, 2), dtype=int)
         allocation = -np.ones(self.problem.number_tasks, dtype=int)
         for i_task in range(self.problem.number_tasks):
             task = self.problem.index_to_task[i_task]
-            task_variable = temp_sol.task_variables[task]
+            task_variable = raw_sol.task_variables[task]
             schedule[i_task, 0] = task_variable.start
             schedule[i_task, 1] = task_variable.end
             for team in task_variable.allocated:
@@ -192,12 +194,12 @@ class CPSatAutoAllocSchedulingSolver(
         sol = AllocSchedulingSolution(
             problem=self.problem, schedule=schedule, allocation=allocation
         )
-        sol._intern_obj = temp_sol.metadata
+        sol._intern_obj = raw_sol.metadata
         return sol
 
     def retrieve_tasks_variables(
         self, cpsolvercb: CpSolverSolutionCallback
-    ) -> TemporarySolution[Task, UnaryResource, NoSkill]:
+    ) -> RawSolution[Task, UnaryResource, NoSkill]:
         """Create solution at temporary format from cpsat variables.
 
         Override it to
@@ -206,7 +208,7 @@ class CPSatAutoAllocSchedulingSolver(
 
         """
         # retrieve main tasks variables
-        temp_sol = super().retrieve_tasks_variables(cpsolvercb)
+        raw_sol = super().retrieve_tasks_variables(cpsolvercb)
         # log objectives
         logger.info(f"Objs = {[cpsolvercb.value(x) for x in self.variables['objs']]}")
         logger.info(
@@ -220,8 +222,8 @@ class CPSatAutoAllocSchedulingSolver(
                 )
         # store objectives
         for obj in self.variables["objectives"]:
-            temp_sol.metadata[obj] = cpsolvercb.value(self.variables["objectives"][obj])
-        return temp_sol
+            raw_sol.metadata[obj] = cpsolvercb.value(self.variables["objectives"][obj])
+        return raw_sol
 
     def is_compatible_task_unary_resource(
         self, task: Task, unary_resource: UnaryResource

--- a/tests/generic_tasks_tools/solvers/cpsat/test_auto.py
+++ b/tests/generic_tasks_tools/solvers/cpsat/test_auto.py
@@ -16,6 +16,11 @@ from discrete_optimization.generic_tasks_tools.generic_scheduling import (
     GenericSchedulingProblem,
     GenericSchedulingSolution,
 )
+from discrete_optimization.generic_tasks_tools.generic_scheduling_utils import (
+    Objective,
+    RawSolution,
+    TaskVariable,
+)
 from discrete_optimization.generic_tasks_tools.skill import (
     NoSkill,
     WithoutSkillProblem,
@@ -23,9 +28,6 @@ from discrete_optimization.generic_tasks_tools.skill import (
 )
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.auto import (
     GenericSchedulingAutoCpSatSolver,
-    Objective,
-    TaskVariable,
-    TemporarySolution,
 )
 from discrete_optimization.generic_tools.callbacks.early_stoppers import (
     NbIterationStopper,
@@ -64,25 +66,25 @@ class MySolution(
     def __init__(
         self,
         problem: MyProblem,
-        temp_sol: TemporarySolution[Task, UnaryResource, Skill],
+        raw_sol: RawSolution[Task, UnaryResource, Skill],
     ):
         super().__init__(problem)
-        self.temp_sol = temp_sol
+        self.raw_sol = raw_sol
 
     def get_end_time(self, task: Task) -> int:
-        return self.temp_sol.task_variables[task].end
+        return self.raw_sol.task_variables[task].end
 
     def get_start_time(self, task: Task) -> int:
-        return self.temp_sol.task_variables[task].start
+        return self.raw_sol.task_variables[task].start
 
     def get_mode(self, task: Task) -> int:
-        return self.temp_sol.task_variables[task].mode
+        return self.raw_sol.task_variables[task].mode
 
     def is_allocated(self, task: Task, unary_resource: UnaryResource) -> bool:
-        return unary_resource in self.temp_sol.task_variables[task].allocated
+        return unary_resource in self.raw_sol.task_variables[task].allocated
 
     def copy(self) -> Solution:
-        return MySolution(problem=self.problem, temp_sol=deepcopy(self.temp_sol))
+        return MySolution(problem=self.problem, raw_sol=deepcopy(self.raw_sol))
 
 
 class MyProblem(
@@ -224,9 +226,9 @@ class MyAutoCpsatSolver(
     problem: MyProblem
 
     def convert_task_variables_to_solution(
-        self, temp_sol: TemporarySolution[Task, UnaryResource, Skill]
+        self, raw_sol: RawSolution[Task, UnaryResource, Skill]
     ) -> MySolution:
-        return MySolution(problem=self.problem, temp_sol=temp_sol)
+        return MySolution(problem=self.problem, raw_sol=raw_sol)
 
     def __init__(
         self,
@@ -249,7 +251,7 @@ def test_problem(caplog):
     problem = MyProblem()
     sol = MySolution(
         problem=problem,
-        temp_sol=TemporarySolution(
+        raw_sol=RawSolution(
             task_variables={
                 "task-1": TaskVariable(
                     start=1, end=4, mode=1, allocated={"worker1": set()}
@@ -270,7 +272,7 @@ def test_problem(caplog):
 
     sol = MySolution(
         problem=problem,
-        temp_sol=TemporarySolution(
+        raw_sol=RawSolution(
             task_variables={
                 "task-1": TaskVariable(
                     start=3, end=6, mode=1, allocated={"worker2": set()}
@@ -289,7 +291,7 @@ def test_problem(caplog):
 
     sol = MySolution(
         problem=problem,
-        temp_sol=TemporarySolution(
+        raw_sol=RawSolution(
             task_variables={
                 "task-1": TaskVariable(
                     start=3,
@@ -313,7 +315,7 @@ def test_problem(caplog):
     # nok: worker not available
     sol = MySolution(
         problem=problem,
-        temp_sol=TemporarySolution(
+        raw_sol=RawSolution(
             task_variables={
                 "task-1": TaskVariable(
                     start=3, end=6, mode=1, allocated={"worker1": set()}
@@ -331,7 +333,7 @@ def test_problem(caplog):
     # nok: cumulative resource not available
     sol = MySolution(
         problem=problem,
-        temp_sol=TemporarySolution(
+        raw_sol=RawSolution(
             task_variables={
                 "task-1": TaskVariable(
                     start=1, end=4, mode=1, allocated={"worker1": set()}
@@ -349,7 +351,7 @@ def test_problem(caplog):
     # nok: duration not correct
     sol = MySolution(
         problem=problem,
-        temp_sol=TemporarySolution(
+        raw_sol=RawSolution(
             task_variables={
                 "task-1": TaskVariable(
                     start=1, end=2, mode=1, allocated={"worker1": set()}
@@ -369,7 +371,7 @@ def test_problem(caplog):
     problem.mode_details["task-2"][0]["cumulative_resource"] = 1
     sol = MySolution(
         problem=problem,
-        temp_sol=TemporarySolution(
+        raw_sol=RawSolution(
             task_variables={
                 "task-1": TaskVariable(
                     start=1, end=4, mode=1, allocated={"worker1": set()}
@@ -435,7 +437,7 @@ def test_auto(
     assert problem.satisfy(sol)
     kpi = problem.evaluate(sol)
     print(kpi)
-    print(sol.temp_sol.task_variables)
+    print(sol.raw_sol.task_variables)
 
     if objective == Objective.NB_UNARY_RESOURCES_USED:
         assert kpi["nb_allocated"] == 1
@@ -453,7 +455,7 @@ def test_auto(
     # check warm start from a "bad" solution
     bad_sol = MySolution(
         problem=problem,
-        temp_sol=TemporarySolution(
+        raw_sol=RawSolution(
             task_variables={
                 "task-1": TaskVariable(
                     start=1, end=4, mode=1, allocated={"worker1": set()}
@@ -474,7 +476,7 @@ def test_auto(
         callbacks=[NbIterationStopper(1)],
     )
     sol, fit = res[0]
-    assert sol.temp_sol.task_variables == bad_sol.temp_sol.task_variables
+    assert sol.raw_sol.task_variables == bad_sol.raw_sol.task_variables
 
 
 def test_task_bounds_user():

--- a/tests/generic_tasks_tools/solvers/cpsat/test_auto_impl.py
+++ b/tests/generic_tasks_tools/solvers/cpsat/test_auto_impl.py
@@ -1,0 +1,620 @@
+#  Copyright (c) 2026 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from ortools.sat.python.cp_model import LinearExprT
+
+import discrete_optimization.fjsp.parser as fjsp_parser
+import discrete_optimization.jsp.parser as jsp_parser
+import discrete_optimization.rcpsp.parser as rcpsp_parser
+import discrete_optimization.rcpsp_multiskill.parser_imopse as parser_imopse
+from discrete_optimization.fjsp.problem import FJobShopSolution
+from discrete_optimization.fjsp.solvers.cpsat_auto import CpSatAutoFjspSolver
+from discrete_optimization.generic_tasks_tools.generic_scheduling_impl import (
+    DURATION,
+    GenericSchedulingImplProblem,
+    GenericSchedulingImplSolution,
+)
+from discrete_optimization.generic_tasks_tools.generic_scheduling_utils import (
+    Objective,
+    RawSolution,
+    TaskVariable,
+)
+from discrete_optimization.generic_tasks_tools.solvers.cpsat.auto_impl import (
+    GenericSchedulingAutoCpSatImplSolver,
+)
+from discrete_optimization.generic_tools.callbacks.early_stoppers import (
+    NbIterationStopper,
+)
+from discrete_optimization.generic_tools.cp_tools import ParametersCp
+from discrete_optimization.jsp.problem import JobShopSolution
+from discrete_optimization.jsp.solvers.cpsat_auto import CpSatAutoJspSolver
+from discrete_optimization.rcpsp import RcpspProblem
+from discrete_optimization.rcpsp.solution import RcpspSolution
+from discrete_optimization.rcpsp.solvers.cpsat_auto import CpSatAutoRcpspSolver
+from discrete_optimization.rcpsp.special_constraints import (
+    SpecialConstraintsDescription,
+)
+from discrete_optimization.rcpsp_multiskill.problem import MultiskillRcpspSolution
+from discrete_optimization.rcpsp_multiskill.solvers.cpsat_auto import (
+    CpSatAutoMultiskillRcpspSolver,
+)
+
+
+@pytest.mark.parametrize(
+    "objective",
+    list(Objective) + [[(Objective.MAKESPAN, -2), (Objective.NB_TASKS_DONE, +2)]],
+)
+@pytest.mark.parametrize(
+    "avoid_interval_optional, duplicate_start_var_per_mode",
+    [(True, False), (False, False), (False, True)],
+)
+@pytest.mark.parametrize(
+    "use_energy_constraints, keep_only_most_nested_energy_constraints",
+    [(False, False), (True, False), (True, True)],
+)
+def test_auto(
+    objective,
+    avoid_interval_optional,
+    duplicate_start_var_per_mode,
+    use_energy_constraints,
+    keep_only_most_nested_energy_constraints,
+    caplog,
+):
+    def custom_evaluate_fn(variable: GenericSchedulingImplSolution):
+        return variable.compute_nb_tasks_done() - variable.get_max_end_time()
+
+    problem = GenericSchedulingImplProblem(
+        horizon=10,
+        mode_details={
+            "task-1": {
+                0: {"non_renewable_resource": 2, "duration": 1},
+                1: {"non_renewable_resource": 1, "duration": 3},
+            },
+            "task-2": {
+                0: {"cumulative_resource": 2, "duration": 4},
+            },
+        },
+        successors={"task-1": ["task-2"]},
+        unary_resources={"worker1", "worker2"},
+        unary_resources_availabilities={
+            "worker1": [(1, 4)],
+            "worker2": [(3, 18)],
+        },
+        non_skill_cumulative_resources={
+            "cumulative_resource": [
+                (3, 5, 1),
+                (5, 10, 2),
+            ],
+        },
+        non_renewable_resources={
+            "non_renewable_resource": 1,
+        },
+        objective=objective,
+        custom_evaluate_fn=custom_evaluate_fn,
+    )
+
+    # prepare solver
+
+    # custom objective: makespan - nb tasks allocated
+    def custom_objective_factory(
+        solver: GenericSchedulingAutoCpSatImplSolver,
+    ) -> LinearExprT:
+        return (
+            solver.get_nb_tasks_done_variable() - solver.get_global_makespan_variable()
+        )
+
+    exactly_one_unary_resource_per_task = objective in [
+        Objective.NB_UNARY_RESOURCES_USED,
+        Objective.NB_RESOURCES_USED,
+        Objective.RESOURCES_CONSUMPTION,
+    ]
+
+    solver = GenericSchedulingAutoCpSatImplSolver(
+        problem=problem,
+        objective=objective,
+        custom_objective_factory=custom_objective_factory,
+    )
+
+    solver.init_model(
+        exactly_one_unary_resource_per_task=exactly_one_unary_resource_per_task
+    )
+
+    # solve
+    res = solver.solve(parameters_cp=ParametersCp.default())
+
+    # check sol and kpis
+    sol: GenericSchedulingImplSolution
+    sol, fit = res[-1]
+    assert problem.satisfy(sol)
+    kpi = problem.evaluate(sol)
+
+    if objective == Objective.NB_UNARY_RESOURCES_USED:
+        assert kpi["nb_unary_resources_used"] == 1
+    elif objective == Objective.NB_RESOURCES_USED:
+        assert kpi["nb_resources_used"] == 3
+    elif objective == Objective.MAKESPAN:
+        assert kpi["makespan"] == 9
+    elif objective == Objective.NB_TASKS_DONE:
+        assert kpi["nb_tasks_done"] == 2
+    elif objective == Objective.CUSTOM:
+        assert kpi["custom_objective"] == 2 - 9
+    elif isinstance(objective, list):
+        assert kpi["nb_tasks_done"] == 2
+        assert kpi["makespan"] == 9
+
+    # check warm start from a "bad" solution
+    bad_sol = GenericSchedulingImplSolution(
+        problem=problem,
+        raw_sol=RawSolution(
+            task_variables={
+                "task-1": TaskVariable(
+                    start=1, end=4, mode=1, allocated={"worker1": set()}
+                ),
+                "task-2": TaskVariable(
+                    start=6, end=10, mode=0, allocated={"worker2": set()}
+                ),
+            }
+        ),
+    )
+    problem.satisfy(bad_sol)
+
+    # warm start + 1 sol only => should find the "bad" solution
+    solver.set_warm_start(solution=bad_sol)
+    res = solver.solve(
+        ortools_cpsat_solver_kwargs=dict(fix_variables_to_their_hinted_value=True),
+        parameters_cp=ParametersCp.default(),
+        callbacks=[NbIterationStopper(1)],
+    )
+    sol, fit = res[0]
+    assert sol.raw_sol.task_variables == bad_sol.raw_sol.task_variables
+
+
+def test_rcpsp_simple():
+    mode_details = {
+        1: {1: {"duration": 0}},  # dummy start
+        2: {1: {"duration": 3, "R1": 1}},
+        3: {1: {"duration": 2, "R1": 1}},
+        4: {1: {"duration": 4, "R1": 1}},
+        5: {1: {"duration": 0}},  # dummy end
+    }
+
+    successors = {
+        1: [2, 3],
+        2: [5],
+        3: [4],
+        4: [5],
+        5: [],
+    }
+
+    resources = {"R1": 2}
+
+    horizon = 100
+
+    special_constraints = SpecialConstraintsDescription(
+        start_together=[(2, 3)],  # tasks 2 and 3 start together
+        start_times={4: 10},  # task 4 should start at 10
+        start_at_end=[(3, 4)],  # task 4 starts when task 3 ends
+        end_times={5: 20},  # task 5 ends at 20
+    )
+    problem = RcpspProblem(
+        resources=resources,
+        non_renewable_resources=[],
+        mode_details=mode_details,
+        successors=successors,
+        horizon=horizon,
+        special_constraints=special_constraints,
+    )
+    solver = CpSatAutoRcpspSolver(problem=problem)
+    result = solver.solve(time_limit=10, parameters_cp=ParametersCp.default())
+    solution: RcpspSolution = result.get_best_solution()
+
+    assert solution is not None, "Solver should find a solution"
+    assert problem.satisfy(solution)
+    assert solution.get_start_time(4) == 10
+    assert solution.get_end_time(5) == 20
+    assert solution.get_end_time(3) == solution.get_start_time(4)
+    assert solution.get_start_time(2) == solution.get_start_time(3)
+
+    # transform to generic problem
+    time_windows = {}
+    windowed_tasks = set()
+    windowed_tasks.update(special_constraints.start_times)
+    windowed_tasks.update(special_constraints.end_times)
+    for task in windowed_tasks:
+        start_lb = start_ub = special_constraints.start_times.get(task, None)
+        end_lb = end_ub = special_constraints.end_times.get(task, None)
+        time_windows[task] = (start_lb, end_lb, start_ub, end_ub)
+
+    start_to_start_min_time_lags = problem.get_start_to_start_min_time_lags() + [
+        (t2, t1, -offset)
+        for t1, t2, offset in problem.get_start_to_start_max_time_lags()
+    ]
+    start_to_end_min_time_lags = problem.get_start_to_end_min_time_lags() + [
+        (t2, t1, -offset) for t1, t2, offset in problem.get_end_to_start_max_time_lags()
+    ]
+    end_to_start_min_time_lags = problem.get_end_to_start_min_time_lags() + [
+        (t2, t1, -offset) for t1, t2, offset in problem.get_start_to_end_max_time_lags()
+    ]
+    end_to_end_min_time_lags = problem.get_end_to_end_min_time_lags() + [
+        (t2, t1, -offset) for t1, t2, offset in problem.get_end_to_end_max_time_lags()
+    ]
+    generic_problem = GenericSchedulingImplProblem(
+        horizon=horizon,
+        mode_details=mode_details,
+        successors=successors,
+        non_skill_cumulative_resources=resources,
+        time_windows=time_windows,
+        start_to_start_min_time_lags=start_to_start_min_time_lags,
+        end_to_start_min_time_lags=end_to_start_min_time_lags,
+        start_to_end_min_time_lags=start_to_end_min_time_lags,
+        end_to_end_min_time_lags=end_to_end_min_time_lags,
+    )
+    generic_solver = GenericSchedulingAutoCpSatImplSolver(
+        problem=generic_problem,
+    )
+    generic_solver.init_model()
+    result = generic_solver.solve(time_limit=10, parameters_cp=ParametersCp.default())
+    generic_solution: GenericSchedulingImplSolution = result.get_best_solution()
+    assert generic_solution is not None
+    assert generic_problem.satisfy(generic_solution)
+
+    # compare solutions
+    from_generic_solution: RcpspSolution = solver.convert_task_variables_to_solution(
+        generic_solution.raw_sol
+    )
+    assert from_generic_solution == solution
+
+
+def test_rcpsp_mm():
+    filename = "j1010_1.mm"
+    files_available = rcpsp_parser.get_data_available()
+    file = [f for f in files_available if filename in f][0]
+    problem = rcpsp_parser.parse_file(file)
+    for resource in problem.resources:
+        problem.resources[resource] = np.array(
+            problem.get_resource_availability_array(resource)
+        )
+        problem.resources[resource][10:15] = 0
+    problem.update_problem()
+    solver = CpSatAutoRcpspSolver(problem=problem)
+    solution, _ = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+        parameters_cp=ParametersCp.default(),
+    )[-1]
+    assert solution is not None, "Solver should find a solution"
+    assert problem.satisfy(solution)
+
+    # transform to generic problem
+    non_renewable_resources = {
+        resource: problem.get_non_renewable_resource_capacity(resource)
+        for resource in problem.non_renewable_resources_list
+    }
+    non_skill_cumulative_resources = {
+        resource: problem.get_resource_availabilities(resource)
+        for resource in problem.non_skill_cumulative_resources_list
+    }
+    generic_problem = GenericSchedulingImplProblem(
+        horizon=problem.horizon,
+        mode_details=problem.mode_details,
+        successors=problem.successors,
+        non_skill_cumulative_resources=non_skill_cumulative_resources,
+        non_renewable_resources=non_renewable_resources,
+    )
+
+    generic_solver = GenericSchedulingAutoCpSatImplSolver(
+        problem=generic_problem,
+    )
+    generic_solver.init_model()
+    generic_solution, _ = generic_solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+        parameters_cp=ParametersCp.default(),
+    )[-1]
+    assert generic_solution is not None
+    assert generic_problem.satisfy(generic_solution)
+
+    # compare solutions
+    from_generic_solution: RcpspSolution = solver.convert_task_variables_to_solution(
+        generic_solution.raw_sol
+    )
+    assert problem.satisfy(from_generic_solution)
+    print("specific", problem.evaluate(solution))
+    print("generic", problem.evaluate(from_generic_solution))
+
+    # generic solution same as or better than specific one
+    assert solver.aggreg_from_sol(from_generic_solution) >= solver.aggreg_from_sol(
+        solution
+    )
+
+
+@pytest.mark.parametrize(
+    "one_worker_per_task, one_skill_per_task, exact_skill, slack_skill, use_energy_constraints, redundant_skill_cumulative",
+    [
+        (False, False, False, False, False, False),
+        (False, False, False, False, False, True),
+        (True, False, False, False, False, False),
+        (True, False, False, False, True, False),
+        (False, True, False, False, False, False),
+        (False, True, True, False, False, False),
+        (False, True, True, True, False, False),
+        (False, False, True, True, False, False),
+        (True, False, True, True, False, False),
+    ],
+)
+def test_rcpsp_multiskill(
+    one_worker_per_task,
+    one_skill_per_task,
+    exact_skill,
+    slack_skill,
+    use_energy_constraints,
+    redundant_skill_cumulative,
+):
+    file = [f for f in parser_imopse.get_data_available() if "100_5_64_9.def" in f][0]
+    problem, _ = parser_imopse.parse_file(file, max_horizon=1000)
+    problem.only_one_skill_per_task = one_skill_per_task
+    task = problem.tasks_list[0]
+    calendar = [2] * problem.horizon
+    for t in range(120, 180):
+        calendar[t] = 1
+    problem.non_renewable_resources = {"R0"}
+    problem.resources_availability = {"R0": [1], "R1": calendar}
+    problem.resources_set = set(problem.resources_availability)
+    problem.partial_preemption_data = None
+    problem.always_releasable_resources = None
+    problem.never_releasable_resources = None
+    problem.mode_details[task][1]["R1"] = 2
+    problem.mode_details[task][2] = dict(problem.mode_details[task][1])
+    problem.mode_details[task][2]["R0"] = 1
+    problem.mode_details[task][1]["R0"] = 2
+    problem.update_problem()
+    solver = CpSatAutoMultiskillRcpspSolver(
+        problem=problem,
+    )
+    solver.init_model(
+        one_worker_per_task=one_worker_per_task,
+        exact_skill=exact_skill,
+        slack_skill=slack_skill,
+        use_energy_constraints=use_energy_constraints,
+        redundant_skill_cumulative=redundant_skill_cumulative,
+    )
+    solution: MultiskillRcpspSolution
+    solution, _ = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+        parameters_cp=ParametersCp.default(),
+    )[-1]
+    assert solution is not None, "Solver should find a solution"
+    assert problem.satisfy(solution)
+    assert solution.check_skill_constraints(
+        exact=exact_skill, slack=5 if slack_skill else 0
+    )
+    if one_skill_per_task:
+        assert all(
+            all(len(skills_used) == 1 for skills_used in allocated.values())
+            for allocated in solution.employee_usage.values()
+        )
+
+    # transform to generic problem
+    non_renewable_resources = {
+        resource: problem.get_non_renewable_resource_capacity(resource)
+        for resource in problem.non_renewable_resources_list
+    }
+    non_skill_cumulative_resources = {
+        resource: problem.get_resource_availabilities(resource)
+        for resource in problem.non_skill_cumulative_resources_list
+    }
+    skills = set(problem.skills_list)
+    unary_resources = set(problem.unary_resources_list)
+    unary_resources_skills = {
+        unary_resource: {
+            skill: detail.skill_value
+            for skill, detail in problem.employees[unary_resource].dict_skill.items()
+        }
+        for unary_resource in unary_resources
+    }
+    unary_resources_availabilities = {
+        unary_resource: [
+            (start, end)
+            for start, end, _ in problem.get_resource_availabilities(
+                resource=unary_resource
+            )
+        ]
+        for unary_resource in unary_resources
+    }
+    generic_problem = GenericSchedulingImplProblem(
+        horizon=problem.horizon,
+        mode_details=problem.mode_details,
+        successors=problem.successors,
+        non_skill_cumulative_resources=non_skill_cumulative_resources,
+        non_renewable_resources=non_renewable_resources,
+        skills=skills,
+        unary_resources=unary_resources,
+        unary_resources_skills=unary_resources_skills,
+        unary_resources_availabilities=unary_resources_availabilities,
+    )
+
+    generic_solver = GenericSchedulingAutoCpSatImplSolver(
+        problem=generic_problem,
+    )
+    generic_solver.init_model(
+        use_only_skill_to_allocate=True,  # same behaviour as multiskill solver
+        at_most_one_unary_resource_per_task=one_worker_per_task,
+        use_exact_skill=exact_skill,
+        use_slack_for_skill=slack_skill,
+        max_slack_for_skill=5,
+        use_energy_constraints=use_energy_constraints,
+        add_redundant_skill_cumulative_constraints=redundant_skill_cumulative,
+    )
+    generic_solution: GenericSchedulingImplSolution
+    generic_solution, _ = generic_solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+        parameters_cp=ParametersCp.default(),
+    )[-1]
+    assert generic_solution is not None
+    assert generic_problem.satisfy(generic_solution)
+    assert generic_solution.check_skill_constraints(
+        exact=exact_skill, slack=5 if slack_skill else 0
+    )
+    if one_skill_per_task:
+        assert all(
+            all(
+                len(skills_used) == 1
+                for skills_used in task_variable.allocated.values()
+            )
+            for task_variable in generic_solution.raw_sol.task_variables.values()
+        )
+
+    # compare solutions
+    from_generic_solution: MultiskillRcpspSolution = (
+        solver.convert_task_variables_to_solution(generic_solution.raw_sol)
+    )
+    assert problem.satisfy(from_generic_solution)
+    assert from_generic_solution.check_skill_constraints(
+        exact=exact_skill, slack=5 if slack_skill else 0
+    )
+    if one_skill_per_task:
+        assert all(
+            all(len(skills_used) == 1 for skills_used in allocated.values())
+            for allocated in from_generic_solution.employee_usage.values()
+        )
+    print("specific", problem.evaluate(solution))
+    print("generic", problem.evaluate(from_generic_solution))
+
+    # generic solution same as or better than specific one
+    assert solver.aggreg_from_sol(from_generic_solution) >= solver.aggreg_from_sol(
+        solution
+    )
+
+
+def test_jsp():
+    filename = "la02"
+    filepath = [f for f in jsp_parser.get_data_available() if f.endswith(filename)][0]
+    problem = jsp_parser.parse_file(filepath)
+    solver = CpSatAutoJspSolver(problem=problem)
+    solution: JobShopSolution = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+        parameters_cp=ParametersCp.default(),
+    ).get_best_solution()
+    print(solution.schedule)
+    assert problem.satisfy(solution)
+
+    # transform to generic problem
+    non_skill_cumulative_resources = {
+        resource: problem.get_resource_availabilities(resource)
+        for resource in problem.non_skill_cumulative_resources_list
+    }
+    mode_details = {
+        task: {
+            mode: {
+                DURATION: problem.get_task_mode_duration(task=task, mode=mode),
+                **{
+                    resource: problem.get_cumulative_resource_consumption(
+                        resource=resource, task=task, mode=mode
+                    )
+                    for resource in problem.cumulative_resources_list
+                },
+            }
+            for mode in problem.get_task_modes(task)
+        }
+        for task in problem.tasks_list
+    }
+    successors = problem.get_precedence_constraints()
+    generic_problem = GenericSchedulingImplProblem(
+        horizon=problem.horizon,
+        mode_details=mode_details,
+        successors=successors,
+        non_skill_cumulative_resources=non_skill_cumulative_resources,
+    )
+
+    generic_solver = GenericSchedulingAutoCpSatImplSolver(
+        problem=generic_problem,
+    )
+    generic_solver.init_model()
+    generic_solution: GenericSchedulingImplSolution
+    generic_solution, _ = generic_solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+        parameters_cp=ParametersCp.default(),
+    )[-1]
+    assert generic_solution is not None
+    assert generic_problem.satisfy(generic_solution)
+
+    # compare solutions
+    from_generic_solution: JobShopSolution = solver.convert_task_variables_to_solution(
+        generic_solution.raw_sol
+    )
+    assert problem.satisfy(from_generic_solution)
+    print("specific", problem.evaluate(solution))
+    print("generic", problem.evaluate(from_generic_solution))
+
+    # generic solution same as or better than specific one
+    assert solver.aggreg_from_sol(from_generic_solution) >= solver.aggreg_from_sol(
+        solution
+    )
+
+
+def test_fjsp():
+    files = fjsp_parser.get_data_available()
+    file = [f for f in files if "Behnke1.fjs" in f][0]
+    problem = fjsp_parser.parse_file(file)
+    solver = CpSatAutoFjspSolver(problem=problem)
+    solution: FJobShopSolution = solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+        parameters_cp=ParametersCp.default(),
+    ).get_best_solution()
+    print(solution.schedule)
+    assert problem.satisfy(solution)
+
+    # transform to generic problem
+    non_skill_cumulative_resources = {
+        resource: problem.get_resource_availabilities(resource)
+        for resource in problem.non_skill_cumulative_resources_list
+    }
+    mode_details = {
+        task: {
+            mode: {
+                DURATION: problem.get_task_mode_duration(task=task, mode=mode),
+                **{
+                    resource: problem.get_cumulative_resource_consumption(
+                        resource=resource, task=task, mode=mode
+                    )
+                    for resource in problem.cumulative_resources_list
+                },
+            }
+            for mode in problem.get_task_modes(task)
+        }
+        for task in problem.tasks_list
+    }
+    successors = problem.get_precedence_constraints()
+    generic_problem = GenericSchedulingImplProblem(
+        horizon=problem.horizon,
+        mode_details=mode_details,
+        successors=successors,
+        non_skill_cumulative_resources=non_skill_cumulative_resources,
+    )
+
+    generic_solver = GenericSchedulingAutoCpSatImplSolver(
+        problem=generic_problem,
+    )
+    generic_solver.init_model()
+    generic_solution: GenericSchedulingImplSolution
+    generic_solution, _ = generic_solver.solve(
+        callbacks=[NbIterationStopper(nb_iteration_max=1)],
+        parameters_cp=ParametersCp.default(),
+    )[-1]
+    assert generic_solution is not None
+    assert generic_problem.satisfy(generic_solution)
+
+    # compare solutions
+    from_generic_solution: FJobShopSolution = solver.convert_task_variables_to_solution(
+        generic_solution.raw_sol
+    )
+    assert problem.satisfy(from_generic_solution)
+    print("specific", problem.evaluate(solution))
+    print("generic", problem.evaluate(from_generic_solution))
+
+    # generic solution same as or better than specific one
+    assert solver.aggreg_from_sol(from_generic_solution) >= solver.aggreg_from_sol(
+        solution
+    )

--- a/tests/generic_tasks_tools/solvers/cpsat/test_auto_impl.py
+++ b/tests/generic_tasks_tools/solvers/cpsat/test_auto_impl.py
@@ -14,7 +14,6 @@ import discrete_optimization.rcpsp_multiskill.parser_imopse as parser_imopse
 from discrete_optimization.fjsp.problem import FJobShopSolution
 from discrete_optimization.fjsp.solvers.cpsat_auto import CpSatAutoFjspSolver
 from discrete_optimization.generic_tasks_tools.generic_scheduling_impl import (
-    DURATION,
     GenericSchedulingImplProblem,
     GenericSchedulingImplSolution,
 )
@@ -69,13 +68,28 @@ def test_auto(
 
     problem = GenericSchedulingImplProblem(
         horizon=10,
-        mode_details={
+        durations_per_mode={
             "task-1": {
-                0: {"non_renewable_resource": 2, "duration": 1},
-                1: {"non_renewable_resource": 1, "duration": 3},
+                0: 1,
+                1: 3,
             },
             "task-2": {
-                0: {"cumulative_resource": 2, "duration": 4},
+                0: 4,
+            },
+        },
+        resource_consumptions={
+            "task-1": {
+                0: {
+                    "non_renewable_resource": 2,
+                },
+                1: {
+                    "non_renewable_resource": 1,
+                },
+            },
+            "task-2": {
+                0: {
+                    "cumulative_resource": 2,
+                },
             },
         },
         successors={"task-1": ["task-2"]},
@@ -242,9 +256,37 @@ def test_rcpsp_simple():
     end_to_end_min_time_lags = problem.get_end_to_end_min_time_lags() + [
         (t2, t1, -offset) for t1, t2, offset in problem.get_end_to_end_max_time_lags()
     ]
+    durations_per_mode = {
+        task: {
+            mode: problem.get_task_mode_duration(task=task, mode=mode)
+            for mode in problem.get_task_modes(task)
+        }
+        for task in problem.tasks_list
+    }
+    resource_consumptions = {
+        task: {
+            mode: {
+                **{
+                    resource: problem.get_cumulative_resource_consumption(
+                        resource=resource, task=task, mode=mode
+                    )
+                    for resource in problem.cumulative_resources_list
+                },
+                **{
+                    resource: problem.get_non_renewable_resource_consumption(
+                        resource=resource, task=task, mode=mode
+                    )
+                    for resource in problem.non_renewable_resources_list
+                },
+            }
+            for mode in problem.get_task_modes(task)
+        }
+        for task in problem.tasks_list
+    }
     generic_problem = GenericSchedulingImplProblem(
         horizon=horizon,
-        mode_details=mode_details,
+        durations_per_mode=durations_per_mode,
+        resource_consumptions=resource_consumptions,
         successors=successors,
         non_skill_cumulative_resources=resources,
         time_windows=time_windows,
@@ -297,9 +339,37 @@ def test_rcpsp_mm():
         resource: problem.get_resource_availabilities(resource)
         for resource in problem.non_skill_cumulative_resources_list
     }
+    durations_per_mode = {
+        task: {
+            mode: problem.get_task_mode_duration(task=task, mode=mode)
+            for mode in problem.get_task_modes(task)
+        }
+        for task in problem.tasks_list
+    }
+    resource_consumptions = {
+        task: {
+            mode: {
+                **{
+                    resource: problem.get_cumulative_resource_consumption(
+                        resource=resource, task=task, mode=mode
+                    )
+                    for resource in problem.cumulative_resources_list
+                },
+                **{
+                    resource: problem.get_non_renewable_resource_consumption(
+                        resource=resource, task=task, mode=mode
+                    )
+                    for resource in problem.non_renewable_resources_list
+                },
+            }
+            for mode in problem.get_task_modes(task)
+        }
+        for task in problem.tasks_list
+    }
     generic_problem = GenericSchedulingImplProblem(
         horizon=problem.horizon,
-        mode_details=problem.mode_details,
+        durations_per_mode=durations_per_mode,
+        resource_consumptions=resource_consumptions,
         successors=problem.successors,
         non_skill_cumulative_resources=non_skill_cumulative_resources,
         non_renewable_resources=non_renewable_resources,
@@ -423,9 +493,37 @@ def test_rcpsp_multiskill(
         ]
         for unary_resource in unary_resources
     }
+    durations_per_mode = {
+        task: {
+            mode: problem.get_task_mode_duration(task=task, mode=mode)
+            for mode in problem.get_task_modes(task)
+        }
+        for task in problem.tasks_list
+    }
+    resource_consumptions = {
+        task: {
+            mode: {
+                **{
+                    resource: problem.get_cumulative_resource_consumption(
+                        resource=resource, task=task, mode=mode
+                    )
+                    for resource in problem.cumulative_resources_list
+                },
+                **{
+                    resource: problem.get_non_renewable_resource_consumption(
+                        resource=resource, task=task, mode=mode
+                    )
+                    for resource in problem.non_renewable_resources_list
+                },
+            }
+            for mode in problem.get_task_modes(task)
+        }
+        for task in problem.tasks_list
+    }
     generic_problem = GenericSchedulingImplProblem(
         horizon=problem.horizon,
-        mode_details=problem.mode_details,
+        durations_per_mode=durations_per_mode,
+        resource_consumptions=resource_consumptions,
         successors=problem.successors,
         non_skill_cumulative_resources=non_skill_cumulative_resources,
         non_renewable_resources=non_renewable_resources,
@@ -505,16 +603,20 @@ def test_jsp():
         resource: problem.get_resource_availabilities(resource)
         for resource in problem.non_skill_cumulative_resources_list
     }
-    mode_details = {
+    durations_per_mode = {
+        task: {
+            mode: problem.get_task_mode_duration(task=task, mode=mode)
+            for mode in problem.get_task_modes(task)
+        }
+        for task in problem.tasks_list
+    }
+    resource_consumptions = {
         task: {
             mode: {
-                DURATION: problem.get_task_mode_duration(task=task, mode=mode),
-                **{
-                    resource: problem.get_cumulative_resource_consumption(
-                        resource=resource, task=task, mode=mode
-                    )
-                    for resource in problem.cumulative_resources_list
-                },
+                resource: problem.get_cumulative_resource_consumption(
+                    resource=resource, task=task, mode=mode
+                )
+                for resource in problem.cumulative_resources_list
             }
             for mode in problem.get_task_modes(task)
         }
@@ -523,7 +625,8 @@ def test_jsp():
     successors = problem.get_precedence_constraints()
     generic_problem = GenericSchedulingImplProblem(
         horizon=problem.horizon,
-        mode_details=mode_details,
+        durations_per_mode=durations_per_mode,
+        resource_consumptions=resource_consumptions,
         successors=successors,
         non_skill_cumulative_resources=non_skill_cumulative_resources,
     )
@@ -571,16 +674,20 @@ def test_fjsp():
         resource: problem.get_resource_availabilities(resource)
         for resource in problem.non_skill_cumulative_resources_list
     }
-    mode_details = {
+    durations_per_mode = {
+        task: {
+            mode: problem.get_task_mode_duration(task=task, mode=mode)
+            for mode in problem.get_task_modes(task)
+        }
+        for task in problem.tasks_list
+    }
+    resource_consumptions = {
         task: {
             mode: {
-                DURATION: problem.get_task_mode_duration(task=task, mode=mode),
-                **{
-                    resource: problem.get_cumulative_resource_consumption(
-                        resource=resource, task=task, mode=mode
-                    )
-                    for resource in problem.cumulative_resources_list
-                },
+                resource: problem.get_cumulative_resource_consumption(
+                    resource=resource, task=task, mode=mode
+                )
+                for resource in problem.cumulative_resources_list
             }
             for mode in problem.get_task_modes(task)
         }
@@ -589,7 +696,8 @@ def test_fjsp():
     successors = problem.get_precedence_constraints()
     generic_problem = GenericSchedulingImplProblem(
         horizon=problem.horizon,
-        mode_details=mode_details,
+        durations_per_mode=durations_per_mode,
+        resource_consumptions=resource_consumptions,
         successors=successors,
         non_skill_cumulative_resources=non_skill_cumulative_resources,
     )

--- a/tests/generic_tasks_tools/test_generic_scheduling_impl.py
+++ b/tests/generic_tasks_tools/test_generic_scheduling_impl.py
@@ -1,0 +1,213 @@
+#  Copyright (c) 2026 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+
+#  Copyright (c) 2026 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+import logging
+
+from pytest import fixture
+
+from discrete_optimization.generic_tasks_tools.generic_scheduling_impl import (
+    GenericSchedulingImplProblem,
+    GenericSchedulingImplSolution,
+)
+from discrete_optimization.generic_tasks_tools.generic_scheduling_utils import (
+    Objective,
+    RawSolution,
+    TaskVariable,
+)
+
+
+@fixture
+def problem_wo_skills():
+    def custom_evaluate_fn(variable: GenericSchedulingImplSolution):
+        return variable.compute_nb_tasks_done() - variable.get_max_end_time()
+
+    return GenericSchedulingImplProblem(
+        horizon=10,
+        mode_details={
+            "task-1": {
+                0: {"non_renewable_resource": 2, "duration": 1},
+                1: {"non_renewable_resource": 1, "duration": 3},
+            },
+            "task-2": {
+                0: {"cumulative_resource": 2, "duration": 4},
+            },
+        },
+        successors={"task-1": ["task-2"]},
+        unary_resources={"worker1", "worker2"},
+        unary_resources_availabilities={
+            "worker1": [(1, 4)],
+            "worker2": [(3, 18)],
+        },
+        non_skill_cumulative_resources={
+            "cumulative_resource": [
+                (3, 5, 1),
+                (5, 10, 2),
+            ],
+        },
+        non_renewable_resources={
+            "non_renewable_resource": 1,
+        },
+        objective=[(Objective.MAKESPAN, -1)]
+        + [(obj, 0) for obj in Objective if obj not in [Objective.MAKESPAN]],
+        custom_evaluate_fn=custom_evaluate_fn,
+    )
+
+
+def test_problem(problem_wo_skills, caplog):
+    problem = problem_wo_skills
+    sol = GenericSchedulingImplSolution(
+        problem=problem,
+        raw_sol=RawSolution(
+            task_variables={
+                "task-1": TaskVariable(
+                    start=1, end=4, mode=1, allocated={"worker1": set()}
+                ),
+                "task-2": TaskVariable(
+                    start=5, end=9, mode=0, allocated={"worker2": set()}
+                ),
+            }
+        ),
+    )
+    problem.satisfy(sol)
+    d = problem.evaluate(sol)
+    print(d)
+    assert d["makespan"] == 9
+    assert d["nb_tasks_done"] == 2
+    assert d["nb_unary_resources_used"] == 2
+    assert d["nb_resources_used"] == 4
+    assert d["resources_consumption"] == 5
+    assert d["custom_objective"] == -7
+
+    sol = GenericSchedulingImplSolution(
+        problem=problem,
+        raw_sol=RawSolution(
+            task_variables={
+                "task-1": TaskVariable(
+                    start=3, end=6, mode=1, allocated={"worker2": set()}
+                ),
+                "task-2": TaskVariable(
+                    start=6, end=10, mode=0, allocated={"worker2": set()}
+                ),
+            }
+        ),
+    )
+    problem.satisfy(sol)
+    d = problem.evaluate(sol)
+    assert d["makespan"] == 10
+    assert d["nb_tasks_done"] == 2
+    assert d["nb_unary_resources_used"] == 1
+
+    sol = GenericSchedulingImplSolution(
+        problem=problem,
+        raw_sol=RawSolution(
+            task_variables={
+                "task-1": TaskVariable(
+                    start=3,
+                    end=6,
+                    mode=1,
+                ),
+                "task-2": TaskVariable(
+                    start=6,
+                    end=10,
+                    mode=0,
+                ),
+            }
+        ),
+    )
+    problem.satisfy(sol)
+    d = problem.evaluate(sol)
+    assert d["makespan"] == 10
+    assert d["nb_tasks_done"] == 0
+    assert d["nb_unary_resources_used"] == 0
+
+    # nok: worker not available
+    sol = GenericSchedulingImplSolution(
+        problem=problem,
+        raw_sol=RawSolution(
+            task_variables={
+                "task-1": TaskVariable(
+                    start=3, end=6, mode=1, allocated={"worker1": set()}
+                ),
+                "task-2": TaskVariable(
+                    start=6, end=10, mode=0, allocated={"worker1": set()}
+                ),
+            }
+        ),
+    )
+    with caplog.at_level(level=logging.DEBUG):
+        assert not problem.satisfy(sol)
+    assert "worker1" in caplog.text
+
+    # nok: cumulative resource not available
+    sol = GenericSchedulingImplSolution(
+        problem=problem,
+        raw_sol=RawSolution(
+            task_variables={
+                "task-1": TaskVariable(
+                    start=1, end=4, mode=1, allocated={"worker1": set()}
+                ),
+                "task-2": TaskVariable(
+                    start=4, end=8, mode=0, allocated={"worker2": set()}
+                ),
+            }
+        ),
+    )
+    with caplog.at_level(level=logging.DEBUG):
+        assert not problem.satisfy(sol)
+    assert "cumulative_resource" in caplog.text
+
+    # nok: duration not correct
+    sol = GenericSchedulingImplSolution(
+        problem=problem,
+        raw_sol=RawSolution(
+            task_variables={
+                "task-1": TaskVariable(
+                    start=1, end=2, mode=1, allocated={"worker1": set()}
+                ),
+                "task-2": TaskVariable(
+                    start=5, end=9, mode=0, allocated={"worker2": set()}
+                ),
+            }
+        ),
+    )
+    with caplog.at_level(level=logging.DEBUG):
+        assert not problem.satisfy(sol)
+    assert "Duration" in caplog.text
+
+    # lower cumulative_resource requirement => better sol
+    problem.mode_details["task-2"][0]["cumulative_resource"] = 1
+    problem.update_problem()
+    sol = GenericSchedulingImplSolution(
+        problem=problem,
+        raw_sol=RawSolution(
+            task_variables={
+                "task-1": TaskVariable(
+                    start=1, end=4, mode=1, allocated={"worker1": set()}
+                ),
+                "task-2": TaskVariable(
+                    start=4, end=8, mode=0, allocated={"worker2": set()}
+                ),
+            }
+        ),
+    )
+    assert problem.satisfy(sol)
+
+
+def test_task_bounds_simple(problem_wo_skills):
+    assert problem_wo_skills.compute_tighter_task_bounds(horizon=8) == {
+        "task-1": (0, 1, 7, 8),
+        "task-2": (0, 4, 4, 8),
+    }
+
+
+def test_task_bounds_cpm(problem_wo_skills):
+    assert problem_wo_skills.compute_tighter_task_bounds(horizon=8, use_cpm=True) == {
+        "task-1": (0, 1, 3, 4),
+        "task-2": (1, 5, 4, 8),
+    }

--- a/tests/generic_tasks_tools/test_generic_scheduling_impl.py
+++ b/tests/generic_tasks_tools/test_generic_scheduling_impl.py
@@ -29,13 +29,28 @@ def problem_wo_skills():
 
     return GenericSchedulingImplProblem(
         horizon=10,
-        mode_details={
+        durations_per_mode={
             "task-1": {
-                0: {"non_renewable_resource": 2, "duration": 1},
-                1: {"non_renewable_resource": 1, "duration": 3},
+                0: 1,
+                1: 3,
             },
             "task-2": {
-                0: {"cumulative_resource": 2, "duration": 4},
+                0: 4,
+            },
+        },
+        resource_consumptions={
+            "task-1": {
+                0: {
+                    "non_renewable_resource": 2,
+                },
+                1: {
+                    "non_renewable_resource": 1,
+                },
+            },
+            "task-2": {
+                0: {
+                    "cumulative_resource": 2,
+                },
             },
         },
         successors={"task-1": ["task-2"]},
@@ -181,7 +196,7 @@ def test_problem(problem_wo_skills, caplog):
     assert "Duration" in caplog.text
 
     # lower cumulative_resource requirement => better sol
-    problem.mode_details["task-2"][0]["cumulative_resource"] = 1
+    problem.resource_consumptions["task-2"][0]["cumulative_resource"] = 1
     problem.update_problem()
     sol = GenericSchedulingImplSolution(
         problem=problem,

--- a/tests/rcpsp_multiskill/solvers/test_cpsat_auto.py
+++ b/tests/rcpsp_multiskill/solvers/test_cpsat_auto.py
@@ -99,6 +99,7 @@ def test_imopse_cpsat_w_non_renewable_n_cumulative_resource(
     # add resources that should change schedule and mode choice
     task = model.tasks_list[0]
     t = solution.get_start_time(task)
+    print(t)
     assert solution.get_mode(task) == 1
     calendar = [2] * model.horizon
     calendar[t] = 1
@@ -120,7 +121,11 @@ def test_imopse_cpsat_w_non_renewable_n_cumulative_resource(
         problem=model,
     )
     solver.init_model(
-        one_worker_per_task=True,
+        one_worker_per_task=one_worker_per_task,
+        exact_skill=exact_skill,
+        slack_skill=slack_skill,
+        use_energy_constraints=use_energy_constraints,
+        redundant_skill_cumulative=redundant_skill_cumulative,
     )
     p = ParametersCp.default_cpsat()
     res = solver.solve(


### PR DESCRIPTION
The new class `GenericSchedulingImplProblem`/`Solution` is an implementation of abstract class `GenericSchedulingProblem`/`Solution`.
Similarly, `GenericSchedulingAutoCpSatImplSolver` is an implementation of abstract class `GenericSchedulingAutoCpSatSolver`.

We also improve bounds on makespan on the way:
- precedence + scheduling => we can restrict list of last tasks in default implementation. (NB: in generic scheduling, precedence graph takes into account time lags so last tasks will also.)
- we can compute upper bound on last tasks ends from initial horizon + time windows upper bounds + max task duration (no need of CPM) to tighten horizon
- the tasks bounds are then computed (potentially with CPM propagation) with this new horizon => tighter makespan lower bound