### PR TITLE
Improve generic scheduling problem/solver implementation

### DIFF
--- a/src/discrete_optimization/generic_tasks_tools/allocation.py
+++ b/src/discrete_optimization/generic_tasks_tools/allocation.py
@@ -36,6 +36,13 @@ class AllocationSolution(TasksSolution[Task], Generic[Task, UnaryResource]):
         """
         ...
 
+    def get_task_allocation(self, task: Task) -> set[UnaryResource]:
+        return {
+            unary_resource
+            for unary_resource in self.problem.unary_resources_list
+            if self.is_allocated(task=task, unary_resource=unary_resource)
+        }
+
     def get_default_tasks_n_unary_resources(
         self,
         tasks: Optional[Iterable[Task]] = None,

--- a/src/discrete_optimization/generic_tasks_tools/calendar_resource.py
+++ b/src/discrete_optimization/generic_tasks_tools/calendar_resource.py
@@ -163,7 +163,7 @@ class CalendarResourceProblem(SchedulingProblem[Task], Generic[Task, Resource]):
         """
         return {
             key: value
-            for key, value in self.__dict__.items()
+            for key, value in super().__getstate__().items()
             if not key.startswith("_lru_cache_")
         }
 

--- a/src/discrete_optimization/generic_tasks_tools/calendar_resource.py
+++ b/src/discrete_optimization/generic_tasks_tools/calendar_resource.py
@@ -269,8 +269,8 @@ class CalendarResourceSolution(SchedulingSolution[Task], Generic[Task, Resource]
             resources=self.problem.calendar_resources_list
         )
 
