### PR TITLE
Add timeouts to all jobs in github actions workflows

### DIFF
--- a/.github/workflows/build-doc.yml
+++ b/.github/workflows/build-doc.yml
@@ -41,6 +41,7 @@ on:
 
 jobs:
   build-doc:
+    timeout-minutes: 5
     outputs:
       doc_version: ${{ steps.sphinx-build.outputs.doc_version }}
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
 
   linters:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - name: create requirements.txt so that pip cache with setup-python works
@@ -42,6 +43,7 @@ jobs:
   trigger:
     # store trigger reason
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       is_release: ${{ steps.reason.outputs.is_release }}
       is_push_on_default_branch: ${{ steps.reason.outputs.is_push_on_default_branch }}
@@ -54,6 +56,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: trigger
+    timeout-minutes: 5
     outputs:
       do_version: ${{ steps.get_library_version.outputs.version }}
     steps:
@@ -85,6 +88,7 @@ jobs:
           echo "version=$version" >> $GITHUB_OUTPUT
 
   test:
+    timeout-minutes: 60
     needs: build
     strategy:
       fail-fast: false
@@ -126,27 +130,33 @@ jobs:
         shell: bash
     steps:
       - name: Checkout discrete-optimization source code
+        timeout-minutes: 5
         uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
+        timeout-minutes: 5
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
           cache-dependency-path: pyproject.toml
       - name: Download artifacts
+        timeout-minutes: 5
         uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist
       - name: Install only discrete-optimization without extras
+        timeout-minutes: 5
         run: |
           wheelfile=$(ls ./dist/discrete_optimization*.whl)
           python -m pip install -U pip
           pip install ${wheelfile}
           pip list
       - name: Check all imports are working
+        timeout-minutes: 5
         run: python tests/test_import_all_submodules.py
       - name: Check minizinc based solvers fails without minizinc binary
+        timeout-minutes: 5
         run: |
           python -c "
           try:
@@ -158,39 +168,48 @@ jobs:
             raise AssertionError('We should not be able to `find_right_minizinc_solver_name()` without minizinc being installed.')
           "
       - name: Create bin/
+        timeout-minutes: 5
         run: mkdir -p bin
       - name: Minizinc prerequisites
+        timeout-minutes: 5
         run: |
           ${{ matrix.minizinc_prerequisites_cmdline }}
       - name: get MiniZinc path to cache
+        timeout-minutes: 5
         id: get-mzn-cache-path
         run: |
           echo "path=${{ matrix.minizinc_cache_path }}" >> $GITHUB_OUTPUT  # expands variables
       - name: Restore MiniZinc cache
+        timeout-minutes: 5
         id: cache-minizinc
         uses: actions/cache@v5
         with:
           path: ${{ steps.get-mzn-cache-path.outputs.path }}
           key: ${{ matrix.minizinc_url }}
       - name: Download MiniZinc
+        timeout-minutes: 5
         if: steps.cache-minizinc.outputs.cache-hit != 'true'
         run: |
           curl -o "${{ matrix.minizinc_downloaded_filepath }}" -L ${{ matrix.minizinc_url }}
       - name: Install MiniZinc
+        timeout-minutes: 5
         if: steps.cache-minizinc.outputs.cache-hit != 'true'
         run: |
           ${{ matrix.minizinc_install_cmdline }}
       - name: Test minizinc install
+        timeout-minutes: 5
         run: |
           ${{ matrix.minizinc_config_cmdline }}
           minizinc --version
       - name: Check imports are working
+        timeout-minutes: 5
         run: |
           # configure minizinc
           ${{ matrix.minizinc_config_cmdline }}
           # check imports
           python tests/test_import_all_submodules.py
       - name: Install test dependencies
+        timeout-minutes: 5
         run: |
           wheelfile=$(ls ./dist/discrete_optimization*.whl)
           extras="quantum, dashboard, optuna, gurobi"
@@ -218,17 +237,20 @@ jobs:
           pip list
 
       - name: Restore tests data cache
+        timeout-minutes: 5
         id: cache-data
         uses: actions/cache@v5
         with:
           path: ~/discrete_optimization_data
           key: data-${{ hashFiles('src/discrete_optimization/datasets.py') }}
       - name: Fetch data for tests
+        timeout-minutes: 5
         if: steps.cache-data.outputs.cache-hit != 'true'
         run: |
           ${{ matrix.minizinc_config_cmdline }}
           python -m discrete_optimization.datasets
       - name: Test with pytest (no coverage)
+        timeout-minutes: 60
         if: ${{ !matrix.coverage }}
         run: |
           # configure minizinc
@@ -240,6 +262,7 @@ jobs:
             -v --durations=0 --durations-min=2 \
             tests
       - name: Test with pytest (with coverage)
+        timeout-minutes: 60
         if: ${{ matrix.coverage }}
         run: |
           # configure minizinc
@@ -255,6 +278,7 @@ jobs:
             -v --durations=0 --durations-min=2 \
             tests
       - name: Test examples in docstrings
+        timeout-minutes: 5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TARGET_JOB_NAME: ${{ env.JOB_NAME }}
@@ -263,6 +287,7 @@ jobs:
           # Use unbuffered output (-u) so line logging indices accurately sync with stdout
           pytest --doctest-modules src -v | python -u .github/scripts/parse_doctest.py || true
       - name: Upload coverage report as artifact
+        timeout-minutes: 5
         if: ${{ matrix.coverage }}
         uses: actions/upload-artifact@v7
         with:
@@ -272,6 +297,7 @@ jobs:
             coverage_html
 
   update-notebooks-for-colab-and-binder:
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     needs: [trigger, build]
     outputs:
@@ -340,6 +366,7 @@ jobs:
 
   deploy:
     # for release tags
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     needs: [trigger, test]
     if: needs.trigger.outputs.is_release == 'true'

--- a/.github/workflows/deploy-doc.yml
+++ b/.github/workflows/deploy-doc.yml
@@ -24,6 +24,7 @@ on:
         type: string
 jobs:
   trigger-binder-build:
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     if: inputs.binder-env-fullref != ''
     steps:
@@ -38,6 +39,7 @@ jobs:
           bash scripts/trigger_binder.sh https://notebooks.gesis.org/binder/build/gh/${binder_env_full_ref}
 
   deploy-doc:
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -57,6 +59,7 @@ jobs:
 
   update-doc-versions:
     # update doc versions index if the doc has been deployed
+    timeout-minutes: 5
     needs: [deploy-doc]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Default value in github actions is 360 minutes for each job. We set a smaller value for all jobs (unfortunately it is not possible to set the default value so a value is set for each job, one by one).
- all jobs but "test": value is set to 5 minutes
- for the bigger job "test", we set it to 60 minutes and also set smaller timeouts for each sub step.