### PR TITLE
Improve non-regression tests handling

### DIFF
--- a/.github/scripts/parse_doctest.py
+++ b/.github/scripts/parse_doctest.py
@@ -74,7 +74,7 @@ def parse_pytest_output(input: TextIO | None = None):
 
     # summary of failures with proper links
     if failures:
-        with open(summary_file, "a") as f:
+        with open(summary_file, "a", encoding="utf-8") as f:
             f.write(f"\n### ⚠️ Failing examples found in docstrings\n\n")
             f.write("| Target File | Line | Jump to Execution Logs | Link to code |\n")
             f.write("| --- | --- | --- | --- |\n")

--- a/.github/scripts/parse_non_regression.py
+++ b/.github/scripts/parse_non_regression.py
@@ -68,7 +68,7 @@ def parse_pytest_output(input: TextIO | None = None):
 
     if regression_failures:
         # summary of failures with proper links
-        with open(summary_file, "at") as f:
+        with open(summary_file, "at", encoding="utf-8") as f:
             f.write(f"\n### ⚠️ Regression found in non-regression tests\n\n")
             f.write("| Test id | Jump to Execution Logs |\n")
             f.write("| --- | --- |\n")
@@ -77,7 +77,7 @@ def parse_pytest_output(input: TextIO | None = None):
                     f"| `{fail['test_id']}` | [Go to Log Line]({fail['log_url']}) |\n"
                 )
     if other_failures:
-        with open(summary_file, "at") as f:
+        with open(summary_file, "at", encoding="utf-8") as f:
             f.write(f"\n### ⚠️ Error found in non-regression tests\n\n")
             f.write("| Test id | Jump to Execution Logs |\n")
             f.write("| --- | --- |\n")
@@ -86,7 +86,7 @@ def parse_pytest_output(input: TextIO | None = None):
                     f"| `{fail['test_id']}` | [Go to Log Line]({fail['log_url']}) |\n"
                 )
     if collection_failures:
-        with open(summary_file, "at") as f:
+        with open(summary_file, "at", encoding="utf-8") as f:
             f.write(f"\n### ⚠️ Error found collecting non-regression tests\n\n")
             f.write("| Test id | Jump to Execution Logs |\n")
             f.write("| --- | --- |\n")

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -280,6 +280,7 @@ jobs:
             --ignore-glob=tests/**/test_*non_regression.py \
             tests
       - name: Test non-regression
+        timeout-minutes: 30
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TARGET_JOB_NAME: ${{ env.JOB_NAME }}
@@ -288,6 +289,7 @@ jobs:
           pytest -v $(python tests/find_non_regression_tests.py) | python -u .github/scripts/parse_non_regression.py || true
 
       - name: Upload nonregression report as artifact
+        timeout-minutes: 5
         uses: actions/upload-artifact@v7
         with:
           name: regressions-${{ matrix.os }}-${{ matrix.python-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -290,7 +290,7 @@ jobs:
       - name: Upload nonregression report as artifact
         uses: actions/upload-artifact@v7
         with:
-          name: regressions
+          name: regressions-${{ matrix.os }}-${{ matrix.python-version }}
           path: regressions.csv
           if-no-files-found: ignore
 


### PR DESCRIPTION
- Add a suffix to regression artifacts according to worker (os + python-version)
- Enforce encoding of summary file for windows so that it does not fail to display
- Add timeouts to new workflow steps handling non-regression tests