### PR TITLE
Create a subproblem given a partial solution for any generic scheduling problem

### DIFF
--- a/src/discrete_optimization/flex_scheduling/problem.py
+++ b/src/discrete_optimization/flex_scheduling/problem.py
@@ -20,7 +20,7 @@ from discrete_optimization.generic_tasks_tools.generic_scheduling import (
     GenericSchedulingSolution,
 )
 from discrete_optimization.generic_tasks_tools.multimode import MultimodeSolution
-from discrete_optimization.generic_tasks_tools.no_overlap_scheduling import (
+from discrete_optimization.generic_tasks_tools.no_overlap import (
     WithoutNoOverlapProblem,
 )
 from discrete_optimization.generic_tasks_tools.scheduling import SchedulingSolution

--- a/src/discrete_optimization/generic_tasks_tools/calendar_resource.py
+++ b/src/discrete_optimization/generic_tasks_tools/calendar_resource.py
@@ -9,6 +9,7 @@ from collections.abc import Hashable, Iterable
 from typing import Generic, Optional, TypeVar
 
 import numpy as np
+import numpy.typing as npt
 import wrapt
 
 from discrete_optimization.generic_tasks_tools.base import Task
@@ -367,7 +368,7 @@ class WithoutCalendarResourceSolution(
 
 
 def convert_calendar_to_availability_intervals(
-    calendar: int | list[int], horizon: int
+    calendar: int | list[int] | npt.NDArray[int], horizon: int
 ) -> list[tuple[int, int, int]]:
     """Convert a calendar into availability intervals.
 
@@ -392,10 +393,10 @@ def convert_calendar_to_availability_intervals(
         for t in range(1, end_calendar):
             if calendar[t] != value:
                 # ends current interval, starts the next one
-                intervals.append((start, t, value))
+                intervals.append((start, t, int(value)))
                 start = t
                 value = calendar[t]
-        intervals.append((start, end_calendar, value))
+        intervals.append((start, end_calendar, int(value)))
         return intervals
 
 

--- a/src/discrete_optimization/generic_tasks_tools/enums.py
+++ b/src/discrete_optimization/generic_tasks_tools/enums.py
@@ -5,7 +5,19 @@ class StartOrEnd(Enum):
     START = "start"
     END = "end"
 
+    def __invert__(self):
+        if self == StartOrEnd.START:
+            return StartOrEnd.END
+        else:
+            return StartOrEnd.START
+
 
 class MinOrMax(Enum):
     MIN = "min"
     MAX = "max"
+
+    def __invert__(self):
+        if self == MinOrMax.MIN:
+            return MinOrMax.MAX
+        else:
+            return MinOrMax.MIN

--- a/src/discrete_optimization/generic_tasks_tools/generic_scheduling.py
+++ b/src/discrete_optimization/generic_tasks_tools/generic_scheduling.py
@@ -17,7 +17,7 @@ from discrete_optimization.generic_tasks_tools.generic_scheduling_utils import (
     Objective,
     Penalty,
 )
-from discrete_optimization.generic_tasks_tools.no_overlap_scheduling import (
+from discrete_optimization.generic_tasks_tools.no_overlap import (
     NoOverlapProblem,
     NoOverlapSolution,
 )
@@ -628,6 +628,7 @@ class GenericSchedulingProblem(
         time_lags: bool = True,
         time_windows: bool = True,
         no_overlap: bool = True,
+        forbidden_intervals: bool = True,
     ) -> bool:
         """Partial checks on solution.
 
@@ -644,6 +645,7 @@ class GenericSchedulingProblem(
             time_lags:
             time_windows:
             no_overlap:
+            forbidden_intervals:
 
         Returns:
 
@@ -680,6 +682,8 @@ class GenericSchedulingProblem(
             and (not time_windows or variable.check_time_windows())
             # no overlap
             and (not no_overlap or variable.check_no_overlap())
+            # forbidden intervals
+            and (not forbidden_intervals or variable.check_forbidden_intervals())
         )
 
 

--- a/src/discrete_optimization/generic_tasks_tools/generic_scheduling_impl.py
+++ b/src/discrete_optimization/generic_tasks_tools/generic_scheduling_impl.py
@@ -80,7 +80,7 @@ class GenericSchedulingImplProblem(
         start_to_end_min_time_lags: Optional[list[tuple[Task, Task, int]]] = None,
         end_to_start_min_time_lags: Optional[list[tuple[Task, Task, int]]] = None,
         end_to_end_min_time_lags: Optional[list[tuple[Task, Task, int]]] = None,
-        no_overlap_sets: set[frozenset[Task]] = None,
+        no_overlap_sets: Optional[set[frozenset[Task]]] = None,
         objective: Objective | Iterable[tuple[Objective, int]] = Objective.MAKESPAN,
         custom_evaluate_fn: Optional[
             Callable[[GenericSchedulingImplSolution], int]
@@ -410,68 +410,6 @@ class GenericSchedulingImplProblem(
         assert isinstance(variable, GenericSchedulingImplSolution)
         return self.satisfy_partial(variable=variable)
 
-    def satisfy_partial(
-        self,
-        variable: GenericSchedulingImplSolution,
-        duration: bool = True,
-        calendar: bool = True,
-        non_renewable_capacity: bool = True,
-        precedence: bool = True,
-        skill: bool = True,
-        allocation: bool = True,
-        time_lags: bool = True,
-        time_windows: bool = True,
-    ) -> bool:
-        """Partial checks on solution.
-
-        One can switch off some checks by setting the corresponding parameter to False.
-
-        Args:
-            variable:
-            duration:
-            calendar:
-            non_renewable_capacity:
-            precedence:
-            skill:
-            allocation:
-            time_lags:
-            time_windows:
-
-        Returns:
-
-        """
-        return (
-            # duration consistency
-            (not duration or variable.check_duration_constraints())
-            # calendar resources capacity violations (unary resources + skills + cumulative resources)
-            and (
-                not calendar
-                or variable.check_all_calendar_resource_capacity_constraints()
-            )
-            # non-renewable resource violation
-            and (
-                not non_renewable_capacity
-                or variable.check_all_non_renewable_resource_capacity_constraints()
-            )
-            # precedence relations
-            and (not precedence or variable.check_precedence_constraints())
-            # skill constraints
-            and (
-                not skill
-                or (
-                    variable.check_skill_constraints()
-                    and variable.check_only_one_skill_per_task_and_unary_resource()
-                    # Check consistency between compatibility/allocation/skill usage
-                    and variable.check_skill_usage_and_allocation_consistency()
-                )
-            )
-            and (not allocation or variable.check_allocation_consistency())
-            # time lags
-            and (not time_lags or variable.check_time_lags())
-            # time window
-            and (not time_windows or variable.check_time_windows())
-        )
-
     def get_solution_type(self) -> type[Solution]:
         return GenericSchedulingImplSolution
 
@@ -572,7 +510,11 @@ class GenericSchedulingImplSolution(
 
     problem: GenericSchedulingImplProblem
 
-    def __init__(self, problem: GenericSchedulingImplProblem, raw_sol: RawSolution):
+    def __init__(
+        self,
+        problem: GenericSchedulingImplProblem,
+        raw_sol: RawSolution[Task, UnaryResource, Skill],
+    ):
         super().__init__(problem)
         self.raw_sol = raw_sol
 

--- a/src/discrete_optimization/generic_tasks_tools/generic_scheduling_impl.py
+++ b/src/discrete_optimization/generic_tasks_tools/generic_scheduling_impl.py
@@ -68,6 +68,9 @@ class GenericSchedulingImplProblem(
         unary_resources_availabilities: Optional[
             dict[UnaryResource, UnaryAvailabilityIntervals]
         ] = None,
+        unary_resources_task_compatibility: Optional[
+            dict[Task, set[UnaryResource]]
+        ] = None,
         skills: Optional[set[Skill]] = None,
         non_skill_cumulative_resources: Optional[
             dict[CumulativeResource, int | AvailabilityIntervals]
@@ -106,9 +109,10 @@ class GenericSchedulingImplProblem(
                 Default to no precedence constraints. Note that a consolidated version of it will
                 be constructed using the time lags constraints.
             unary_resources: available unary resources.  Default to none.
-            unary_resources_skills: skill values of each unary resource. Mssing key => skill value = 0
+            unary_resources_skills: skill values of each unary resource. Missing key => skill value = 0
             unary_resources_availabilities: availability of unary resources on the form of list of intervals (start, end)
                 Missing key => always available.
+            unary_resources_task_compatibility: maps a task to its compatible unary resources. Missing key => all unary resources allowed.
             skills: available skills
             non_skill_cumulative_resources: cumulative resources (excluding skills) availabilities.
                 Format: either int => always available at the given max capacity,
@@ -173,6 +177,10 @@ class GenericSchedulingImplProblem(
             ] = {}
         else:
             self.unary_resources_availabilities = unary_resources_availabilities
+        if unary_resources_task_compatibility is None:
+            self.unary_resources_task_compatibility: dict[Task, set[UnaryResource]] = {}
+        else:
+            self.unary_resources_task_compatibility = unary_resources_task_compatibility
         if skills is None:
             self.skills: set[Skill] = set()
         else:
@@ -290,6 +298,17 @@ class GenericSchedulingImplProblem(
             return self.unary_resources_skills[unary_resource][skill]
         except KeyError:
             return 0
+
+    def is_compatible_task_unary_resource(
+        self, task: Task, unary_resource: UnaryResource
+    ) -> bool:
+        compatible_unary_resources = self.unary_resources_task_compatibility.get(
+            task, None
+        )
+        if compatible_unary_resources is None:
+            return super().is_compatible_task_unary_resource(task, unary_resource)
+        else:
+            return unary_resource in compatible_unary_resources
 
     def get_cumulative_resource_consumption(
         self, resource: CumulativeResource, task: Task, mode: int

--- a/src/discrete_optimization/generic_tasks_tools/generic_scheduling_impl.py
+++ b/src/discrete_optimization/generic_tasks_tools/generic_scheduling_impl.py
@@ -3,13 +3,18 @@
 #  LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
-from collections.abc import Callable, Hashable, Iterable
+from collections.abc import Callable, Container, Hashable, Iterable
 from copy import deepcopy
 from typing import Optional
 
+import numpy as np
 import wrapt
 
-from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
+from discrete_optimization.generic_tasks_tools.calendar_resource import (
+    convert_availability_intervals_to_calendar,
+    convert_calendar_to_availability_intervals,
+)
+from discrete_optimization.generic_tasks_tools.enums import MinOrMax, StartOrEnd
 from discrete_optimization.generic_tasks_tools.generic_scheduling import (
     GenericSchedulingProblem,
     GenericSchedulingSolution,
@@ -434,10 +439,6 @@ class GenericSchedulingImplProblem(
     def tasks_list(self) -> list[Task]:
         return self._tasks_list
 
-    def satisfy(self, variable: Solution) -> bool:
-        assert isinstance(variable, GenericSchedulingImplSolution)
-        return self.satisfy_partial(variable=variable)
-
     def get_solution_type(self) -> type[Solution]:
         return GenericSchedulingImplSolution
 
@@ -523,6 +524,231 @@ class GenericSchedulingImplProblem(
             return self.unary_resource_costs[task][mode][unary_resource]
         except KeyError:
             return super().get_unary_resource_cost(task, mode, unary_resource)
+
+    def create_subproblem_from_partial_solution(
+        self, partial_solution: RawSolution[Task, UnaryResource, Skill]
+    ) -> GenericSchedulingImplProblem:
+        """Create a subproblem according to a partial solution.
+
+        - Tasks already scheduled are removed from subproblem.
+        - Add time windows constraints to model timelags/precedence constraints with removed tasks.
+        - Update resource calendars with scheduled allocations
+        - Update non-renewable resources max capacities
+        - Transform no_overlap constraints into forbidden intervals constraints
+
+        """
+        scheduled_tasks = partial_solution.task_variables
+
+        # restrict tasks list
+        new_tasks_list = [
+            task for task in self.tasks_list if task not in scheduled_tasks
+        ]
+        new_durations_per_mode = {
+            task: self.durations_per_mode[task] for task in new_tasks_list
+        }
+        new_successors = {
+            task: [
+                next_task
+                for next_task in next_tasks
+                if next_task not in scheduled_tasks
+            ]
+            for task, next_tasks in self.successors.items()
+            if task not in scheduled_tasks
+        }
+        new_start_to_start_min_time_lags = _restrict_timelags(
+            self.start_to_start_min_time_lags, tasks_to_remove=scheduled_tasks
+        )
+        new_end_to_start_min_time_lags = _restrict_timelags(
+            self.end_to_start_min_time_lags, tasks_to_remove=scheduled_tasks
+        )
+        new_start_to_end_min_time_lags = _restrict_timelags(
+            self.start_to_end_min_time_lags, tasks_to_remove=scheduled_tasks
+        )
+        new_end_to_end_min_time_lags = _restrict_timelags(
+            self.end_to_end_min_time_lags, tasks_to_remove=scheduled_tasks
+        )
+
+        # translate time lags/precedence constraints involving missing tasks into time windows constraints
+        new_time_windows_nested: dict[tuple[Task, StartOrEnd, MinOrMax], set[int]] = {
+            (task, start_or_end, min_or_max): {
+                # at least the original bound
+                self.get_task_bound(
+                    task=task,
+                    start_or_end=start_or_end,
+                    min_or_max=min_or_max,
+                )
+            }
+            for task in new_tasks_list
+            for start_or_end in StartOrEnd
+            for min_or_max in MinOrMax
+        }
+        for task1_start_or_end in StartOrEnd:
+            for task2_start_or_end in StartOrEnd:
+                for min_or_max in MinOrMax:
+                    for task1, task2, offset in self.get_consolidated_time_lags(
+                        task1_start_or_end=task1_start_or_end,
+                        task2_start_or_end=task2_start_or_end,
+                        min_or_max=min_or_max,
+                    ):
+                        if task1 in scheduled_tasks and task2 not in scheduled_tasks:
+                            scheduled_task = task1
+                            task = task2
+                            scheduled_task_start_or_end = task1_start_or_end
+                            task_start_or_end = task2_start_or_end
+                            scheduled_offset = offset
+                            task_min_or_max = min_or_max
+                        elif task1 not in scheduled_tasks and task2 in scheduled_tasks:
+                            scheduled_task = task2
+                            task = task1
+                            scheduled_task_start_or_end = task2_start_or_end
+                            task_start_or_end = task1_start_or_end
+                            scheduled_offset = -offset
+                            task_min_or_max = ~min_or_max
+
+                        else:
+                            continue
+
+                        bound_from_schedule = (
+                            scheduled_tasks[scheduled_task].get_start_or_end(
+                                scheduled_task_start_or_end
+                            )
+                            + scheduled_offset
+                        )
+                        new_time_windows_nested[
+                            (task, task_start_or_end, task_min_or_max)
+                        ].add(bound_from_schedule)
+        new_time_windows = {
+            task: (
+                max(new_time_windows_nested[(task, StartOrEnd.START, MinOrMax.MIN)]),
+                max(new_time_windows_nested[(task, StartOrEnd.END, MinOrMax.MIN)]),
+                min(new_time_windows_nested[(task, StartOrEnd.START, MinOrMax.MAX)]),
+                min(new_time_windows_nested[(task, StartOrEnd.END, MinOrMax.MAX)]),
+            )
+            for task in new_tasks_list
+        }
+
+        # Update non-renewable resources max capacities
+        new_non_renewable_resources = {
+            resource: old_max_capacity
+            - sum(
+                self.get_non_renewable_resource_consumption(
+                    resource=resource, task=task, mode=task_variable.mode
+                )
+                for task, task_variable in scheduled_tasks.items()
+            )
+            for resource, old_max_capacity in self.non_renewable_resources.items()
+        }
+
+        # Update resources availabilities
+        calendar_resources = (
+            self.unary_resources_list + self.non_skill_cumulative_resources_list
+        )
+        resources_calendars = {
+            resource: np.array(
+                convert_availability_intervals_to_calendar(
+                    intervals=self.get_resource_availabilities(resource=resource),
+                    horizon=self.horizon,
+                ),
+                dtype=int,
+            )
+            for resource in calendar_resources
+        }
+        for task, task_variable in scheduled_tasks.items():
+            start = task_variable.start
+            end = task_variable.end
+            for resource in self.unary_resources_list:
+                if resource in task_variable.allocated:
+                    resources_calendars[resource][start:end] -= 1
+            for resource in self.non_skill_cumulative_resources_list:
+                conso = self.get_cumulative_resource_consumption(
+                    resource=resource, task=task, mode=task_variable.mode
+                )
+                resources_calendars[resource][start:end] -= conso
+        new_non_skill_cumulative_resources = {
+            resource: convert_calendar_to_availability_intervals(
+                calendar=resources_calendars[resource],
+                horizon=self.horizon,
+            )
+            for resource in self.non_skill_cumulative_resources_list
+        }
+        new_unary_resources_availabilities = {
+            resource: [
+                (start, end)
+                for start, end, value in convert_calendar_to_availability_intervals(
+                    calendar=resources_calendars[resource],
+                    horizon=self.horizon,
+                )
+                if value > 0
+            ]
+            for resource in self.unary_resources_list
+        }
+
+        # Transform no_overlap constraints into forbidden intervals constraints
+        new_no_overlap_sets: set[frozenset[Task]] = set()
+        new_forbidden_intervals: dict[Task, list[tuple[int, int]]] = {
+            task: list(self.get_forbidden_intervals(task=task))
+            for task in self.tasks_list
+        }
+        for not_overlapping_tasks in self.get_no_overlap():
+            if not_overlapping_tasks.isdisjoint(scheduled_tasks):
+                # no removed tasks in it => ok
+                new_no_overlap_sets.add(not_overlapping_tasks)
+            else:
+                # remove scheduled tasks and replace them by forbidden intervals
+                new_not_overlapping_tasks = not_overlapping_tasks.difference(
+                    scheduled_tasks
+                )
+                scheduled_tasks_in_not_overlapping_tasks = (
+                    not_overlapping_tasks.difference(new_not_overlapping_tasks)
+                )
+                new_no_overlap_sets.add(new_not_overlapping_tasks)
+                for task in new_not_overlapping_tasks:
+                    new_forbidden_intervals[task].extend(
+                        [
+                            (
+                                scheduled_tasks[scheduled_task].start,
+                                scheduled_tasks[scheduled_task].end,
+                            )
+                            for scheduled_task in scheduled_tasks_in_not_overlapping_tasks
+                        ]
+                    )
+
+        return GenericSchedulingImplProblem(
+            horizon=self.horizon,
+            durations_per_mode=new_durations_per_mode,
+            resource_consumptions=self.resource_consumptions,
+            successors=new_successors,
+            unary_resources=self.unary_resources,
+            unary_resources_skills=self.unary_resources_skills,
+            unary_resources_availabilities=new_unary_resources_availabilities,
+            unary_resources_task_compatibility=self.unary_resources_task_compatibility,
+            skills=self.skills,
+            non_skill_cumulative_resources=new_non_skill_cumulative_resources,
+            non_renewable_resources=new_non_renewable_resources,
+            time_windows=new_time_windows,
+            start_to_start_min_time_lags=new_start_to_start_min_time_lags,
+            start_to_end_min_time_lags=new_start_to_end_min_time_lags,
+            end_to_start_min_time_lags=new_end_to_start_min_time_lags,
+            end_to_end_min_time_lags=new_end_to_end_min_time_lags,
+            no_overlap_sets=new_no_overlap_sets,
+            forbidden_intervals=new_forbidden_intervals,
+            objective=self.weighted_objectives,
+            custom_evaluate_fn=self.custom_evaluate_fn,
+            objective_resource_weights=self.objective_resource_weights,
+            mode_costs=self.mode_costs,
+            unary_resource_costs=self.unary_resource_costs,
+            compute_time_penalty=self.compute_time_penalty,
+        )
+
+
+def _restrict_timelags(
+    timelags: list[tuple[Task, Task, int]], tasks_to_remove: Container[Task]
+) -> list[tuple[Task, Task, int]]:
+    return [
+        (task1, task2, offset)
+        for task1, task2, offset in timelags
+        if (task1 not in tasks_to_remove) and (task2 not in tasks_to_remove)
+    ]
 
 
 class GenericSchedulingImplSolution(

--- a/src/discrete_optimization/generic_tasks_tools/generic_scheduling_impl.py
+++ b/src/discrete_optimization/generic_tasks_tools/generic_scheduling_impl.py
@@ -84,6 +84,7 @@ class GenericSchedulingImplProblem(
         end_to_start_min_time_lags: Optional[list[tuple[Task, Task, int]]] = None,
         end_to_end_min_time_lags: Optional[list[tuple[Task, Task, int]]] = None,
         no_overlap_sets: Optional[set[frozenset[Task]]] = None,
+        forbidden_intervals: Optional[dict[Task, list[tuple[int, int]]]] = None,
         objective: Objective | Iterable[tuple[Objective, int]] = Objective.MAKESPAN,
         custom_evaluate_fn: Optional[
             Callable[[GenericSchedulingImplSolution], int]
@@ -134,6 +135,7 @@ class GenericSchedulingImplProblem(
                 task1, task2, offset meaning end(task1) + offset <= end(task2)
                 Note that using negative offset can model end-to-end max time lags.
             no_overlap_sets: a set of (set of tasks that should not overlap together)
+            forbidden_intervals: maps task to forbidden intervals that cannot overlap with it. Missing key => no forbidden intervals.
             objective: objective for the problem. Default to minimization of makespan.
                 Either an iterable of (objective, weight) so that the problem should *maximize* the aggregated objective
                 resulting from weighted sum of objectives, or a single objective in which case we use the corresponding
@@ -221,6 +223,10 @@ class GenericSchedulingImplProblem(
             self.no_overlap_sets = set()
         else:
             self.no_overlap_sets = no_overlap_sets
+        if forbidden_intervals is None:
+            self.forbidden_intervals = {}
+        else:
+            self.forbidden_intervals = forbidden_intervals
         if isinstance(objective, Objective):
             self.weighted_objectives: tuple[tuple[Objective, int], ...] = (
                 (objective, OBJECTIVE_DEFAULT_WEIGHTS[objective]),
@@ -320,6 +326,9 @@ class GenericSchedulingImplProblem(
 
     def get_no_overlap(self) -> set[frozenset[Task]]:
         return self.no_overlap_sets
+
+    def get_forbidden_intervals(self, task: Task) -> list[tuple[int, int]]:
+        return self.forbidden_intervals.get(task, [])
 
     @wrapt.lru_cache(maxsize=None)
     def get_resource_availabilities(

--- a/src/discrete_optimization/generic_tasks_tools/generic_scheduling_utils.py
+++ b/src/discrete_optimization/generic_tasks_tools/generic_scheduling_utils.py
@@ -10,6 +10,7 @@ from typing import Any, Generic
 
 from discrete_optimization.generic_tasks_tools.allocation import UnaryResource
 from discrete_optimization.generic_tasks_tools.base import Task
+from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
 from discrete_optimization.generic_tasks_tools.skill import Skill
 
 
@@ -27,6 +28,12 @@ class TaskVariable(Generic[UnaryResource, Skill]):
         default_factory=dict
     )  # additional information if needed
 
+    def get_start_or_end(self, start_or_end: StartOrEnd) -> int:
+        if start_or_end == StartOrEnd.START:
+            return self.start
+        else:
+            return self.end
+
 
 @dataclass
 class RawSolution(Generic[Task, UnaryResource, Skill]):
@@ -34,10 +41,20 @@ class RawSolution(Generic[Task, UnaryResource, Skill]):
 
     Does not inherit from d-o `Solution` class.
 
+    You can do `raw_sol_1 | raw_sol_2`, it will return another raw solution merging both `task_variables` dictionaries,
+    but dropping metadata.
+
     ."""
 
     task_variables: dict[Task, TaskVariable[UnaryResource, Skill]]
     metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __or__(
+        self, other: RawSolution[Task, UnaryResource, Skill]
+    ) -> RawSolution[Task, UnaryResource, Skill]:
+        return RawSolution(
+            task_variables=self.task_variables | other.task_variables,
+        )
 
 
 class Objective(Enum):

--- a/src/discrete_optimization/generic_tasks_tools/no_overlap.py
+++ b/src/discrete_optimization/generic_tasks_tools/no_overlap.py
@@ -28,13 +28,27 @@ class NoOverlapProblem(SchedulingProblem[Task]):
         """
         ...
 
+    def get_forbidden_intervals(self, task: Task) -> list[tuple[int, int]]:
+        """Get fixed intervals that should not overlap with given task.
+
+        Default to empty list. To be overridden in child classes.
+
+        Args:
+            task:
+
+        Returns:
+            List of intervals (start, end) with start <= end (will not be checked)
+
+        """
+        return []
+
 
 class NoOverlapSolution(SchedulingSolution[Task]):
     """Solution for problem with precedence constraints."""
 
     problem: NoOverlapProblem[Task]
 
-    def check_no_overlap(self):
+    def check_no_overlap(self) -> bool:
         # Doesnt work perfectly for zero duration tasks,
         # this is more equivalent to cumulative with capacity 1.
         for tasks in self.problem.get_no_overlap():
@@ -46,10 +60,41 @@ class NoOverlapSolution(SchedulingSolution[Task]):
                 if end == st:
                     continue
                 if np.max(cumul_use[(st - min_start) : (end - min_start)]) == 1:
-                    logger.info(f"{task} has overlap inside {tasks}")
+                    logger.debug(f"Task {task} has overlap inside {tasks}")
                     return False
                 cumul_use[(st - min_start) : (end - min_start)] += 1
         return True
+
+    def check_forbidden_intervals(self) -> bool:
+        for task in self.problem.tasks_list:
+            intervals = self.problem.get_forbidden_intervals(task)
+            if len(intervals) > 0:
+                start1 = self.get_start_time(task)
+                end1 = self.get_end_time(task)
+                if any(
+                    _check_intervals_intersect(start1, end1, start2, end2)
+                    for start2, end2 in intervals
+                ):
+                    logger.debug(f"Task {task} overlaps with its forbidden intervals.")
+                    return False
+        return True
+
+
+def _check_intervals_intersect(start1: int, end1: int, start2: int, end2: int) -> bool:
+    """Check whether two intervals are intersecting
+
+    We assume that start1<end1 and start2<end2.
+
+    Args:
+        start1: start of first interval
+        end1: end of first interval
+        start2: start of second interval
+        end2: end of second interval
+
+    Returns:
+
+    """
+    return not ((end1 <= start2) or (end2 <= start1))
 
 
 class WithoutNoOverlapProblem(NoOverlapProblem[Task]):

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto.py
@@ -945,6 +945,8 @@ class GenericSchedulingAutoCpSatSolver(
             self.create_energy_constraints(branches=branches)
         # no overlap
         self.create_no_overlap_constraints()
+        # forbidden intervals
+        self.create_forbidden_intervals_constraints()
 
     def _set_objective(self) -> None:
         if self.objective == Objective.CUSTOM:

--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/no_overlap.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/no_overlap.py
@@ -2,7 +2,7 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 from discrete_optimization.generic_tasks_tools.base import Task
-from discrete_optimization.generic_tasks_tools.no_overlap_scheduling import (
+from discrete_optimization.generic_tasks_tools.no_overlap import (
     NoOverlapProblem,
 )
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.scheduling import (
@@ -21,3 +21,17 @@ class NoOverlapCpSatSolver(SchedulingCpSatSolver[Task]):
         for tasks in self.problem.get_no_overlap():
             intervals = [self.get_task_interval(task) for task in tasks]
             self.cp_model.add_no_overlap(intervals)
+
+    def create_forbidden_intervals_constraints(self):
+        for task in self.problem.tasks_list:
+            intervals = self.problem.get_forbidden_intervals(task)
+            if len(intervals) > 0:
+                self.cp_model.add_no_overlap(
+                    [self.get_task_interval(task)]
+                    + [
+                        self.cp_model.new_interval_var(
+                            start=start, end=end, size=end - start, name=""
+                        )
+                        for start, end in intervals
+                    ]
+                )

--- a/src/discrete_optimization/generic_tasks_tools/timewindow.py
+++ b/src/discrete_optimization/generic_tasks_tools/timewindow.py
@@ -5,7 +5,7 @@ import logging
 from typing import Generic
 
 from discrete_optimization.generic_tasks_tools.base import Task
-from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
+from discrete_optimization.generic_tasks_tools.enums import MinOrMax, StartOrEnd
 from discrete_optimization.generic_tasks_tools.scheduling import (
     SchedulingProblem,
     SchedulingSolution,
@@ -16,6 +16,28 @@ logger = logging.getLogger(__name__)
 
 class TimewindowProblem(SchedulingProblem[Task], Generic[Task]):
     """Class for problem having time windows between tasks."""
+
+    def get_task_bound(
+        self, task: Task, start_or_end: StartOrEnd, min_or_max: MinOrMax
+    ) -> int:
+        """Get a lower or upper bound on a task start or end.
+
+        Args:
+            task:
+            start_or_end:
+            min_or_max: min -> lower bound, max -> upper bound
+
+        Returns:
+
+        """
+        if min_or_max == MinOrMax.MIN:
+            return self.get_task_start_or_end_lower_bound(
+                task=task, start_or_end=start_or_end
+            )
+        else:
+            return self.get_task_start_or_end_upper_bound(
+                task=task, start_or_end=start_or_end
+            )
 
     def get_task_start_or_end_lower_bound(
         self, task: Task, start_or_end: StartOrEnd

--- a/src/discrete_optimization/rcpsp/problem.py
+++ b/src/discrete_optimization/rcpsp/problem.py
@@ -29,7 +29,7 @@ from discrete_optimization.generic_tasks_tools.enums import StartOrEnd
 from discrete_optimization.generic_tasks_tools.generic_scheduling import (
     GenericSchedulingProblem,
 )
-from discrete_optimization.generic_tasks_tools.no_overlap_scheduling import (
+from discrete_optimization.generic_tasks_tools.no_overlap import (
     NoOverlapProblem,
     WithoutNoOverlapProblem,
 )

--- a/src/discrete_optimization/rcpsp_multiskill/problem.py
+++ b/src/discrete_optimization/rcpsp_multiskill/problem.py
@@ -30,7 +30,7 @@ from discrete_optimization.generic_tasks_tools.generic_scheduling import (
     GenericSchedulingProblem,
     GenericSchedulingSolution,
 )
-from discrete_optimization.generic_tasks_tools.no_overlap_scheduling import (
+from discrete_optimization.generic_tasks_tools.no_overlap import (
     WithoutNoOverlapProblem,
 )
 from discrete_optimization.generic_tools.do_problem import (

--- a/src/discrete_optimization/shop/jsp/problem.py
+++ b/src/discrete_optimization/shop/jsp/problem.py
@@ -12,7 +12,7 @@ from discrete_optimization.generic_tasks_tools.multimode import (
 from discrete_optimization.generic_tasks_tools.multimode_scheduling import (
     SinglemodeSchedulingProblem,
 )
-from discrete_optimization.generic_tasks_tools.no_overlap_scheduling import (
+from discrete_optimization.generic_tasks_tools.no_overlap import (
     WithoutNoOverlapProblem,
 )
 from discrete_optimization.shop.base import AnyShopSolution, CommonShopProblem, Task

--- a/src/discrete_optimization/workforce/scheduling/problem.py
+++ b/src/discrete_optimization/workforce/scheduling/problem.py
@@ -26,7 +26,7 @@ from discrete_optimization.generic_tasks_tools.multimode import (
 from discrete_optimization.generic_tasks_tools.multimode_scheduling import (
     SinglemodeSchedulingProblem,
 )
-from discrete_optimization.generic_tasks_tools.no_overlap_scheduling import (
+from discrete_optimization.generic_tasks_tools.no_overlap import (
     WithoutNoOverlapProblem,
 )
 from discrete_optimization.generic_tasks_tools.non_renewable_resource import (

--- a/tests/generic_tasks_tools/solvers/cpsat/test_auto.py
+++ b/tests/generic_tasks_tools/solvers/cpsat/test_auto.py
@@ -21,7 +21,7 @@ from discrete_optimization.generic_tasks_tools.generic_scheduling_utils import (
     RawSolution,
     TaskVariable,
 )
-from discrete_optimization.generic_tasks_tools.no_overlap_scheduling import (
+from discrete_optimization.generic_tasks_tools.no_overlap import (
     WithoutNoOverlapProblem,
 )
 from discrete_optimization.generic_tasks_tools.skill import (

--- a/tests/generic_tasks_tools/solvers/cpsat/test_auto_impl.py
+++ b/tests/generic_tasks_tools/solvers/cpsat/test_auto_impl.py
@@ -232,6 +232,27 @@ def test_start_to_end_time_lag():
     assert problem.satisfy(solution)
 
 
+def test_no_overlap():
+    problem = GenericSchedulingImplProblem(
+        horizon=10,
+        durations_per_mode={
+            "task-1": {
+                0: 2,
+            },
+            "task-2": {
+                0: 4,
+            },
+        },
+        no_overlap_sets={frozenset({"task-1", "task-2"})},
+        forbidden_intervals={"task-1": [(1, 3)]},
+    )
+    solver = GenericSchedulingAutoCpSatImplSolver(problem=problem)
+    sol: GenericSchedulingImplSolution = solver.solve().get_best_solution()
+    assert problem.satisfy(sol)
+    kpi = problem.evaluate(sol)
+    assert kpi["makespan"] == 6
+
+
 def test_rcpsp_simple():
     mode_details = {
         1: {1: {"duration": 0}},  # dummy start

--- a/tests/generic_tasks_tools/test_generic_scheduling_impl.py
+++ b/tests/generic_tasks_tools/test_generic_scheduling_impl.py
@@ -74,6 +74,23 @@ def problem_wo_skills():
     )
 
 
+@fixture
+def problem_no_overlap():
+    return GenericSchedulingImplProblem(
+        horizon=10,
+        durations_per_mode={
+            "task-1": {
+                0: 2,
+            },
+            "task-2": {
+                0: 4,
+            },
+        },
+        no_overlap_sets={frozenset({"task-1", "task-2"})},
+        forbidden_intervals={"task-1": [(4, 6)]},
+    )
+
+
 def test_problem(problem_wo_skills, caplog):
     problem = problem_wo_skills
     sol = GenericSchedulingImplSolution(
@@ -245,20 +262,8 @@ def test_task_bounds_cpm(problem_wo_skills):
     }
 
 
-def test_no_overlap(caplog):
-    problem = GenericSchedulingImplProblem(
-        horizon=10,
-        durations_per_mode={
-            "task-1": {
-                0: 2,
-            },
-            "task-2": {
-                0: 4,
-            },
-        },
-        no_overlap_sets={frozenset({"task-1", "task-2"})},
-        forbidden_intervals={"task-1": [(4, 6)]},
-    )
+def test_no_overlap(problem_no_overlap, caplog):
+    problem = problem_no_overlap
     # nok no overlap
     sol = GenericSchedulingImplSolution(
         problem=problem,
@@ -310,3 +315,234 @@ def test_no_overlap(caplog):
         ),
     )
     assert problem.satisfy(sol)
+
+
+def test_subproblem_from_partial_solution(caplog):
+    problem = GenericSchedulingImplProblem(
+        horizon=20,
+        durations_per_mode={
+            "task-1": {
+                0: 1,
+                1: 3,
+            },
+            "task-2": {
+                0: 4,
+            },
+            "task-3": {
+                0: 2,
+                1: 2,
+            },
+        },
+        resource_consumptions={
+            "task-1": {
+                0: {
+                    "non_renewable_resource": 2,
+                },
+                1: {
+                    "non_renewable_resource": 1,
+                },
+            },
+            "task-2": {
+                0: {
+                    "cumulative_resource": 2,
+                },
+            },
+            "task-3": {
+                0: {
+                    "cumulative_resource": 1,
+                },
+                1: {
+                    "non_renewable_resource": 1,
+                },
+            },
+        },
+        successors={"task-1": ["task-2", "task-3"]},
+        end_to_end_min_time_lags=[("task-3", "task-2", -1)],
+        unary_resources={"worker1", "worker2"},
+        unary_resources_availabilities={
+            "worker1": [(1, 4)],
+            "worker2": [(3, 18)],
+        },
+        non_skill_cumulative_resources={
+            "cumulative_resource": [
+                (3, 5, 1),
+                (5, 12, 2),
+                (12, 20, 3),
+            ],
+        },
+        non_renewable_resources={
+            "non_renewable_resource": 1,
+        },
+    )
+
+    # create subproblem
+    partial_solution = RawSolution(
+        task_variables={
+            "task-1": TaskVariable(
+                start=3, end=6, mode=1, allocated={"worker2": set()}
+            ),
+            "task-2": TaskVariable(
+                start=10, end=14, mode=0, allocated={"worker2": set()}
+            ),
+        }
+    )
+    subproblem = problem.create_subproblem_from_partial_solution(partial_solution)
+    assert "task-1" not in subproblem.tasks_list
+    assert "task-3" in subproblem.tasks_list
+    print(subproblem.time_windows)
+    print(subproblem.unary_resources_availabilities)
+    print(subproblem.non_skill_cumulative_resources)
+
+    # subsol ok
+    subsol = GenericSchedulingImplSolution(
+        problem=subproblem,
+        raw_sol=RawSolution(
+            task_variables={
+                "task-3": TaskVariable(
+                    start=6, end=8, mode=0, allocated={"worker2": set()}
+                ),
+            }
+        ),
+    )
+    assert subproblem.satisfy(subsol)
+    complete_sol = GenericSchedulingImplSolution(
+        problem=problem, raw_sol=partial_solution | subsol.raw_sol
+    )
+    assert problem.satisfy(complete_sol)
+
+    # subsol nok precedence
+    subsol = GenericSchedulingImplSolution(
+        problem=subproblem,
+        raw_sol=RawSolution(
+            task_variables={
+                "task-3": TaskVariable(start=5, end=7, mode=0, allocated={}),
+            }
+        ),
+    )
+    assert not subproblem.satisfy(subsol)
+    complete_sol = GenericSchedulingImplSolution(
+        problem=problem, raw_sol=partial_solution | subsol.raw_sol
+    )
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        assert not problem.satisfy(complete_sol)
+    assert "precedence" in caplog.text
+
+    # subsol nok unary_resource
+    subsol = GenericSchedulingImplSolution(
+        problem=subproblem,
+        raw_sol=RawSolution(
+            task_variables={
+                "task-3": TaskVariable(
+                    start=11, end=13, mode=0, allocated={"worker2": set()}
+                ),
+            }
+        ),
+    )
+    assert not subproblem.satisfy(subsol)
+    complete_sol = GenericSchedulingImplSolution(
+        problem=problem, raw_sol=partial_solution | subsol.raw_sol
+    )
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        assert not problem.satisfy(complete_sol)
+    assert "worker2" in caplog.text
+
+    # subsol nok non-renewable ressource
+    subsol = GenericSchedulingImplSolution(
+        problem=subproblem,
+        raw_sol=RawSolution(
+            task_variables={
+                "task-3": TaskVariable(start=9, end=11, mode=1),
+            }
+        ),
+    )
+    assert not subproblem.satisfy(subsol)
+    complete_sol = GenericSchedulingImplSolution(
+        problem=problem, raw_sol=partial_solution | subsol.raw_sol
+    )
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        assert not problem.satisfy(complete_sol)
+    assert "non_renewable_resource" in caplog.text
+
+    # subsol nok cumulative ressource
+    subsol = GenericSchedulingImplSolution(
+        problem=subproblem,
+        raw_sol=RawSolution(
+            task_variables={
+                "task-3": TaskVariable(start=9, end=11, mode=0),
+            }
+        ),
+    )
+    assert not subproblem.satisfy(subsol)
+    complete_sol = GenericSchedulingImplSolution(
+        problem=problem, raw_sol=partial_solution | subsol.raw_sol
+    )
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        assert not problem.satisfy(complete_sol)
+    assert "cumulative_resource" in caplog.text
+
+    # subsol nok time lag
+    subsol = GenericSchedulingImplSolution(
+        problem=subproblem,
+        raw_sol=RawSolution(
+            task_variables={
+                "task-3": TaskVariable(start=14, end=16, mode=0),
+            }
+        ),
+    )
+    assert not subproblem.satisfy(subsol)
+    complete_sol = GenericSchedulingImplSolution(
+        problem=problem, raw_sol=partial_solution | subsol.raw_sol
+    )
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        assert not problem.satisfy(complete_sol)
+    assert "time lag" in caplog.text
+
+
+def test_subproblem_with_no_overlap_from_partial_solution(problem_no_overlap, caplog):
+    problem = problem_no_overlap
+
+    # create subproblem
+    partial_solution = RawSolution(
+        task_variables={
+            "task-1": TaskVariable(start=1, end=3, mode=0),
+        }
+    )
+    subproblem = problem.create_subproblem_from_partial_solution(partial_solution)
+
+    # subsol ok
+    subsol = GenericSchedulingImplSolution(
+        problem=subproblem,
+        raw_sol=RawSolution(
+            task_variables={
+                "task-2": TaskVariable(start=3, end=7, mode=0),
+            }
+        ),
+    )
+    assert subproblem.satisfy(subsol)
+    complete_sol = GenericSchedulingImplSolution(
+        problem=problem, raw_sol=partial_solution | subsol.raw_sol
+    )
+    assert problem.satisfy(complete_sol)
+
+    # subsol nok no_overlap
+    subsol = GenericSchedulingImplSolution(
+        problem=subproblem,
+        raw_sol=RawSolution(
+            task_variables={
+                "task-2": TaskVariable(start=2, end=6, mode=0),
+            }
+        ),
+    )
+    assert not subproblem.satisfy(subsol)
+    complete_sol = GenericSchedulingImplSolution(
+        problem=problem, raw_sol=partial_solution | subsol.raw_sol
+    )
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        assert not problem.satisfy(complete_sol)
+    assert "overlap" in caplog.text

--- a/tests/generic_tasks_tools/test_generic_scheduling_impl.py
+++ b/tests/generic_tasks_tools/test_generic_scheduling_impl.py
@@ -243,3 +243,70 @@ def test_task_bounds_cpm(problem_wo_skills):
         "task-1": (0, 1, 3, 4),
         "task-2": (1, 5, 4, 8),
     }
+
+
+def test_no_overlap(caplog):
+    problem = GenericSchedulingImplProblem(
+        horizon=10,
+        durations_per_mode={
+            "task-1": {
+                0: 2,
+            },
+            "task-2": {
+                0: 4,
+            },
+        },
+        no_overlap_sets={frozenset({"task-1", "task-2"})},
+        forbidden_intervals={"task-1": [(4, 6)]},
+    )
+    # nok no overlap
+    sol = GenericSchedulingImplSolution(
+        problem=problem,
+        raw_sol=RawSolution(
+            task_variables={
+                "task-1": TaskVariable(start=1, end=3, mode=0),
+                "task-2": TaskVariable(start=2, end=6, mode=0),
+            }
+        ),
+    )
+    caplog.clear()
+    with caplog.at_level(level=logging.DEBUG):
+        assert not problem.satisfy(sol)
+    assert "overlap" in caplog.text
+
+    # nok forbidden intervals
+    sol = GenericSchedulingImplSolution(
+        problem=problem,
+        raw_sol=RawSolution(
+            task_variables={
+                "task-1": TaskVariable(start=4, end=6, mode=0),
+                "task-2": TaskVariable(start=0, end=4, mode=0),
+            }
+        ),
+    )
+    caplog.clear()
+    with caplog.at_level(level=logging.DEBUG):
+        assert not problem.satisfy(sol)
+    assert "forbidden" in caplog.text
+
+    # ok
+    sol = GenericSchedulingImplSolution(
+        problem=problem,
+        raw_sol=RawSolution(
+            task_variables={
+                "task-1": TaskVariable(start=1, end=3, mode=0),
+                "task-2": TaskVariable(start=3, end=7, mode=0),
+            }
+        ),
+    )
+    assert problem.satisfy(sol)
+    sol = GenericSchedulingImplSolution(
+        problem=problem,
+        raw_sol=RawSolution(
+            task_variables={
+                "task-1": TaskVariable(start=7, end=9, mode=0),
+                "task-2": TaskVariable(start=3, end=7, mode=0),
+            }
+        ),
+    )
+    assert problem.satisfy(sol)


### PR DESCRIPTION
A partial solution is here a solution where only a part of tasks are scheduled but with all features (start, end, mode, allocated resources and skills). It translated into a `RawSolution` whose `task_variables` contains only a subset of tasks.

We define the subproblem with the following steps:
- Tasks already scheduled are removed from subproblem.
- Add time windows constraints to model timelags/precedence constraints with removed tasks.
- Update resource calendars with scheduled allocations
- Update non-renewable resources max capacities
- Transform no_overlap constraints into forbidden intervals constraints

To do sol we add some features to  `GenericSchedulingImplProblem`:
- add possibility to forbid intervals for a given task
- add possibility to set compatibility between tasks and unary resources

We also add the possibility to query start or end of task  by using `StartOrEnd`, and task bound with `StartOrEnd` + `MinOrMax`.
Some operator are implemented so that you can do
- `~StartOrEnd.START` -> `StartOrEnd.END`
- `~MinOrMax.MIN` -> `MinOrMax.MAX`
- `raw_sol1 | raw_sol2` which will return a new `RawSolution` with the union of both dictionaries mapping tasks to their corresponding variables. It simplifies the reconstruction of a complete solution from initial partial solution + solution of the new subproblem. See tests for examples.