### PR TITLE
Stop testing docstrings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -251,9 +251,6 @@ jobs:
             --cov-report term \
             -v --durations=0 --durations-min=2 \
             tests
-      - name: Test examples in docstrings
-        run: |
-          pytest --doctest-modules src -v
       - name: Upload coverage report as artifact
         if: ${{ matrix.coverage }}
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
As examples are often incomplete (problem not created for instance)