### PR TITLE
Fix dispersion constraint implem 

### DIFF
--- a/src/discrete_optimization/workforce/scheduling/solvers/cpsat.py
+++ b/src/discrete_optimization/workforce/scheduling/solvers/cpsat.py
@@ -437,7 +437,13 @@ class CPSatAllocSchedulingSolver(
             dict_fairness = model_fairness(
                 used_team=self.variables["used"],
                 allocation_variables=[
-                    self.allocation_is_present[task] for task in self.problem.tasks_list
+                    {
+                        self.problem.teams_to_index[team]: self.allocation_is_present[
+                            task
+                        ][team]
+                        for team in self.allocation_is_present[task]
+                    }
+                    for task in self.problem.tasks_list
                 ],
                 value_per_task=dur,
                 modelisation_dispersion=modelisation_dispersion,
@@ -457,7 +463,13 @@ class CPSatAllocSchedulingSolver(
             variables = cumulate_value_per_teams_version_2(
                 used_team=self.variables["used"],
                 allocation_variables=[
-                    self.allocation_is_present[task] for task in self.problem.tasks_list
+                    {
+                        self.problem.teams_to_index[team]: self.allocation_is_present[
+                            task
+                        ][team]
+                        for team in self.allocation_is_present[task]
+                    }
+                    for task in self.problem.tasks_list
                 ],
                 value_per_task=dur,
                 cp_model=self.cp_model,


### PR DESCRIPTION
the argument "allocation_variables" passed to model_fairness function was wrong, it expect a list of 
dictionnary where keys are index of team (and not team keys), or list of list...
Maybe it is worth to change it in the future.