### PR TITLE
Make optional the bound cumulative constraint for nb unary resource optimization

### DIFF
--- a/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto.py
+++ b/src/discrete_optimization/generic_tasks_tools/solvers/cpsat/auto.py
@@ -141,6 +141,7 @@ class GenericSchedulingAutoCpSatSolver(
     as the calendar for a skill is deduce from unary_resource calendars.
 
     """
+    add_cumulative_approximation_nb_unary_resource_used = False
 
     # cpsat variables
     start_or_end_variables: dict[tuple[Task, StartOrEnd], LinearExprT]
@@ -972,8 +973,10 @@ class GenericSchedulingAutoCpSatSolver(
                 objective_var = self.get_nb_tasks_done_variable()
             case Objective.NB_UNARY_RESOURCES_USED:
                 objective_var = self.get_nb_unary_resources_used_variable()
-                if self.exactly_one_unary_resource_per_task:
-                    # TODO = make this an option
+                if (
+                    self.exactly_one_unary_resource_per_task
+                    and self.add_cumulative_approximation_nb_unary_resource_used
+                ):
                     capa_used = self.cp_model.new_int_var(
                         lb=0,
                         ub=len(self.problem.unary_resources_list),


### PR DESCRIPTION
implemented the todo, and set the param to false, as it had bad effect on optimisation workforce scheduling with (nbteams, dispersion workload) optimisation (see regression in https://github.com/airbus/discrete-optimization/actions/runs/33761589214)