### PR TITLE
Improvements on generic scheduling for scikit-decide integration

### DIFF
--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/timelag.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/timelag.py
@@ -18,6 +18,7 @@ class TimelagCpSatSolver(SchedulingCpSatSolver[Task]):
         self,
         task1_start_or_end: StartOrEnd,
         task2_start_or_end: StartOrEnd,
+        skip_equality_with_0_offset: bool = False,
     ) -> None:
         # after normalization only offsets >=0 (min time lags) or >0 (max time lags)
         min_timelags = self.problem.get_consolidated_time_lags(
@@ -36,6 +37,7 @@ class TimelagCpSatSolver(SchedulingCpSatSolver[Task]):
         # - offset==0: (t1, t2, 0) in min time lags and (t2, t1, 0) in reversed tasks min time lags
         # set computation
         equality_timelags_positive_offset = set(min_timelags).intersection(max_timelags)
+
         min_timelags_0_offset = [
             (t1, t2, 0) for (t1, t2, offset) in min_timelags if offset == 0
         ]
@@ -56,9 +58,13 @@ class TimelagCpSatSolver(SchedulingCpSatSolver[Task]):
                 or (t2, t1, 0) not in equality_timelags_0_offset
             ):
                 equality_timelags_0_offset.add((t1, t2, 0))