-    def compute_calendar_resources_consumptions(self) -> dict[Resource, int]:
-        """Compute total consumption of each calendar resource by the solution."""
+    def compute_calendar_resources_levels(self) -> dict[Resource, int]:
+        """Compute the level (i.e. min capacity needed) for each calendar resource."""
         return {
             resource: int(timed_conso.max())
             for resource, timed_conso in self._compute_calendar_resource_consumption_np(
@@ -278,10 +278,10 @@ class CalendarResourceSolution(SchedulingSolution[Task], Generic[Task, Resource]
             ).items()
         }
 
-    def compute_aggregated_calendar_resources_consumptions(
+    def compute_aggregated_calendar_resources_levels(
         self, weights: Optional[dict[Resource, int]] = None
     ) -> int:
-        """Compute aggregated consumption of each calendar resource by the solution.
+        """Compute aggregated level (i.e. min capacity needed) of each calendar resource.
 
         Args:
             weights: optional weights to apply to each resource in the sum. Default to 1.
@@ -291,7 +291,7 @@ class CalendarResourceSolution(SchedulingSolution[Task], Generic[Task, Resource]
             weights = {}
         return sum(
             conso * weights.get(resource, 1)
-            for resource, conso in self.compute_calendar_resources_consumptions().items()
+            for resource, conso in self.compute_calendar_resources_levels().items()
         )
 
     def compute_nb_calendar_resources_used(
@@ -310,7 +310,7 @@ class CalendarResourceSolution(SchedulingSolution[Task], Generic[Task, Resource]
             weights = {}
         return sum(
             (conso > 0) * weights.get(resource, 1)
-            for resource, conso in self.compute_calendar_resources_consumptions().items()
+            for resource, conso in self.compute_calendar_resources_levels().items()
         )
 
 
@@ -347,7 +347,7 @@ class WithoutCalendarResourceSolution(
     def check_all_calendar_resource_capacity_constraints(self) -> bool:
         return True
 
-    def compute_aggregated_calendar_resources_consumptions(
+    def compute_aggregated_calendar_resources_levels(
         self, weights: Optional[dict[Resource, int]] = None
     ):
         return 0
@@ -357,7 +357,7 @@ class WithoutCalendarResourceSolution(
     ) -> int:
         return 0
 
-    def compute_calendar_resources_consumptions(self) -> dict[Resource, int]:
+    def compute_calendar_resources_levels(self) -> dict[Resource, int]:
         return {}
 
 

--- a/src/discrete_optimization/generic_tasks_tools/calendar_resource.py
+++ b/src/discrete_optimization/generic_tasks_tools/calendar_resource.py
@@ -161,9 +161,14 @@ class CalendarResourceProblem(SchedulingProblem[Task], Generic[Task, Resource]):
         See https://github.com/GrahamDumpleton/wrapt/issues/343
 
         """
+        try:
+            dico = super().__getstate__()
+        except AttributeError:
+            # python < 3.11: __getstate__() not always defined
+            dico = self.__dict__
         return {
             key: value
-            for key, value in super().__getstate__().items()
+            for key, value in dico.items()
             if not key.startswith("_lru_cache_")
         }
 

--- a/src/discrete_optimization/generic_tasks_tools/generic_scheduling.py
+++ b/src/discrete_optimization/generic_tasks_tools/generic_scheduling.py
@@ -608,19 +608,6 @@ class GenericSchedulingProblem(
         """
         return 0
 
-    def __getstate__(self):
-        """Get state for pickle.
-
-        Solve issue when instance has cached methods called. (And thus unpickable cache created.)
-        See https://github.com/GrahamDumpleton/wrapt/issues/343
-
-        """
-        return {
-            key: value
-            for key, value in super().__getstate__().items()
-            if not key.startswith("_lru_cache_")
-        }
-
 
 class GenericSchedulingSolution(
     SkillSolution[

--- a/src/discrete_optimization/generic_tasks_tools/generic_scheduling.py
+++ b/src/discrete_optimization/generic_tasks_tools/generic_scheduling.py
@@ -1,6 +1,8 @@
 #  Copyright (c) 2026 AIRBUS and its affiliates.
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
 from collections import defaultdict
 from typing import Generic, Optional
 
@@ -11,6 +13,10 @@ from discrete_optimization.generic_tasks_tools.allocation import (
 )
 from discrete_optimization.generic_tasks_tools.base import Task
 from discrete_optimization.generic_tasks_tools.enums import MinOrMax, StartOrEnd
+from discrete_optimization.generic_tasks_tools.generic_scheduling_utils import (
+    Objective,
+    Penalty,
+)
 from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
     NonRenewableResource,
     NonRenewableResourceProblem,
@@ -39,6 +45,7 @@ from discrete_optimization.generic_tasks_tools.timewindow import (
 
 CumulativeResource = Skill | NonSkillCumulativeResource
 Resource = CumulativeResource | UnaryResource
+AnyResource = NonRenewableResource | Resource
 
 
 class GenericSchedulingProblem(
@@ -484,6 +491,87 @@ class GenericSchedulingProblem(
 
         """
         self.update_time_lags()
+
+    def compute_subobjective(
+        self,
+        variable: GenericSchedulingSolution,
+        objective: Objective,
+        resource_weights: Optional[dict[AnyResource, int]] = None,
+    ) -> int:
+        """Compute subobjective from given solution."""
+        match objective:
+            case Objective.MAKESPAN:
+                return variable.get_max_end_time()
+            case Objective.NB_TASKS_DONE:
+                return variable.compute_nb_tasks_done()
+            case Objective.NB_UNARY_RESOURCES_USED:
+                return variable.compute_nb_unary_resources_used()
+            case Objective.NB_RESOURCES_USED:
+                return variable.compute_nb_calendar_resources_used(
+                    weights=resource_weights
+                ) + variable.compute_nb_non_renewable_resources_used(
+                    weights=resource_weights
+                )
+            case Objective.RESOURCES_LEVELS:
+                return variable.compute_aggregated_calendar_resources_levels(
+                    weights=resource_weights
+                ) + variable.compute_aggregated_non_renewable_resources_consumptions(
+                    weights=resource_weights
+                )
+            case _:
+                raise NotImplementedError()
+
+    def compute_penalty(
+        self, variable: GenericSchedulingSolution, penalty: Penalty
+    ) -> int:
+        """Compute penalty from given solution."""
+        match penalty:
+            case Penalty.TIME:
+                penalty = 0
+                # time windows
+                for task in self.tasks_list:
+                    start = variable.get_start_time(task)
+                    end = variable.get_end_time(task)
+                    start_lb = self.get_task_start_or_end_lower_bound(
+                        task=task, start_or_end=StartOrEnd.START
+                    )
+                    end_lb = self.get_task_start_or_end_lower_bound(
+                        task=task, start_or_end=StartOrEnd.END
+                    )
+                    start_ub = self.get_task_start_or_end_upper_bound(
+                        task=task, start_or_end=StartOrEnd.START
+                    )
+                    end_ub = self.get_task_start_or_end_upper_bound(
+                        task=task, start_or_end=StartOrEnd.END
+                    )
+                    penalty += max(0, start_lb - start)
+                    penalty += max(0, end_lb - end)
+                    penalty += max(0, start - start_ub)
+                    penalty += max(0, end - end_ub)
+                # time lags
+                for task1_start_or_end in StartOrEnd:
+                    for task2_start_or_end in StartOrEnd:
+                        for min_or_max in MinOrMax:
+                            for task1, task2, offset in self.get_original_time_lags(
+                                task1_start_or_end=task1_start_or_end,
+                                task2_start_or_end=task2_start_or_end,
+                                min_or_max=min_or_max,
+                            ):
+                                t1 = variable.get_start_or_end_time(
+                                    task=task1, start_or_end=task1_start_or_end
+                                )
+                                t2 = variable.get_start_or_end_time(
+                                    task=task2, start_or_end=task2_start_or_end
+                                )
+                                if min_or_max == MinOrMax.MIN:
+                                    penalty += max(0, t1 + offset - t2)
+                                else:
+                                    penalty += max(0, t2 - (t1 + offset))
+
+            case _:
+                raise NotImplementedError()
+
+        return penalty
 
     def __getstate__(self):
         """Get state for pickle.

--- a/src/discrete_optimization/generic_tasks_tools/generic_scheduling.py
+++ b/src/discrete_optimization/generic_tasks_tools/generic_scheduling.py
@@ -69,6 +69,7 @@ class GenericSchedulingProblem(
     - skill: some cumulative resource are skills that are brought to tasks by allocated unary resources
     - non-renewable: the tasks consume non-renewable resources according to the chosen mode
     - precedence: precedence constraints between tasks
+    - cost: the choice of a mode or of an allocation has a given cost
 
     Even though this class is generic but encompasses also more specific cases:
     - singlemode: actually only one mode per task
@@ -78,6 +79,7 @@ class GenericSchedulingProblem(
     - no calendar: resource capacity can be given as a constant on [0, horizon)
     - no non-renewable ressources: if non_renewable_resources_list empty
     - no precedence constraints: precedence constraints empty
+    - no cost: cost = 0
 
     We suppose that all renewable resources are
     - either cumulative ones
@@ -518,6 +520,8 @@ class GenericSchedulingProblem(
                 ) + variable.compute_aggregated_non_renewable_resources_consumptions(
                     weights=resource_weights
                 )
+            case Objective.COST:
+                return variable.compute_cost()
             case _:
                 raise NotImplementedError()
 
@@ -573,6 +577,37 @@ class GenericSchedulingProblem(
 
         return penalty
 
+    def get_mode_cost(self, task: Task, mode: int) -> int:
+        """Get cost of choosing given mode.
+
+        Default to no cost. To be overridden in child classes with actual costs.
+
+        Args:
+            task:
+            mode:
+
+        Returns:
+
+        """
+        return 0
+
+    def get_unary_resource_cost(
+        self, task: Task, mode: int, unary_resource: UnaryResource
+    ) -> int:
+        """Get cost of allocating given unary resource.
+
+        Default to no cost. To be overridden in child classes with actual costs.
+
+        Args:
+            task:
+            mode:
+            unary_resource:
+
+        Returns:
+
+        """
+        return 0
+
     def __getstate__(self):
         """Get state for pickle.
 
@@ -615,3 +650,19 @@ class GenericSchedulingSolution(
             return super().get_calendar_resource_consumption(
                 resource=resource, task=task
             )
+
+    def compute_cost(self) -> int:
+        return sum(
+            (
+                self.problem.get_mode_cost(
+                    task=task, mode=(mode := self.get_mode(task=task))
+                )
+                + sum(
+                    self.problem.get_unary_resource_cost(
+                        task=task, mode=mode, unary_resource=unary_resource
+                    )
+                    for unary_resource in self.get_task_allocation(task=task)
+                )
+            )
+            for task in self.problem.tasks_list
+        )

--- a/src/discrete_optimization/generic_tasks_tools/generic_scheduling_impl.py
+++ b/src/discrete_optimization/generic_tasks_tools/generic_scheduling_impl.py
@@ -85,6 +85,10 @@ class GenericSchedulingImplProblem(
             Callable[[GenericSchedulingImplSolution], int]
         ] = None,
         objective_resource_weights: Optional[dict[AnyResource, int]] = None,
+        mode_costs: Optional[dict[Task, dict[int, int]]] = None,
+        unary_resource_costs: Optional[
+            dict[Task, dict[int, dict[UnaryResource, int]]]
+        ] = None,
         compute_time_penalty: bool = True,
     ):
         """
@@ -135,6 +139,8 @@ class GenericSchedulingImplProblem(
             objective_resource_weights: Weights to be used by the objective when summing used resources
                 (`Objective.NB_RESOURCES_USED`) or resources levels (`Objective.RESOURCES_LEVELS`).
                 Default to 1 for resources not mentioned.
+            mode_costs: cost of choosing each mode. Missing key => cost = 0.
+            unary_resource_costs: cost of allocating each unary resource. Missing key => cost = 0.
             compute_time_penalty: whether to include time penalties in evaluation
 
         """
@@ -212,6 +218,14 @@ class GenericSchedulingImplProblem(
             self.objective_resource_weights: dict[AnyResource, int] = {}
         else:
             self.objective_resource_weights = objective_resource_weights
+        if mode_costs is None:
+            self.mode_costs = {}
+        else:
+            self.mode_costs = mode_costs
+        if unary_resource_costs is None:
+            self.unary_resource_costs = {}
+        else:
+            self.unary_resource_costs = unary_resource_costs
         self.compute_time_penalty = compute_time_penalty
         self.update_problem()
 
@@ -521,6 +535,20 @@ class GenericSchedulingImplProblem(
     def get_dummy_solution(self) -> Solution:
         raise NotImplementedError()
 
+    def get_mode_cost(self, task: Task, mode: int) -> int:
+        try:
+            return self.mode_costs[task][mode]
+        except KeyError:
+            return super().get_mode_cost(task, mode)
+
+    def get_unary_resource_cost(
+        self, task: Task, mode: int, unary_resource: UnaryResource
+    ) -> int:
+        try:
+            return self.unary_resource_costs[task][mode][unary_resource]
+        except KeyError:
+            return super().get_unary_resource_cost(task, mode, unary_resource)
+
 
 class GenericSchedulingImplSolution(
     GenericSchedulingSolution[
@@ -558,6 +586,9 @@ class GenericSchedulingImplSolution(
 
     def is_allocated(self, task: Task, unary_resource: UnaryResource) -> bool:
         return unary_resource in self.raw_sol.task_variables[task].allocated
+
+    def get_task_allocation(self, task: Task) -> set[UnaryResource]:
+        return set(self.raw_sol.task_variables[task].allocated)
 
     def copy(self) -> Solution:
         return GenericSchedulingImplSolution(

--- a/src/discrete_optimization/generic_tasks_tools/generic_scheduling_impl.py
+++ b/src/discrete_optimization/generic_tasks_tools/generic_scheduling_impl.py
@@ -16,7 +16,9 @@ from discrete_optimization.generic_tasks_tools.generic_scheduling import (
 )
 from discrete_optimization.generic_tasks_tools.generic_scheduling_utils import (
     OBJECTIVE_DEFAULT_WEIGHTS,
+    PENALTY_DEFAULT_WEIGHTS,
     Objective,
+    Penalty,
     RawSolution,
 )
 from discrete_optimization.generic_tools.do_problem import (
@@ -83,6 +85,7 @@ class GenericSchedulingImplProblem(
             Callable[[GenericSchedulingImplSolution], int]
         ] = None,
         objective_resource_weights: Optional[dict[AnyResource, int]] = None,
+        compute_time_penalty: bool = True,
     ):
         """
 
@@ -132,6 +135,7 @@ class GenericSchedulingImplProblem(
             objective_resource_weights: Weights to be used by the objective when summing used resources
                 (`Objective.NB_RESOURCES_USED`) or resources levels (`Objective.RESOURCES_LEVELS`).
                 Default to 1 for resources not mentioned.
+            compute_time_penalty: whether to include time penalties in evaluation
 
         """
         self.horizon = horizon
@@ -208,6 +212,7 @@ class GenericSchedulingImplProblem(
             self.objective_resource_weights: dict[AnyResource, int] = {}
         else:
             self.objective_resource_weights = objective_resource_weights
+        self.compute_time_penalty = compute_time_penalty
         self.update_problem()
 
     def update_problem(self):
@@ -454,43 +459,41 @@ class GenericSchedulingImplProblem(
         raise NotImplementedError()
 
     def evaluate(self, variable: Solution) -> dict[str, float]:
-        return {
+        dict_eval = {
             objective.value: self.compute_subobjective(
                 variable=variable, objective=objective
             )
             for objective, _ in self.weighted_objectives
         }
+        if self.compute_time_penalty:
+            penalty = Penalty.TIME
+            dict_eval[penalty.value] = self.compute_penalty(
+                variable=variable, penalty=penalty
+            )
+        return dict_eval
 
     def compute_subobjective(
-        self, variable: GenericSchedulingImplSolution, objective: Objective
+        self,
+        variable: GenericSchedulingSolution,
+        objective: Objective,
+        resource_weights: Optional[dict[AnyResource, int]] = None,
     ) -> int:
+        if resource_weights is None:
+            resource_weights = self.objective_resource_weights
         match objective:
-            case Objective.MAKESPAN:
-                return variable.get_max_end_time()
-            case Objective.NB_TASKS_DONE:
-                return variable.compute_nb_tasks_done()
-            case Objective.NB_UNARY_RESOURCES_USED:
-                return variable.compute_nb_unary_resources_used()
-            case Objective.NB_RESOURCES_USED:
-                return variable.compute_nb_calendar_resources_used(
-                    weights=self.objective_resource_weights
-                ) + variable.compute_nb_non_renewable_resources_used(
-                    weights=self.objective_resource_weights
-                )
-            case Objective.RESOURCES_LEVELS:
-                return variable.compute_aggregated_calendar_resources_levels(
-                    weights=self.objective_resource_weights
-                ) + variable.compute_aggregated_non_renewable_resources_consumptions(
-                    weights=self.objective_resource_weights
-                )
             case Objective.CUSTOM:
                 if self.custom_evaluate_fn is None:
                     raise RuntimeError(
                         "self.custom_evaluate_fn is not defined but custom objective used."
                     )
+                assert isinstance(variable, GenericSchedulingImplSolution)
                 return self.custom_evaluate_fn(variable)
             case _:
-                raise NotImplementedError()
+                return super().compute_subobjective(
+                    variable=variable,
+                    objective=objective,
+                    resource_weights=resource_weights,
+                )
 
     def get_objective_register(self) -> ObjectiveRegister:
         if len(self.weighted_objectives) == 1:
@@ -503,6 +506,12 @@ class GenericSchedulingImplProblem(
             )
             for objective, weight in self.weighted_objectives
         }
+        if self.compute_time_penalty:
+            penalty = Penalty.TIME
+            dict_objective[penalty.value] = ObjectiveDoc(
+                type=TypeObjective.PENALTY,
+                default_weight=PENALTY_DEFAULT_WEIGHTS[penalty],
+            )
         return ObjectiveRegister(
             objective_sense=ModeOptim.MAXIMIZATION,
             objective_handling=handling,

--- a/src/discrete_optimization/generic_tasks_tools/generic_scheduling_impl.py
+++ b/src/discrete_optimization/generic_tasks_tools/generic_scheduling_impl.py
@@ -130,7 +130,7 @@ class GenericSchedulingImplProblem(
                 actually minimize the makespan.
             custom_evaluate_fn: function used to evaluate the "custom" objective (to be maximized).
             objective_resource_weights: Weights to be used by the objective when summing used resources
-                (`Objective.NB_RESOURCES_USED`) or resources consumption (`Objective.RESOURCES_CONSUMPTION`).
+                (`Objective.NB_RESOURCES_USED`) or resources levels (`Objective.RESOURCES_LEVELS`).
                 Default to 1 for resources not mentioned.
 
         """
@@ -477,8 +477,8 @@ class GenericSchedulingImplProblem(
                 ) + variable.compute_nb_non_renewable_resources_used(
                     weights=self.objective_resource_weights
                 )
-            case Objective.RESOURCES_CONSUMPTION:
-                return variable.compute_aggregated_calendar_resources_consumptions(
+            case Objective.RESOURCES_LEVELS:
+                return variable.compute_aggregated_calendar_resources_levels(
                     weights=self.objective_resource_weights
                 ) + variable.compute_aggregated_non_renewable_resources_consumptions(
                     weights=self.objective_resource_weights

--- a/src/discrete_optimization/generic_tasks_tools/generic_scheduling_utils.py
+++ b/src/discrete_optimization/generic_tasks_tools/generic_scheduling_utils.py
@@ -75,3 +75,15 @@ OBJECTIVE_DEFAULT_WEIGHTS: dict[Objective, int] = {
     Objective.CUSTOM: 1,
 }
 """Default weight applied to a given objective so that it will be *maximized*."""
+
+
+class Penalty(Enum):
+    "Penalties for a generic scheduling problem."
+
+    TIME = "time_penalty"
+
+
+PENALTY_DEFAULT_WEIGHTS: dict[Penalty, int] = {
+    Penalty.TIME: -100,
+}
+"""Default weight applied to a given penalty to be added to the objective so that it will be *maximized*."""

--- a/src/discrete_optimization/generic_tasks_tools/generic_scheduling_utils.py
+++ b/src/discrete_optimization/generic_tasks_tools/generic_scheduling_utils.py
@@ -63,6 +63,8 @@ class Objective(Enum):
     The weigths are to be defined in `solver.objective_resource_weights`.
 
     """
+    COST = "cost"
+    """Cost of the solution taking into account mode choice and resources consumptions."""
     CUSTOM = "custom_objective"
 
 
@@ -72,6 +74,7 @@ OBJECTIVE_DEFAULT_WEIGHTS: dict[Objective, int] = {
     Objective.NB_UNARY_RESOURCES_USED: -1,
     Objective.NB_RESOURCES_USED: -1,
     Objective.RESOURCES_LEVELS: -1,
+    Objective.COST: -1,
     Objective.CUSTOM: 1,
 }
 """Default weight applied to a given objective so that it will be *maximized*."""

--- a/src/discrete_optimization/generic_tasks_tools/generic_scheduling_utils.py
+++ b/src/discrete_optimization/generic_tasks_tools/generic_scheduling_utils.py
@@ -56,8 +56,8 @@ class Objective(Enum):
     The weigths are to be defined in `solver.objective_resource_weights`.
 
     """
-    RESOURCES_CONSUMPTION = "resources_consumption"
-    """Weighted sum of resources consumptions, to minimize.
+    RESOURCES_LEVELS = "resources_levels"
+    """Weighted sum of resources levels (i.e. needed capacities), to minimize.
 
     Include non-renewable, cumulative, and unary resources.
     The weigths are to be defined in `solver.objective_resource_weights`.
@@ -71,7 +71,7 @@ OBJECTIVE_DEFAULT_WEIGHTS: dict[Objective, int] = {
     Objective.NB_TASKS_DONE: 1,
     Objective.NB_UNARY_RESOURCES_USED: -1,
     Objective.NB_RESOURCES_USED: -1,
-    Objective.RESOURCES_CONSUMPTION: -1,
+    Objective.RESOURCES_LEVELS: -1,
     Objective.CUSTOM: 1,
 }
 """Default weight applied to a given objective so that it will be *maximized*."""

--- a/src/discrete_optimization/generic_tasks_tools/scheduling.py
+++ b/src/discrete_optimization/generic_tasks_tools/scheduling.py
@@ -54,6 +54,13 @@ class SchedulingSolution(TasksSolution[Task]):
     @abstractmethod
     def get_start_time(self, task: Task) -> int: ...
 
+    def get_start_or_end_time(self, task: Task, start_or_end: StartOrEnd) -> int:
+        """Get the start or end time for a given task."""
+        if start_or_end == StartOrEnd.START:
+            return self.get_start_time(task)
+        else:
+            return self.get_end_time(task)
+
     def get_duration(self, task: Task) -> int:
         return self.get_end_time(task) - self.get_start_time(task)
 
@@ -63,11 +70,7 @@ class SchedulingSolution(TasksSolution[Task]):
     def constraint_on_task_satisfied(
         self, task: Task, start_or_end: StartOrEnd, sign: SignEnum, time: int
     ) -> bool:
-        if start_or_end == StartOrEnd.START:
-            actual_time = self.get_start_time(task)
-        else:
-            actual_time = self.get_end_time(task)
-
+        actual_time = self.get_start_or_end_time(task=task, start_or_end=start_or_end)
         if sign == SignEnum.UEQ:
             return actual_time >= time
         elif sign == SignEnum.LEQ:
@@ -78,6 +81,8 @@ class SchedulingSolution(TasksSolution[Task]):
             return actual_time > time
         elif sign == SignEnum.EQUAL:
             return actual_time == time
+        else:
+            raise NotImplementedError()
 
     def constraint_chaining_tasks_satisfied(self, task1: Task, task2: Task) -> bool:
         return self.get_end_time(task1) == self.get_start_time(task2)

--- a/src/discrete_optimization/generic_tasks_tools/skill.py
+++ b/src/discrete_optimization/generic_tasks_tools/skill.py
@@ -132,19 +132,6 @@ class SkillProblem(
         self.get_unary_resource_with_skill.cache_clear()
         self.get_skills_of_unary_resource.cache_clear()
 
-    def __getstate__(self):
-        """Get state for pickle.
-
-        Solve issue when instance has cached methods called. (And thus unpickable cache created.)
-        See https://github.com/GrahamDumpleton/wrapt/issues/343
-
-        """
-        return {
-            key: value
-            for key, value in super().__getstate__().items()
-            if not key.startswith("_lru_cache_")
-        }
-
 
 class SkillSolution(
     CumulativeResourceSolution[Task, CumulativeResource, OtherCalendarResource],

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto.py
@@ -110,9 +110,9 @@ class GenericSchedulingAutoCpSatSolver(
     # objective settings
     objective: Objective = Objective.MAKESPAN  # Objective set by `init_model()`
     objective_resource_weights: Optional[dict[AnyResource, int]] = None
-    """Weights to be used by the objective when summing used resources or resources consumption.
+    """Weights to be used by the objective when summing used resources or resources levels.
 
-    This is the case if `objective` is set to `Objective.NB_RESOURCES_USED` or  `Objective.RESOURCES_CONSUMPTION`.
+    This is the case if `objective` is set to `Objective.NB_RESOURCES_USED` or  `Objective.RESOURCES_LEVELS`.
     Default to 1 for resources not mentioned.
 
     Hypothesis: cumulative, unary, and non-renewable resources have different values.
@@ -158,10 +158,10 @@ class GenericSchedulingAutoCpSatSolver(
     """Variables tracking whether a (unary, cumulative, or non-renewable) resource has been used at least once."""
     all_used_variables_created = False
     """Flag telling whether 'all_used_variables' have been created"""
-    resource_consumption_variables: dict[AnyResource, LinearExprT]
-    """Variables tracking total consumption of each (unary, cumulative, or non-renewable) resource."""
-    resource_consumption_variables_created = False
-    """Flag telling whether 'resource_consumption_variables' have been created"""
+    resource_level_variables: dict[AnyResource, LinearExprT]
+    """Variables tracking level (capacity needed) of each (unary, cumulative, or non-renewable) resource."""
+    resource_level_variables_created = False
+    """Flag telling whether 'resource_level_variables' have been created"""
 
     @property
     def needs_duration_variables(self) -> bool:
@@ -328,8 +328,8 @@ class GenericSchedulingAutoCpSatSolver(
 
         self.all_used_variables_created = False
         self.all_used_variables = {}
-        self.resource_consumption_variables_created = False
-        self.resource_consumption_variables = {}
+        self.resource_level_variables_created = False
+        self.resource_level_variables = {}
 
     def _create_variables(self):
         self._create_start_or_end_variables()
@@ -709,20 +709,18 @@ class GenericSchedulingAutoCpSatSolver(
             self.cp_model.add(used == 0)
         return used
 
-    def _create_resource_consumption_variables(self):
-        if not self.resource_consumption_variables_created:
+    def _create_resource_level_variables(self):
+        if not self.resource_level_variables_created:
             self.check_resources_lists()
             self.create_used_variables()
             # allocated unary resources
             for resource in self.problem.unary_resources_list:
-                self.resource_consumption_variables[resource] = self.used_variables[
-                    resource
-                ]
+                self.resource_level_variables[resource] = self.used_variables[resource]
             # cumulative resources
             for resource in self.problem.cumulative_resources_list:
                 max_capacity = self.problem.get_resource_max_capacity(resource)
-                conso_tot_var = self.cp_model.new_int_var(
-                    lb=0, ub=max_capacity, name=f"conso_{resource}"
+                level_var = self.cp_model.new_int_var(
+                    lb=0, ub=max_capacity, name=f"level_{resource}"
                 )
                 if max_capacity > 1:
                     # cumulative constraint on the new "conso" variable
@@ -744,15 +742,15 @@ class GenericSchedulingAutoCpSatSolver(
                             self.cp_model.add_cumulative(
                                 intervals=intervals,
                                 demands=demands,
-                                capacity=conso_tot_var,
+                                capacity=level_var,
                             )
                             for (
                                 _,
                                 conso_var,
                             ) in intervals_n_consumptions:
-                                self.cp_model.add(conso_tot_var >= conso_var)
+                                self.cp_model.add(level_var >= conso_var)
                         else:
-                            conso_tot_var = 0
+                            level_var = 0
                     else:
                         mode_intervals_consumptions_is_present = [
                             (
@@ -784,16 +782,16 @@ class GenericSchedulingAutoCpSatSolver(
                             self.cp_model.add_cumulative(
                                 intervals=intervals,
                                 demands=demands,
-                                capacity=conso_tot_var,
+                                capacity=level_var,
                             )
                             for (
                                 _,
                                 conso,
                                 is_present,
                             ) in mode_intervals_consumptions_is_present:
-                                self.cp_model.add(conso_tot_var >= conso * is_present)
+                                self.cp_model.add(level_var >= conso * is_present)
                         else:
-                            conso_tot_var = 0
+                            level_var = 0
                 else:
                     # disjunctive resource, no need to use the interval variables
                     # (no overlap constraint already handled by `create_calendar_resources_constraint()`
@@ -808,22 +806,22 @@ class GenericSchedulingAutoCpSatSolver(
                     ]
                     if len(list_is_present_variables) > 0:
                         self.cp_model.add_max_equality(
-                            conso_tot_var, list_is_present_variables
+                            level_var, list_is_present_variables
                         )
                     else:
-                        conso_tot_var = 0
+                        level_var = 0
 
-                self.resource_consumption_variables[resource] = conso_tot_var
+                self.resource_level_variables[resource] = level_var
             # non-renewable resources
             for resource in self.problem.non_renewable_resources_list:
-                self.resource_consumption_variables[resource] = sum(
+                self.resource_level_variables[resource] = sum(
                     self.get_non_renewable_resource_demand_variable(
                         task=task, resource=resource
                     )
                     for task in self.problem.tasks_list
                 )
 
-            self.resource_consumption_variables_created = True
+            self.resource_level_variables_created = True
 
     def check_resources_lists(self):
         resources_list = (
@@ -850,15 +848,15 @@ class GenericSchedulingAutoCpSatSolver(
             for resource, used in self.all_used_variables.items()
         )
 
-    def get_aggregated_resources_consumptions_variable(self) -> LinearExprT:
-        """Get cpsat variable aggregating consumptions of each resource."""
+    def get_aggregated_resources_levels_variable(self) -> LinearExprT:
+        """Get cpsat variable aggregating levels (ie min capacities needed) of each resource."""
         weights = self.objective_resource_weights
         if weights is None:
             weights = {}
-        self._create_resource_consumption_variables()
+        self._create_resource_level_variables()
         return sum(
             weights.get(resource, 1) * conso
-            for resource, conso in self.resource_consumption_variables.items()
+            for resource, conso in self.resource_level_variables.items()
         )
 
     def _add_constraints(self) -> None:
@@ -903,8 +901,8 @@ class GenericSchedulingAutoCpSatSolver(
                 objective_var = self.get_nb_unary_resources_used_variable()
             case Objective.NB_RESOURCES_USED:
                 objective_var = self.get_nb_resources_used_variable()
-            case Objective.RESOURCES_CONSUMPTION:
-                objective_var = self.get_aggregated_resources_consumptions_variable()
+            case Objective.RESOURCES_LEVELS:
+                objective_var = self.get_aggregated_resources_levels_variable()
             case _:
                 raise NotImplementedError()
         return objective_var

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto.py
@@ -154,6 +154,8 @@ class GenericSchedulingAutoCpSatSolver(
     skill_variables: dict[Task, dict[UnaryResource, dict[Skill, LinearExprT]]]
     demand_variables: dict[Task, dict[AnyResource, LinearExprT]]
     energy_variables: dict[Task, dict[AnyResource, LinearExprT]]
+    mode_cost_variables: dict[Task, LinearExprT]
+    unary_resource_cost_variables: dict[Task, dict[UnaryResource, LinearExprT]]
     all_used_variables: dict[AnyResource, IntVar]
     """Variables tracking whether a (unary, cumulative, or non-renewable) resource has been used at least once."""
     all_used_variables_created = False
@@ -325,6 +327,8 @@ class GenericSchedulingAutoCpSatSolver(
         self.allocation_is_present = {}
         self.allocation_intervals = {}
         self.skill_variables = {}
+        self.mode_cost_variables = {}
+        self.unary_resource_cost_variables = {}
 
         self.all_used_variables_created = False
         self.all_used_variables = {}
@@ -365,27 +369,21 @@ class GenericSchedulingAutoCpSatSolver(
 
         """
         for task in self.problem.tasks_list:
-            possible_durations = {
-                self.problem.get_task_mode_duration(task=task, mode=mode)
+            mode2duration = {
+                mode: self.problem.get_task_mode_duration(task=task, mode=mode)
                 for mode in self.problem.get_task_modes(task)
             }
-            if len(possible_durations) == 1:
-                # single mode: fixed duration
-                self.duration_variables[task] = next(iter(possible_durations))
-            else:
-                # multi mode
-                self.duration_variables[task] = self.cp_model.new_int_var_from_domain(
-                    domain=Domain.from_values(list(possible_durations)),
-                    name=f"duration_{task}",
-                )
-                # duration per mode constraint  (managed by interval opt else)
-                if self.avoid_interval_optional or not self.needs_task_interval:
-                    # not needed if intervals optional per mode + intervals constraints already defined
-                    for mode in self.problem.get_task_modes(task=task):
-                        self.cp_model.add(
-                            self.duration_variables[task]
-                            == self.problem.get_task_mode_duration(task=task, mode=mode)
-                        ).only_enforce_if(self.modes_is_present[task][mode])
+            # constraint var value enforced by is_present_mode
+            # not needed if intervals optional per mode + intervals constraints also defined
+            create_constraint_with_is_present_mode = (
+                self.avoid_interval_optional or not self.needs_task_interval
+            )
+            self.duration_variables[task] = self._create_var_per_mode(
+                name=f"duration_{task}",
+                mode2value=mode2duration,
+                task=task,
+                create_constraint_with_is_present_mode=create_constraint_with_is_present_mode,
+            )
             if self.needs_task_interval:
                 # interval constraint
                 self.task_interval_variables[task] = self.cp_model.new_interval_var(
@@ -568,7 +566,11 @@ class GenericSchedulingAutoCpSatSolver(
                 )
 
     def _create_var_per_mode(
-        self, name: str, mode2value: dict[int, int], task: Task
+        self,
+        name: str,
+        mode2value: dict[int, int],
+        task: Task,
+        create_constraint_with_is_present_mode: bool = True,
     ) -> LinearExprT:
         possible_values = set(mode2value.values())
         if len(possible_values) == 1:
@@ -577,45 +579,61 @@ class GenericSchedulingAutoCpSatSolver(
             var = self.cp_model.new_int_var_from_domain(
                 domain=Domain.from_values(list(possible_values)), name=name
             )
-            for mode, value in mode2value.items():
-                self.cp_model.add(var == value).only_enforce_if(
-                    self.modes_is_present[task][mode]
+            if create_constraint_with_is_present_mode:
+                for mode, value in mode2value.items():
+                    self.cp_model.add(var == value).only_enforce_if(
+                        self.modes_is_present[task][mode]
+                    )
+        return var
+
+    def _create_var_per_mode_if_allocated(
+        self,
+        name: str,
+        mode2value: dict[int, int],
+        task: Task,
+        unary_resource: UnaryResource,
+    ) -> LinearExprT:
+        is_allocated = self.get_task_unary_resource_is_present_variable(
+            task=task, unary_resource=unary_resource
+        )
+        if isinstance(is_allocated, int) and is_allocated == 0:
+            # never allocated
+            var = 0
+        else:
+            possible_values = set(mode2value.values())
+            possible_values.add(0)  # no allocation
+            if len(possible_values) == 1:
+                var = next(iter(possible_values))
+            else:
+                var = self.cp_model.new_int_var_from_domain(
+                    domain=Domain.from_values(list(possible_values)), name=name
                 )
+                for mode, value in mode2value.items():
+                    self.cp_model.add(var == value).only_enforce_if(
+                        [is_allocated, self.modes_is_present[task][mode]]
+                    )
         return var
 
     def _create_energy_variables(self):
         for task in self.problem.tasks_list:
             self.energy_variables[task] = {}
             for resource in self.problem.unary_resources_list:
-                is_allocated = self.get_task_unary_resource_is_present_variable(
-                    task=task, unary_resource=resource
-                )
-                if isinstance(is_allocated, int) and is_allocated == 0:
-                    # never allocated
-                    var = 0
-                else:
-                    # value depending on allocation + mode
-                    name = f"energy_{task}_{resource}"
-                    mode2value = {
-                        mode: self.problem.get_task_mode_duration(task=task, mode=mode)
-                        for mode in self.problem.get_task_modes(task=task)
-                    }
-                    possible_values = set(mode2value.values())
-                    possible_values.add(0)  # no allocation
-                    var = self.cp_model.new_int_var_from_domain(
-                        domain=Domain.from_values(list(possible_values)), name=name
+                # cannot use quadratic sum => create var with constraint on is_present_mode and is_allocated
+                self.energy_variables[task][resource] = (
+                    self._create_var_per_mode_if_allocated(
+                        name=f"energy_{task}_{resource}",
+                        mode2value={
+                            mode: self.problem.get_task_mode_duration(
+                                task=task, mode=mode
+                            )  # conso = 1
+                            for mode in self.problem.get_task_modes(task=task)
+                        },
+                        task=task,
+                        unary_resource=resource,
                     )
-                    self.cp_model.add(var == 0).only_enforce_if(~is_allocated)
-                    for mode, value in mode2value.items():
-                        self.cp_model.add(var == value).only_enforce_if(
-                            [
-                                is_allocated,
-                                self.modes_is_present[task][mode],
-                            ]
-                        )
-                self.energy_variables[task][resource] = var
-
+                )
             for resource in self.problem.cumulative_resources_list:
+                # linear sum
                 self.energy_variables[task][resource] = sum(
                     self.modes_is_present[task][mode]
                     * self.problem.get_task_mode_duration(task=task, mode=mode)
@@ -859,6 +877,50 @@ class GenericSchedulingAutoCpSatSolver(
             for resource, conso in self.resource_level_variables.items()
         )
 
+    def _create_cost_variables(self):
+        for task in self.problem.tasks_list:
+            self.mode_cost_variables[task] = sum(
+                self.modes_is_present[task][mode]
+                * self.problem.get_mode_cost(task=task, mode=mode)
+                for mode in self.problem.get_task_modes(task)
+            )
+            self.unary_resource_cost_variables[task] = {}
+            for unary_resource in self.problem.unary_resources_list:
+                self.unary_resource_cost_variables[task][unary_resource] = (
+                    self._create_var_per_mode_if_allocated(
+                        name=f"unary_resource_cost_{task}_{unary_resource}",
+                        mode2value={
+                            mode: self.problem.get_unary_resource_cost(
+                                task=task, mode=mode, unary_resource=unary_resource
+                            )
+                            for mode in self.problem.get_task_modes(task=task)
+                        },
+                        task=task,
+                        unary_resource=unary_resource,
+                    )
+                )
+
+    def _get_total_cost_variable(self) -> LinearExprT:
+        return sum(
+            (
+                self.mode_cost_variables[task]
+                + sum(
+                    self.unary_resource_cost_variables[task][unary_resource]
+                    for unary_resource in self.problem.unary_resources_list
+                )
+            )
+            for task in self.problem.tasks_list
+        )
+
+    def get_cost_variable(self) -> LinearExprT:
+        """Get cpsat variable tracking cost."""
+        try:
+            return self._get_total_cost_variable()
+        except KeyError:
+            # cost variables not yet created
+            self._create_cost_variables()
+            return self._get_total_cost_variable()
+
     def _add_constraints(self) -> None:
         # time lag
         self.create_timelag_constraints()
@@ -903,6 +965,8 @@ class GenericSchedulingAutoCpSatSolver(
                 objective_var = self.get_nb_resources_used_variable()
             case Objective.RESOURCES_LEVELS:
                 objective_var = self.get_aggregated_resources_levels_variable()
+            case Objective.COST:
+                objective_var = self.get_cost_variable()
             case _:
                 raise NotImplementedError()
         return objective_var

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto_impl.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto_impl.py
@@ -137,20 +137,36 @@ class GenericSchedulingAutoCpSatImplSolver(
         )
 
         # use the params_objective_function to define the objective
+        # keep only objectives, not penalties
+        indices_obj = []
+        for i, obj in enumerate(self.params_objective_function.objectives):
+            try:
+                Objective(obj)
+            except ValueError:
+                # not an objective (e.g. "time_penalty")
+                pass
+            else:
+                indices_obj.append(i)
+        if len(indices_obj) == 0:
+            raise ValueError(
+                "`self.params_objective_function` does not contain any objective from `Objective` enumeration."
+            )
+        # single obj vs aggregated obj
         match self.params_objective_function.objective_handling:
             case ObjectiveHandling.SINGLE:
+                i_obj = indices_obj[0]
                 objective_var = self.params_objective_function.weights[
-                    0
+                    i_obj
                 ] * self.get_objective_variable(
-                    Objective(self.params_objective_function.objectives[0])
+                    Objective(self.params_objective_function.objectives[i_obj])
                 )
             case ObjectiveHandling.AGGREGATE:
                 objective_var = sum(
-                    weight * self.get_objective_variable(Objective(objective_name))
-                    for objective_name, weight in zip(
-                        self.params_objective_function.objectives,
-                        self.params_objective_function.weights,
+                    self.params_objective_function.weights[i]
+                    * self.get_objective_variable(
+                        Objective(self.params_objective_function.objectives[i])
                     )
+                    for i in indices_obj
                 )
             case _:
                 raise NotImplementedError()

--- a/src/discrete_optimization/generic_tasks_tools/timelag.py
+++ b/src/discrete_optimization/generic_tasks_tools/timelag.py
@@ -258,9 +258,14 @@ class TimelagProblem(SchedulingProblem[Task], Generic[Task]):
         See https://github.com/GrahamDumpleton/wrapt/issues/343
 
         """
+        try:
+            dico = super().__getstate__()
+        except AttributeError:
+            # python < 3.11: __getstate__() not always defined
+            dico = self.__dict__
         return {
             key: value
-            for key, value in super().__getstate__().items()
+            for key, value in dico.items()
             if not key.startswith("_lru_cache_")
         }
 

--- a/src/discrete_optimization/rcpsp/solvers/cpsat_auto.py
+++ b/src/discrete_optimization/rcpsp/solvers/cpsat_auto.py
@@ -317,13 +317,11 @@ class CpSatAutoCumulativeResourceRcpspSolver(CpSatAutoRcpspSolver):
 
         super().init_model(**kwargs)
 
-        resources_consumption_var = (
-            self.get_aggregated_resources_consumptions_variable()
-        )
+        resources_level_var = self.get_aggregated_resources_levels_variable()
         makespan_var = self.get_global_makespan_variable()
 
         self.cp_model.minimize(
-            weight_on_used_resource * resources_consumption_var
+            weight_on_used_resource * resources_level_var
             + weight_on_makespan * makespan_var
         )
 
@@ -331,7 +329,7 @@ class CpSatAutoCumulativeResourceRcpspSolver(CpSatAutoRcpspSolver):
         if obj == "makespan":
             return self.get_global_makespan_variable()
         elif obj == "used_resource":
-            return self.get_aggregated_resources_consumptions_variable()
+            return self.get_aggregated_resources_levels_variable()
         else:
             raise ValueError(f"Unknown objective '{obj}'.")
 

--- a/tests/generic_tasks_tools/solvers/cpsat/test_auto.py
+++ b/tests/generic_tasks_tools/solvers/cpsat/test_auto.py
@@ -172,7 +172,7 @@ class MyProblem(
             nb_allocated=variable.compute_nb_unary_resources_used(),
             nb_resources_used=variable.compute_nb_calendar_resources_used()
             + variable.compute_nb_non_renewable_resources_used(),
-            resources_consumptions=variable.compute_aggregated_calendar_resources_consumptions()
+            resources_levels=variable.compute_aggregated_calendar_resources_levels()
             + variable.compute_aggregated_non_renewable_resources_consumptions(),
             nb_tasks_done=variable.compute_nb_tasks_done(),
         )
@@ -206,7 +206,7 @@ class MyProblem(
                     type=TypeObjective.OBJECTIVE,
                     default_weight=1,
                 ),
-                resources_consumptions=ObjectiveDoc(
+                resources_levels=ObjectiveDoc(
                     type=TypeObjective.OBJECTIVE,
                     default_weight=1,
                 ),
@@ -268,7 +268,7 @@ def test_problem(caplog):
     assert d["nb_tasks_done"] == 2
     assert d["nb_allocated"] == 2
     assert d["nb_resources_used"] == 4
-    assert d["resources_consumptions"] == 5
+    assert d["resources_levels"] == 5
 
     sol = MySolution(
         problem=problem,
@@ -410,7 +410,7 @@ def test_auto(
     if objective in [
         Objective.NB_UNARY_RESOURCES_USED,
         Objective.NB_RESOURCES_USED,
-        Objective.RESOURCES_CONSUMPTION,
+        Objective.RESOURCES_LEVELS,
     ]:
         solver.exactly_one_unary_resource_per_task = True
     with caplog.at_level(logging.WARNING):

--- a/tests/generic_tasks_tools/solvers/cpsat/test_auto_impl.py
+++ b/tests/generic_tasks_tools/solvers/cpsat/test_auto_impl.py
@@ -109,6 +109,23 @@ def test_auto(
         },
         objective=objective,
         custom_evaluate_fn=custom_evaluate_fn,
+        mode_costs={
+            "task-1": {
+                0: 100,
+                1: 3,
+            },
+            "task-2": {
+                0: 0,
+            },
+        },
+        unary_resource_costs={
+            "task-1": {
+                1: {
+                    "worker1": 27,
+                    "worker2": 10,
+                },
+            },
+        },
     )
 
     # prepare solver
@@ -125,6 +142,7 @@ def test_auto(
         Objective.NB_UNARY_RESOURCES_USED,
         Objective.NB_RESOURCES_USED,
         Objective.RESOURCES_LEVELS,
+        Objective.COST,
     ]
 
     solver = GenericSchedulingAutoCpSatImplSolver(
@@ -154,6 +172,12 @@ def test_auto(
         assert kpi["makespan"] == 9
     elif objective == Objective.NB_TASKS_DONE:
         assert kpi["nb_tasks_done"] == 2
+    elif objective == Objective.COST:
+        assert sol.get_mode("task-1") == 1
+        assert not sol.is_allocated("task-1", unary_resource="worker1")
+        assert sol.is_allocated("task-1", unary_resource="worker2")
+        assert kpi["cost"] == 3 + 10
+
     elif objective == Objective.CUSTOM:
         assert kpi["custom_objective"] == 2 - 9
     elif isinstance(objective, list):
@@ -161,6 +185,8 @@ def test_auto(
         assert kpi["makespan"] == 9
 
     # check warm start from a "bad" solution
+    if objective == Objective.COST:
+        return  # skip warm start
     bad_sol = GenericSchedulingImplSolution(
         problem=problem,
         raw_sol=RawSolution(

--- a/tests/generic_tasks_tools/solvers/cpsat/test_auto_impl.py
+++ b/tests/generic_tasks_tools/solvers/cpsat/test_auto_impl.py
@@ -124,7 +124,7 @@ def test_auto(
     exactly_one_unary_resource_per_task = objective in [
         Objective.NB_UNARY_RESOURCES_USED,
         Objective.NB_RESOURCES_USED,
-        Objective.RESOURCES_CONSUMPTION,
+        Objective.RESOURCES_LEVELS,
     ]
 
     solver = GenericSchedulingAutoCpSatImplSolver(

--- a/tests/generic_tasks_tools/test_generic_scheduling_impl.py
+++ b/tests/generic_tasks_tools/test_generic_scheduling_impl.py
@@ -96,7 +96,7 @@ def test_problem(problem_wo_skills, caplog):
     assert d["nb_tasks_done"] == 2
     assert d["nb_unary_resources_used"] == 2
     assert d["nb_resources_used"] == 4
-    assert d["resources_consumption"] == 5
+    assert d["resources_levels"] == 5
     assert d["custom_objective"] == -7
 
     sol = GenericSchedulingImplSolution(

--- a/tests/generic_tasks_tools/test_generic_scheduling_impl.py
+++ b/tests/generic_tasks_tools/test_generic_scheduling_impl.py
@@ -214,8 +214,15 @@ def test_problem(problem_wo_skills, caplog):
     assert problem.satisfy(sol)
     d = problem.evaluate(sol)
     assert d["time_penalty"] == 0
+    assert d["cost"] == 0
 
-    # time penalty with wirong time windows and time lags
+    # non-null cost
+    problem.mode_costs = {"task-1": {0: 10, 1: 35}}
+    problem.unary_resource_costs = {"task-2": {0: {"worker1": 23, "worker2": 3}}}
+    d = problem.evaluate(sol)
+    assert d["cost"] == 38
+
+    # time penalty with wrong time windows and time lags
     problem.time_windows["task-1"] = 2, None, None, None
     problem.end_to_start_min_time_lags.append(("task-1", "task-2", 2))
     problem.update_problem()

--- a/tests/generic_tasks_tools/test_generic_scheduling_impl.py
+++ b/tests/generic_tasks_tools/test_generic_scheduling_impl.py
@@ -212,6 +212,16 @@ def test_problem(problem_wo_skills, caplog):
         ),
     )
     assert problem.satisfy(sol)
+    d = problem.evaluate(sol)
+    assert d["time_penalty"] == 0
+
+    # time penalty with wirong time windows and time lags
+    problem.time_windows["task-1"] = 2, None, None, None
+    problem.end_to_start_min_time_lags.append(("task-1", "task-2", 2))
+    problem.update_problem()
+    assert not problem.satisfy(sol)
+    d = problem.evaluate(sol)
+    assert d["time_penalty"] == 3
 
 
 def test_task_bounds_simple(problem_wo_skills):


### PR DESCRIPTION
- fix `__getstate__`  so that it works with multiple inheritance
- change  "resource_consumptions" into "resources_levels"  as it is actually the min capacity needed that is optimized rather than the total consumption
- compute (optionally) a time penalty when evaluating generic scheduling solutions
- add a cost objective taking into account
  - a cost per mode (possibly related to the duration and resources consumption)
  - a cost per unary resource allocation (possibly related to the duration as the defined cost is per mode)