-        equality_timelags = equality_timelags_positive_offset.union(
-            equality_timelags_0_offset
-        )
+        if skip_equality_with_0_offset:
+            # skip as already covered
+            equality_timelags = equality_timelags_positive_offset
+        else:
+            equality_timelags = equality_timelags_positive_offset.union(
+                equality_timelags_0_offset
+            )
         # add corresponding constraints to cp_model
         for task1, task2, offset in equality_timelags:
             self.cp_model.add(
@@ -102,13 +108,13 @@ class TimelagCpSatSolver(SchedulingCpSatSolver[Task]):
         """Add precedence constraints to cp model."""
         for task1_start_or_end in StartOrEnd:
             for task2_start_or_end in StartOrEnd:
-                if (task1_start_or_end, task2_start_or_end) == (
-                    StartOrEnd.START,
-                    StartOrEnd.END,
-                ):
-                    # already covered by (StartOrEnd.END, StartOrEnd.START)
-                    continue
                 self._create_timelag_constraints(
                     task1_start_or_end=task1_start_or_end,
                     task2_start_or_end=task2_start_or_end,
+                    # start(t1) == end(t2) already covered by (StartOrEnd.END, StartOrEnd.START)
+                    skip_equality_with_0_offset=(task1_start_or_end, task2_start_or_end)
+                    == (
+                        StartOrEnd.START,
+                        StartOrEnd.END,
+                    ),
                 )

--- a/src/discrete_optimization/generic_tasks_tools/solvers_map.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers_map.py
@@ -1,0 +1,116 @@
+#  Copyright (c) 2022 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+
+from typing import Any
+
+from discrete_optimization.generic_tasks_tools.generic_scheduling_impl import (
+    GenericSchedulingImplProblem,
+)
+from discrete_optimization.generic_tasks_tools.solvers.cpsat.auto_impl import (
+    GenericSchedulingAutoCpSatImplSolver,
+)
+from discrete_optimization.generic_tasks_tools.solvers.lns_cp.constraint_handler import (
+    TasksConstraintHandler,
+)
+from discrete_optimization.generic_tools.do_problem import Problem
+from discrete_optimization.generic_tools.do_solver import SolverDO
+from discrete_optimization.generic_tools.hyperparameters.hyperparameter import SubBrick
+from discrete_optimization.generic_tools.lns_cp import LnsOrtoolsCpSat
+from discrete_optimization.generic_tools.result_storage.result_storage import (
+    ResultStorage,
+)
+
+BaseProblemType = GenericSchedulingImplProblem
+
+
+solvers: dict[str, list[tuple[type[SolverDO], dict[str, Any]]]] = {
+    "cp": [
+        (GenericSchedulingAutoCpSatImplSolver, {}),
+    ],
+    "lns-scheduling": [
+        (
+            LnsOrtoolsCpSat,
+            {
+                "nb_iteration_lns": 100,
+                "nb_iteration_no_improvement": 100,
+                "subsolver_subbrick": SubBrick(
+                    cls=GenericSchedulingAutoCpSatImplSolver, kwargs={}
+                ),
+                "constraint_handler_subbrick": SubBrick(
+                    cls=TasksConstraintHandler, kwargs={}
+                ),
+                "skip_initial_solution_provider": True,
+            },
+        ),
+    ],
+}
+
+solvers_map: dict[type[SolverDO], tuple[str, dict[str, Any]]] = {}
+for key in solvers:
+    for solver, param in solvers[key]:
+        solvers_map[solver] = (key, param)
+
+solvers_compatibility: dict[type[SolverDO], list[type[Problem]]] = {
+    solver: [BaseProblemType] for solver in solvers_map
+}
+
+
+def look_for_solver(
+    domain: Problem,
+) -> list[type[SolverDO]]:
+    class_domain = domain.__class__
+    return look_for_solver_class(class_domain)
+
+
+def look_for_solver_class(
+    class_domain: type[Problem],
+) -> list[type[SolverDO]]:
+    available = []
+    for solver in solvers_compatibility:
+        if class_domain in solvers_compatibility[solver]:
+            available += [solver]
+    return available
+
+
+def solve(
+    method: type[SolverDO],
+    problem: Problem,
+    **kwargs: Any,
+) -> ResultStorage:
+    solver = return_solver(method=method, problem=problem, **kwargs)
+    return solver.solve(**kwargs)
+
+
+def solve_return_solver(
+    method: type[SolverDO],
+    problem: Problem,
+    **kwargs: Any,
+) -> tuple[ResultStorage, SolverDO]:
+    solver = return_solver(method=method, problem=problem, **kwargs)
+    return solver.solve(**kwargs), solver
+
+
+def return_solver(
+    method: type[SolverDO],
+    problem: Problem,
+    **kwargs: Any,
+) -> SolverDO:
+    solver: SolverDO
+    solver = method(problem=problem, **kwargs)
+    try:
+        solver.init_model(**kwargs)
+    except:
+        pass
+    return solver
+
+
+def get_solver_default_arguments(
+    method: type[SolverDO],
+) -> dict[str, Any]:
+    try:
+        return solvers_map[method][1]
+    except KeyError:
+        raise KeyError(
+            f"{method} is not in the list of available solvers for {BaseProblemType.__name__}."
+        )

--- a/tests/generic_tasks_tools/solvers/cpsat/test_auto_impl.py
+++ b/tests/generic_tasks_tools/solvers/cpsat/test_auto_impl.py
@@ -213,6 +213,25 @@ def test_auto(
     assert sol.raw_sol.task_variables == bad_sol.raw_sol.task_variables
 
 
+def test_start_to_end_time_lag():
+    problem = GenericSchedulingImplProblem(
+        horizon=10,
+        durations_per_mode={
+            "task-1": {
+                0: 3,
+            },
+            "task-2": {
+                0: 4,
+            },
+        },
+        start_to_end_min_time_lags=[("task-1", "task-2", 8)],
+    )
+    solver = GenericSchedulingAutoCpSatImplSolver(problem=problem)
+    result = solver.solve(time_limit=10, parameters_cp=ParametersCp.default())
+    solution: GenericSchedulingImplSolution = result.get_best_solution()
+    assert problem.satisfy(solution)
+
+
 def test_rcpsp_simple():
     mode_details = {
         1: {1: {"duration": 0}},  # dummy start


### PR DESCRIPTION
- Add a solvers_map for `GenericSchedulingImplProblem`;
- Fix time lags handling in cpsat-auto (we were missing start-to-end timelags except for equalities with 0 offset)