### PR TITLE
Make GenericSchedulingImplProblem a dataclass

### DIFF
--- a/src/discrete_optimization/binpack/problem.py
+++ b/src/discrete_optimization/binpack/problem.py
@@ -90,12 +90,15 @@ class BinPackProblemBinType(AllocationProblem[Item, BinPack], SchedulingProblem[
         list_items: list[ItemBinPack],
         list_bin_type: list[BinType],
         list_bin_instances: list[BinInstance],
-        incompatible_items: set[tuple[int, int]] = None,
+        incompatible_items: set[tuple[int, int]] | None = None,
     ):
         self.list_items = list_items
         self.list_bin_type = list_bin_type
         self.list_bin_instances = list_bin_instances
-        self.incompatible_items = incompatible_items
+        if incompatible_items is None:
+            self.incompatible_items = set()
+        else:
+            self.incompatible_items = incompatible_items
         self.nb_items = len(self.list_items)
         self.nb_bins = len(self.list_bin_instances)
         self.nb_bins_type = len(self.list_bin_type)
@@ -178,7 +181,7 @@ class BinPackProblem(BinPackProblemBinType):
         self,
         list_items: list[ItemBinPack],
         capacity_bin: int,
-        incompatible_items: set[tuple[int, int]] = None,
+        incompatible_items: set[tuple[int, int]] | None = None,
     ):
         bin_type = BinType(type="unique_type", capacity=capacity_bin)
         bin_instances = [

--- a/src/discrete_optimization/binpack/transformations/to_generic.py
+++ b/src/discrete_optimization/binpack/transformations/to_generic.py
@@ -81,15 +81,9 @@ class BinpackToGenericSchedulingTransformation(
                 horizon=source_problem.nb_items,
                 durations_per_mode={i: {0: 1} for i in range(source_problem.nb_items)},
                 resource_consumptions={
-                    i: {0: {"capacity": source_problem.list_items[i].weight}}
+                    i: {0: {"capacity": int(source_problem.list_items[i].weight)}}
                     for i in range(source_problem.nb_items)
                 },
-                successors={},
-                unary_resources=set(),
-                unary_resources_skills=None,
-                unary_resources_availabilities=None,
-                unary_resources_task_compatibility=None,
-                skills=None,
                 non_skill_cumulative_resources={
                     "capacity": [
                         (
@@ -100,18 +94,10 @@ class BinpackToGenericSchedulingTransformation(
                         for i in range(len(source_problem.list_bin_instances))
                     ]
                 },
-                non_renewable_resources=None,
-                time_windows=None,
-                start_to_start_min_time_lags=None,
-                start_to_end_min_time_lags=None,
-                end_to_start_min_time_lags=None,
-                end_to_end_min_time_lags=None,
-                no_overlap_sets=set(
-                    [
-                        frozenset([item1, item2])
-                        for item1, item2 in source_problem.incompatible_items
-                    ]
-                ),
+                no_overlap_sets={
+                    frozenset([item1, item2])
+                    for item1, item2 in source_problem.incompatible_items
+                },
                 forbidden_intervals={
                     item: [
                         (i, i + 1)
@@ -121,13 +107,9 @@ class BinpackToGenericSchedulingTransformation(
                     ]
                     for item in range(source_problem.nb_items)
                 },
-                flexible_gap_blocking_constraints=None,
-                span_blocking_constraints=None,
-                mode_constraints=None,
-                same_unary_allocation=None,
                 objective=Objective.MAKESPAN,
             )
-        return None
+        raise NotImplementedError()
 
     def back_transform_solution(
         self, solution: GenericSchedulingImplSolution, source_problem: BinPackProblem

--- a/src/discrete_optimization/generic_tasks_tools/generic_scheduling_impl.py
+++ b/src/discrete_optimization/generic_tasks_tools/generic_scheduling_impl.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Container, Hashable, Iterable
 from copy import deepcopy
+from dataclasses import InitVar, dataclass, field
 from typing import Optional
 
 import numpy as np
@@ -54,6 +55,7 @@ UnaryAvailabilityIntervals = list[tuple[int, int]]  # start, end
 AvailabilityIntervals = list[tuple[int, int, int]]  # start, end, value
 
 
+@dataclass
 class GenericSchedulingImplProblem(
     GenericSchedulingProblem[
         Task, UnaryResource, Skill, NonSkillCumulativeResource, NonRenewableResource
@@ -63,232 +65,133 @@ class GenericSchedulingImplProblem(
 
     It implements the abstract class `GenericSchedulingProblem`.
 
+    Attributes:
+        horizon: max allowed time to finish the tasks
+        durations_per_mode: task -> mode -> duration. Tasks durations, mode by mode.
+            This is used to know all available tasks, all available modes for a given task, and corresponding durations.
+        resource_consumptions: task -> mode -> resource -> conso.
+            Cumulative or non-renewable resource consumption, task by task, mode by mode. The resource can be a skill.
+            Missing key => conso = 0
+        successors: maps a task to its successors in the precedence graph.
+            Each successor task must start after the given task ends.
+            Default to no precedence constraints. Note that a consolidated version of it will
+            be constructed using the time lags constraints.
+        unary_resources: available unary resources.  Default to none.
+        unary_resources_skills: skill values of each unary resource. Missing key => skill value = 0
+        unary_resources_availabilities: availability of unary resources on the form of list of intervals (start, end)
+            Missing key => always available.
+        unary_resources_task_compatibility: maps a task to its compatible unary resources. Missing key => all unary resources allowed.
+        skills: available skills
+        non_skill_cumulative_resources: cumulative resources (excluding skills) availabilities.
+            Format: either int => always available at the given max capacity,
+            or list of intervals + capacity (start, end, value)
+        non_renewable_resources: non-renewable resources max capacities
+        time_windows: maps task to start_lb, end_lb, start_ub, end_ub s.t.
+            start_lb <= start(task) <= start_ub and end_lb <= end(task) <= end_ub
+            missing or none value means 0 (lb) or self.horizon (ub)
+        start_to_start_min_time_lags: min time lags constraints between task starts.
+            task1, task2, offset meaning start(task1) + offset <= start(task2)
+            Note that using negative offset can model start-to-start max time lags.
+        start_to_end_min_time_lags: min time lags constraints first task start and second task end.
+            task1, task2, offset meaning start(task1) + offset <= end(task2)
+            Note that using negative offset can model end-to-start max time lags.
+        end_to_start_min_time_lags: min time lags constraints between first task end and second task start.
+            task1, task2, offset meaning end(task1) + offset <= start(task2)
+            Note that using negative offset can model start-to-end max time lags.
+        end_to_end_min_time_lags: min time lags constraints between task ends.
+            task1, task2, offset meaning end(task1) + offset <= end(task2)
+            Note that using negative offset can model end-to-end max time lags.
+        no_overlap_sets: a set of (set of tasks that should not overlap together)
+        forbidden_intervals: maps task to forbidden intervals that cannot overlap with it. Missing key => no forbidden intervals.
+        flexible_gap_blocking_constraints: list of blocking constraints between entity points.
+            Each constraint is (entity1, point1, entity2, point2, resources, metadata).
+            Default to no blocking constraints.
+        span_blocking_constraints: list of span blocking constraints.
+            Each constraint is (tasks, resources, metadata) where tasks is a frozenset.
+            Default to no blocking constraints.
+        objective: objective for the problem. Default to minimization of makespan.
+            Either an iterable of (objective, weight) so that the problem should *maximize* the aggregated objective
+            resulting from weighted sum of objectives, or a single objective in which case we use the corresponding
+            default weight from
+            `discrete_optimization.generic_tasks_tools.generic_scheduling_utils.OBJECTIVE_DEFAULT_WEIGHTS`
+            and maximize it. For instance the default weight for makespan is -1 so that it will
+            actually minimize the makespan.
+        custom_evaluate_fn: function used to evaluate the "custom" objective (to be maximized).
+        objective_resource_weights: Weights to be used by the objective when summing used resources
+            (`Objective.NB_RESOURCES_USED`) or resources levels (`Objective.RESOURCES_LEVELS`).
+            Default to 1 for resources not mentioned.
+        mode_costs: cost of choosing each mode. Missing key => cost = 0.
+        unary_resource_costs: cost of allocating each unary resource. Missing key => cost = 0.
+        compute_time_penalty: whether to include time penalties in evaluation
+
     """
 
-    def __init__(
-        self,
-        horizon: int,
-        durations_per_mode: dict[Task, dict[int, int]],
-        resource_consumptions: Optional[
-            dict[Task, dict[int, dict[CumulativeResource | NonRenewableResource, int]]]
-        ] = None,
-        successors: Optional[dict[Task, Iterable[Task]]] = None,
-        unary_resources: Optional[set[UnaryResource]] = None,
-        unary_resources_skills: Optional[dict[UnaryResource, dict[Skill, int]]] = None,
-        unary_resources_availabilities: Optional[
-            dict[UnaryResource, UnaryAvailabilityIntervals]
-        ] = None,
-        unary_resources_task_compatibility: Optional[
-            dict[Task, set[UnaryResource]]
-        ] = None,
-        skills: Optional[set[Skill]] = None,
-        non_skill_cumulative_resources: Optional[
-            dict[NonSkillCumulativeResource, int | AvailabilityIntervals]
-        ] = None,
-        non_renewable_resources: Optional[dict[NonRenewableResource, int]] = None,
-        time_windows: Optional[
-            dict[Task, tuple[int | None, int | None, int | None, int | None]]
-        ] = None,
-        start_to_start_min_time_lags: Optional[list[tuple[Task, Task, int]]] = None,
-        start_to_end_min_time_lags: Optional[list[tuple[Task, Task, int]]] = None,
-        end_to_start_min_time_lags: Optional[list[tuple[Task, Task, int]]] = None,
-        end_to_end_min_time_lags: Optional[list[tuple[Task, Task, int]]] = None,
-        no_overlap_sets: Optional[set[frozenset[Task]]] = None,
-        forbidden_intervals: Optional[dict[Task, list[tuple[int, int]]]] = None,
-        flexible_gap_blocking_constraints: Optional[
-            list[FlexibleGapBlockingConstraint]
-        ] = None,
-        span_blocking_constraints: Optional[list[SpanBlockingConstraint]] = None,
-        mode_constraints: Optional[
-            list[tuple[ModeConstraintType, list[tuple[Task, int]]]]
-        ] = None,
-        same_unary_allocation: Optional[list[set[Task]]] = None,
-        objective: Objective | Iterable[tuple[Objective, int]] = Objective.MAKESPAN,
-        custom_evaluate_fn: Optional[
-            Callable[[GenericSchedulingImplSolution], int]
-        ] = None,
-        objective_resource_weights: Optional[dict[AnyResource, int]] = None,
-        mode_costs: Optional[dict[Task, dict[int, int]]] = None,
-        unary_resource_costs: Optional[
-            dict[Task, dict[int, dict[UnaryResource, int]]]
-        ] = None,
-        compute_time_penalty: bool = True,
-    ):
-        """
+    horizon: int
+    durations_per_mode: dict[Task, dict[int, int]]
+    resource_consumptions: dict[
+        Task, dict[int, dict[CumulativeResource | NonRenewableResource, int]]
+    ] = field(default_factory=dict)
+    successors: dict[Task, set[Task]] = field(default_factory=dict)
+    unary_resources: set[UnaryResource] = field(default_factory=set)
+    unary_resources_skills: dict[UnaryResource, dict[Skill, int]] = field(
+        default_factory=dict
+    )
+    unary_resources_availabilities: dict[UnaryResource, UnaryAvailabilityIntervals] = (
+        field(default_factory=dict)
+    )
+    unary_resources_task_compatibility: dict[Task, set[UnaryResource]] = field(
+        default_factory=dict
+    )
+    skills: set[Skill] = field(default_factory=set)
+    non_skill_cumulative_resources: dict[
+        NonSkillCumulativeResource, int | AvailabilityIntervals
+    ] = field(default_factory=dict)
+    non_renewable_resources: dict[NonRenewableResource, int] = field(
+        default_factory=dict
+    )
+    time_windows: dict[Task, tuple[int | None, int | None, int | None, int | None]] = (
+        field(default_factory=dict)
+    )
+    start_to_start_min_time_lags: list[tuple[Task, Task, int]] = field(
+        default_factory=list
+    )
+    start_to_end_min_time_lags: list[tuple[Task, Task, int]] = field(
+        default_factory=list
+    )
+    end_to_start_min_time_lags: list[tuple[Task, Task, int]] = field(
+        default_factory=list
+    )
+    end_to_end_min_time_lags: list[tuple[Task, Task, int]] = field(default_factory=list)
+    no_overlap_sets: set[frozenset[Task]] = field(default_factory=set)
+    forbidden_intervals: dict[Task, list[tuple[int, int]]] = field(default_factory=dict)
+    flexible_gap_blocking_constraints: list[FlexibleGapBlockingConstraint] = field(
+        default_factory=list
+    )
+    span_blocking_constraints: list[SpanBlockingConstraint] = field(
+        default_factory=list
+    )
+    mode_constraints: list[tuple[ModeConstraintType, list[tuple[Task, int]]]] = field(
+        default_factory=list
+    )
+    same_unary_allocation: list[set[Task]] = field(default_factory=list)
+    objective: InitVar[Objective | Iterable[tuple[Objective, int]]] = Objective.MAKESPAN
+    weighted_objectives: tuple[tuple[Objective, int], ...] = field(init=False)
+    custom_evaluate_fn: Optional[Callable[[GenericSchedulingImplSolution], int]] = None
+    objective_resource_weights: Optional[dict[AnyResource, int]] = None
+    mode_costs: dict[Task, dict[int, int]] = field(default_factory=dict)
+    unary_resource_costs: dict[Task, dict[int, dict[UnaryResource, int]]] = field(
+        default_factory=dict
+    )
+    compute_time_penalty: bool = True
 
-        Args:
-            horizon: max allowed time to finish the tasks
-            durations_per_mode: task -> mode -> duration. Tasks durations, mode by mode.
-                This is used to know all available tasks, all available modes for a given task, and corresponding durations.
-            resource_consumptions: task -> mode -> resource -> conso.
-                Cumulative or non-renewable resource consumption, task by task, mode by mode. The resource can be a skill.
-                Missing key => conso = 0
-            successors: maps a task to its successors in the precedence graph.
-                Each successor task must start after the given task ends.
-                Default to no precedence constraints. Note that a consolidated version of it will
-                be constructed using the time lags constraints.
-            unary_resources: available unary resources.  Default to none.
-            unary_resources_skills: skill values of each unary resource. Missing key => skill value = 0
-            unary_resources_availabilities: availability of unary resources on the form of list of intervals (start, end)
-                Missing key => always available.
-            unary_resources_task_compatibility: maps a task to its compatible unary resources. Missing key => all unary resources allowed.
-            skills: available skills
-            non_skill_cumulative_resources: cumulative resources (excluding skills) availabilities.
-                Format: either int => always available at the given max capacity,
-                or list of intervals + capacity (start, end, value)
-            non_renewable_resources: non-renewable resources max capacities
-            time_windows: maps task to start_lb, end_lb, start_ub, end_ub s.t.
-                start_lb <= start(task) <= start_ub and end_lb <= end(task) <= end_ub
-                missing or none value means 0 (lb) or self.horizon (ub)
-            start_to_start_min_time_lags: min time lags constraints between task starts.
-                task1, task2, offset meaning start(task1) + offset <= start(task2)
-                Note that using negative offset can model start-to-start max time lags.
-            start_to_end_min_time_lags: min time lags constraints first task start and second task end.
-                task1, task2, offset meaning start(task1) + offset <= end(task2)
-                Note that using negative offset can model end-to-start max time lags.
-            end_to_start_min_time_lags: min time lags constraints between first task end and second task start.
-                task1, task2, offset meaning end(task1) + offset <= start(task2)
-                Note that using negative offset can model start-to-end max time lags.
-            end_to_end_min_time_lags: min time lags constraints between task ends.
-                task1, task2, offset meaning end(task1) + offset <= end(task2)
-                Note that using negative offset can model end-to-end max time lags.
-            no_overlap_sets: a set of (set of tasks that should not overlap together)
-            forbidden_intervals: maps task to forbidden intervals that cannot overlap with it. Missing key => no forbidden intervals.
-            flexible_gap_blocking_constraints: list of blocking constraints between entity points.
-                Each constraint is (entity1, point1, entity2, point2, resources, metadata).
-                Default to no blocking constraints.
-            span_blocking_constraints: list of span blocking constraints.
-                Each constraint is (tasks, resources, metadata) where tasks is a frozenset.
-                Default to no blocking constraints.
-            objective: objective for the problem. Default to minimization of makespan.
-                Either an iterable of (objective, weight) so that the problem should *maximize* the aggregated objective
-                resulting from weighted sum of objectives, or a single objective in which case we use the corresponding
-                default weight from
-                `discrete_optimization.generic_tasks_tools.generic_scheduling_utils.OBJECTIVE_DEFAULT_WEIGHTS`
-                and maximize it. For instance the default weight for makespan is -1 so that it will
-                actually minimize the makespan.
-            custom_evaluate_fn: function used to evaluate the "custom" objective (to be maximized).
-            objective_resource_weights: Weights to be used by the objective when summing used resources
-                (`Objective.NB_RESOURCES_USED`) or resources levels (`Objective.RESOURCES_LEVELS`).
-                Default to 1 for resources not mentioned.
-            mode_costs: cost of choosing each mode. Missing key => cost = 0.
-            unary_resource_costs: cost of allocating each unary resource. Missing key => cost = 0.
-            compute_time_penalty: whether to include time penalties in evaluation
-
-        """
-        self.horizon = horizon
-        self.durations_per_mode = durations_per_mode
-        # default values
-        if resource_consumptions is None:
-            self.resource_consumptions: dict[
-                Task, dict[int, dict[CumulativeResource | NonRenewableResource, int]]
-            ] = {}
-        else:
-            self.resource_consumptions = resource_consumptions
-        if successors is None:
-            self.successors: dict[Task, Iterable[Task]] = {}
-        else:
-            self.successors = successors
-        if unary_resources is None:
-            self.unary_resources: set[UnaryResource] = set()
-        else:
-            self.unary_resources = unary_resources
-        if unary_resources_skills is None:
-            self.unary_resources_skills: dict[UnaryResource, dict[Skill, int]] = {}
-        else:
-            self.unary_resources_skills = unary_resources_skills
-        if unary_resources_availabilities is None:
-            self.unary_resources_availabilities: dict[
-                UnaryResource, UnaryAvailabilityIntervals
-            ] = {}
-        else:
-            self.unary_resources_availabilities = unary_resources_availabilities
-        if unary_resources_task_compatibility is None:
-            self.unary_resources_task_compatibility: dict[Task, set[UnaryResource]] = {}
-        else:
-            self.unary_resources_task_compatibility = unary_resources_task_compatibility
-        if skills is None:
-            self.skills: set[Skill] = set()
-        else:
-            self.skills = skills
-        if non_skill_cumulative_resources is None:
-            self.non_skill_cumulative_resources: dict[
-                CumulativeResource, int | AvailabilityIntervals
-            ] = {}
-        else:
-            self.non_skill_cumulative_resources = non_skill_cumulative_resources
-        if non_renewable_resources is None:
-            self.non_renewable_resources: dict[NonRenewableResource, int] = {}
-        else:
-            self.non_renewable_resources = non_renewable_resources
-        if time_windows is None:
-            self.time_windows: dict[
-                Task, tuple[int | None, int | None, int | None, int | None]
-            ] = {}
-        else:
-            self.time_windows = time_windows
-        if start_to_start_min_time_lags is None:
-            self.start_to_start_min_time_lags: list[tuple[Task, Task, int]] = []
-        else:
-            self.start_to_start_min_time_lags = start_to_start_min_time_lags
-        if start_to_end_min_time_lags is None:
-            self.start_to_end_min_time_lags: list[tuple[Task, Task, int]] = []
-        else:
-            self.start_to_end_min_time_lags = start_to_end_min_time_lags
-        if end_to_start_min_time_lags is None:
-            self.end_to_start_min_time_lags: list[tuple[Task, Task, int]] = []
-        else:
-            self.end_to_start_min_time_lags = end_to_start_min_time_lags
-        if end_to_end_min_time_lags is None:
-            self.end_to_end_min_time_lags: list[tuple[Task, Task, int]] = []
-        else:
-            self.end_to_end_min_time_lags = end_to_end_min_time_lags
-        if no_overlap_sets is None:
-            self.no_overlap_sets = set()
-        else:
-            self.no_overlap_sets = no_overlap_sets
-        if forbidden_intervals is None:
-            self.forbidden_intervals = {}
-        else:
-            self.forbidden_intervals = forbidden_intervals
-        if flexible_gap_blocking_constraints is None:
-            self.flexible_gap_blocking_constraints: list[
-                FlexibleGapBlockingConstraint
-            ] = []
-        else:
-            self.flexible_gap_blocking_constraints = flexible_gap_blocking_constraints
-        if span_blocking_constraints is None:
-            self.span_blocking_constraints: list[SpanBlockingConstraint] = []
-        else:
-            self.span_blocking_constraints = span_blocking_constraints
-        if mode_constraints is None:
-            self.mode_constraints = []
-        else:
-            self.mode_constraints = mode_constraints
-        if same_unary_allocation is None:
-            self.same_unary_allocation: list[set[Task]] = []
-        else:
-            self.same_unary_allocation = same_unary_allocation
+    def __post_init__(self, objective: Objective | Iterable[tuple[Objective, int]]):
         if isinstance(objective, Objective):
             self.weighted_objectives: tuple[tuple[Objective, int], ...] = (
                 (objective, OBJECTIVE_DEFAULT_WEIGHTS[objective]),
             )
         else:
             self.weighted_objectives = tuple(objective)
-        self.custom_evaluate_fn = custom_evaluate_fn
-        if objective_resource_weights is None:
-            self.objective_resource_weights: dict[AnyResource, int] = {}
-        else:
-            self.objective_resource_weights = objective_resource_weights
-        if mode_costs is None:
-            self.mode_costs = {}
-        else:
-            self.mode_costs = mode_costs
-        if unary_resource_costs is None:
-            self.unary_resource_costs = {}
-        else:
-            self.unary_resource_costs = unary_resource_costs
-        self.compute_time_penalty = compute_time_penalty
+
         self.update_problem()
 
     def update_problem(self):
@@ -602,11 +505,11 @@ class GenericSchedulingImplProblem(
             task: self.durations_per_mode[task] for task in new_tasks_list
         }
         new_successors = {
-            task: [
+            task: {
                 next_task
                 for next_task in next_tasks
                 if next_task not in scheduled_tasks
-            ]
+            }
             for task, next_tasks in self.successors.items()
             if task not in scheduled_tasks
         }

--- a/src/discrete_optimization/generic_tasks_tools/transformations/generic_scheduling_impl.py
+++ b/src/discrete_optimization/generic_tasks_tools/transformations/generic_scheduling_impl.py
@@ -164,9 +164,9 @@ class ToGenericSchedulingImpl(
             }
             for task in source_problem.tasks_list
         }
-        successors: dict[Task, Iterable[Task]] = (
-            source_problem.get_precedence_constraints()
-        )
+        successors: dict[Task, set[Task]] = {
+            k: set(v) for k, v in source_problem.get_precedence_constraints().items()
+        }
         unary_resources: set[UnaryResource] = set(source_problem.unary_resources_list)
         unary_resources_skills: dict[UnaryResource, dict[Skill, int]] = {
             unary_resource: {

--- a/src/discrete_optimization/rcpsp_multiskill/solvers/cpsat.py
+++ b/src/discrete_optimization/rcpsp_multiskill/solvers/cpsat.py
@@ -14,7 +14,6 @@ from discrete_optimization.generic_tasks_tools.generic_scheduling_utils import (
 from discrete_optimization.generic_tasks_tools.solvers.cpsat.auto import (
     GenericSchedulingAutoCpSatSolver,
 )
-from discrete_optimization.generic_tools.do_problem import Solution
 from discrete_optimization.generic_tools.hyperparameters.hyperparameter import (
     CategoricalHyperparameter,
 )
@@ -22,6 +21,7 @@ from discrete_optimization.rcpsp_multiskill.problem import (
     NB_EMPLOYEES_LB,
     CumulativeResource,
     MultiskillRcpspProblem,
+    MultiskillRcpspSolution,
     NonRenewableResource,
     NonSkillCumulativeResource,
     Skill,
@@ -54,7 +54,7 @@ class CpSatMultiskillRcpspSolver(
 
     def convert_task_variables_to_solution(
         self, raw_sol: RawSolution[Task, UnaryResource, Skill]
-    ) -> Solution:
+    ) -> MultiskillRcpspSolution:
         """Convert solution from autosolver format into do format.
 
         To be used in `self.retrieve_solution()`.

--- a/tests/generic_tasks_tools/solvers/cpsat/test_auto_impl.py
+++ b/tests/generic_tasks_tools/solvers/cpsat/test_auto_impl.py
@@ -33,14 +33,23 @@ from discrete_optimization.rcpsp.solvers.cpsat import CpSatRcpspSolver
 from discrete_optimization.rcpsp.special_constraints import (
     SpecialConstraintsDescription,
 )
+from discrete_optimization.rcpsp.transformations.generic_scheduling_impl import (
+    RcpspToGenericSchedulingTransformation,
+)
 from discrete_optimization.rcpsp_multiskill.problem import MultiskillRcpspSolution
 from discrete_optimization.rcpsp_multiskill.solvers.cpsat import (
     CpSatMultiskillRcpspSolver,
+)
+from discrete_optimization.rcpsp_multiskill.transformations.generic_scheduling_impl import (
+    MultiskillRcpspToGenericSchedulingTransformation,
 )
 from discrete_optimization.shop.fjsp.problem import FJobShopSolution
 from discrete_optimization.shop.fjsp.solvers.cpsat import CpSatFjspSolver
 from discrete_optimization.shop.jsp.problem import JobShopSolution
 from discrete_optimization.shop.jsp.solvers.cpsat import CpSatJspSolver
+from discrete_optimization.shop.transformations.to_generic_scheduling import (
+    ShopToGenericSchedulingTransformation,
+)
 
 
 @pytest.mark.parametrize(
@@ -80,7 +89,7 @@ def test_auto(
                 },
             },
         },
-        successors={"task-1": ["task-2"]},
+        successors={"task-1": {"task-2"}},
         unary_resources={"worker1", "worker2"},
         unary_resources_availabilities={
             "worker1": [(1, 4)],
@@ -251,11 +260,11 @@ def test_rcpsp_simple():
     }
 
     successors = {
-        1: [2, 3],
-        2: [5],
-        3: [4],
-        4: [5],
-        5: [],
+        1: {2, 3},
+        2: {5},
+        3: {4},
+        4: {5},
+        5: {},
     }
 
     resources = {"R1": 2}
@@ -288,67 +297,8 @@ def test_rcpsp_simple():
     assert solution.get_start_time(2) == solution.get_start_time(3)
 
     # transform to generic problem
-    time_windows = {}
-    windowed_tasks = set()
-    windowed_tasks.update(special_constraints.start_times)
-    windowed_tasks.update(special_constraints.end_times)
-    for task in windowed_tasks:
-        start_lb = start_ub = special_constraints.start_times.get(task, None)
-        end_lb = end_ub = special_constraints.end_times.get(task, None)
-        time_windows[task] = (start_lb, end_lb, start_ub, end_ub)
-
-    start_to_start_min_time_lags = problem.get_start_to_start_min_time_lags() + [
-        (t2, t1, -offset)
-        for t1, t2, offset in problem.get_start_to_start_max_time_lags()
-    ]
-    start_to_end_min_time_lags = problem.get_start_to_end_min_time_lags() + [
-        (t2, t1, -offset) for t1, t2, offset in problem.get_end_to_start_max_time_lags()
-    ]
-    end_to_start_min_time_lags = problem.get_end_to_start_min_time_lags() + [
-        (t2, t1, -offset) for t1, t2, offset in problem.get_start_to_end_max_time_lags()
-    ]
-    end_to_end_min_time_lags = problem.get_end_to_end_min_time_lags() + [
-        (t2, t1, -offset) for t1, t2, offset in problem.get_end_to_end_max_time_lags()
-    ]
-    durations_per_mode = {
-        task: {
-            mode: problem.get_task_mode_duration(task=task, mode=mode)
-            for mode in problem.get_task_modes(task)
-        }
-        for task in problem.tasks_list
-    }
-    resource_consumptions = {
-        task: {
-            mode: {
-                **{
-                    resource: problem.get_cumulative_resource_consumption(
-                        resource=resource, task=task, mode=mode
-                    )
-                    for resource in problem.cumulative_resources_list
-                },
-                **{
-                    resource: problem.get_non_renewable_resource_consumption(
-                        resource=resource, task=task, mode=mode
-                    )
-                    for resource in problem.non_renewable_resources_list
-                },
-            }
-            for mode in problem.get_task_modes(task)
-        }
-        for task in problem.tasks_list
-    }
-    generic_problem = GenericSchedulingImplProblem(
-        horizon=horizon,
-        durations_per_mode=durations_per_mode,
-        resource_consumptions=resource_consumptions,
-        successors=successors,
-        non_skill_cumulative_resources=resources,
-        time_windows=time_windows,
-        start_to_start_min_time_lags=start_to_start_min_time_lags,
-        end_to_start_min_time_lags=end_to_start_min_time_lags,
-        start_to_end_min_time_lags=start_to_end_min_time_lags,
-        end_to_end_min_time_lags=end_to_end_min_time_lags,
-    )
+    transfo = RcpspToGenericSchedulingTransformation()
+    generic_problem = transfo.transform_problem(problem)
     generic_solver = GenericSchedulingAutoCpSatImplSolver(
         problem=generic_problem,
     )
@@ -385,49 +335,8 @@ def test_rcpsp_mm():
     assert problem.satisfy(solution)
 
     # transform to generic problem
-    non_renewable_resources = {
-        resource: problem.get_non_renewable_resource_capacity(resource)
-        for resource in problem.non_renewable_resources_list
-    }
-    non_skill_cumulative_resources = {
-        resource: problem.get_resource_availabilities(resource)
-        for resource in problem.non_skill_cumulative_resources_list
-    }
-    durations_per_mode = {
-        task: {
-            mode: problem.get_task_mode_duration(task=task, mode=mode)
-            for mode in problem.get_task_modes(task)
-        }
-        for task in problem.tasks_list
-    }
-    resource_consumptions = {
-        task: {
-            mode: {
-                **{
-                    resource: problem.get_cumulative_resource_consumption(
-                        resource=resource, task=task, mode=mode
-                    )
-                    for resource in problem.cumulative_resources_list
-                },
-                **{
-                    resource: problem.get_non_renewable_resource_consumption(
-                        resource=resource, task=task, mode=mode
-                    )
-                    for resource in problem.non_renewable_resources_list
-                },
-            }
-            for mode in problem.get_task_modes(task)
-        }
-        for task in problem.tasks_list
-    }
-    generic_problem = GenericSchedulingImplProblem(
-        horizon=problem.horizon,
-        durations_per_mode=durations_per_mode,
-        resource_consumptions=resource_consumptions,
-        successors=problem.successors,
-        non_skill_cumulative_resources=non_skill_cumulative_resources,
-        non_renewable_resources=non_renewable_resources,
-    )
+    transfo = RcpspToGenericSchedulingTransformation()
+    generic_problem = transfo.transform_problem(problem)
 
     generic_solver = GenericSchedulingAutoCpSatImplSolver(
         problem=generic_problem,
@@ -521,71 +430,8 @@ def test_rcpsp_multiskill(
         )
 
     # transform to generic problem
-    non_renewable_resources = {
-        resource: problem.get_non_renewable_resource_capacity(resource)
-        for resource in problem.non_renewable_resources_list
-    }
-    non_skill_cumulative_resources = {
-        resource: problem.get_resource_availabilities(resource)
-        for resource in problem.non_skill_cumulative_resources_list
-    }
-    skills = set(problem.skills_list)
-    unary_resources = set(problem.unary_resources_list)
-    unary_resources_skills = {
-        unary_resource: {
-            skill: detail.skill_value
-            for skill, detail in problem.employees[unary_resource].dict_skill.items()
-        }
-        for unary_resource in unary_resources
-    }
-    unary_resources_availabilities = {
-        unary_resource: [
-            (start, end)
-            for start, end, _ in problem.get_resource_availabilities(
-                resource=unary_resource
-            )
-        ]
-        for unary_resource in unary_resources
-    }
-    durations_per_mode = {
-        task: {
-            mode: problem.get_task_mode_duration(task=task, mode=mode)
-            for mode in problem.get_task_modes(task)
-        }
-        for task in problem.tasks_list
-    }
-    resource_consumptions = {
-        task: {
-            mode: {
-                **{
-                    resource: problem.get_cumulative_resource_consumption(
-                        resource=resource, task=task, mode=mode
-                    )
-                    for resource in problem.cumulative_resources_list
-                },
-                **{
-                    resource: problem.get_non_renewable_resource_consumption(
-                        resource=resource, task=task, mode=mode
-                    )
-                    for resource in problem.non_renewable_resources_list
-                },
-            }
-            for mode in problem.get_task_modes(task)
-        }
-        for task in problem.tasks_list
-    }
-    generic_problem = GenericSchedulingImplProblem(
-        horizon=problem.horizon,
-        durations_per_mode=durations_per_mode,
-        resource_consumptions=resource_consumptions,
-        successors=problem.successors,
-        non_skill_cumulative_resources=non_skill_cumulative_resources,
-        non_renewable_resources=non_renewable_resources,
-        skills=skills,
-        unary_resources=unary_resources,
-        unary_resources_skills=unary_resources_skills,
-        unary_resources_availabilities=unary_resources_availabilities,
-    )
+    transfo = MultiskillRcpspToGenericSchedulingTransformation()
+    generic_problem = transfo.transform_problem(problem)
 
     generic_solver = GenericSchedulingAutoCpSatImplSolver(
         problem=generic_problem,
@@ -653,38 +499,8 @@ def test_jsp():
     assert problem.satisfy(solution)
 
     # transform to generic problem
-    non_skill_cumulative_resources = {
-        resource: problem.get_resource_availabilities(resource)
-        for resource in problem.non_skill_cumulative_resources_list
-    }
-    durations_per_mode = {
-        task: {
-            mode: problem.get_task_mode_duration(task=task, mode=mode)
-            for mode in problem.get_task_modes(task)
-        }
-        for task in problem.tasks_list
-    }
-    resource_consumptions = {
-        task: {
-            mode: {
-                resource: problem.get_cumulative_resource_consumption(
-                    resource=resource, task=task, mode=mode
-                )
-                for resource in problem.cumulative_resources_list
-            }
-            for mode in problem.get_task_modes(task)
-        }
-        for task in problem.tasks_list
-    }
-    successors = problem.get_precedence_constraints()
-    generic_problem = GenericSchedulingImplProblem(
-        horizon=problem.horizon,
-        durations_per_mode=durations_per_mode,
-        resource_consumptions=resource_consumptions,
-        successors=successors,
-        non_skill_cumulative_resources=non_skill_cumulative_resources,
-    )
-
+    transfo = ShopToGenericSchedulingTransformation()
+    generic_problem = transfo.transform_problem(problem)
     generic_solver = GenericSchedulingAutoCpSatImplSolver(
         problem=generic_problem,
     )
@@ -724,37 +540,8 @@ def test_fjsp():
     assert problem.satisfy(solution)
 
     # transform to generic problem
-    non_skill_cumulative_resources = {
-        resource: problem.get_resource_availabilities(resource)
-        for resource in problem.non_skill_cumulative_resources_list
-    }
-    durations_per_mode = {
-        task: {
-            mode: problem.get_task_mode_duration(task=task, mode=mode)
-            for mode in problem.get_task_modes(task)
-        }
-        for task in problem.tasks_list
-    }
-    resource_consumptions = {
-        task: {
-            mode: {
-                resource: problem.get_cumulative_resource_consumption(
-                    resource=resource, task=task, mode=mode
-                )
-                for resource in problem.cumulative_resources_list
-            }
-            for mode in problem.get_task_modes(task)
-        }
-        for task in problem.tasks_list
-    }
-    successors = problem.get_precedence_constraints()
-    generic_problem = GenericSchedulingImplProblem(
-        horizon=problem.horizon,
-        durations_per_mode=durations_per_mode,
-        resource_consumptions=resource_consumptions,
-        successors=successors,
-        non_skill_cumulative_resources=non_skill_cumulative_resources,
-    )
+    transfo = ShopToGenericSchedulingTransformation()
+    generic_problem = transfo.transform_problem(problem)
 
     generic_solver = GenericSchedulingAutoCpSatImplSolver(
         problem=generic_problem,

--- a/tests/generic_tasks_tools/test_generic_scheduling_impl.py
+++ b/tests/generic_tasks_tools/test_generic_scheduling_impl.py
@@ -53,7 +53,7 @@ def problem_wo_skills():
                 },
             },
         },
-        successors={"task-1": ["task-2"]},
+        successors={"task-1": {"task-2"}},
         unary_resources={"worker1", "worker2"},
         unary_resources_availabilities={
             "worker1": [(1, 4)],
@@ -356,7 +356,7 @@ def test_subproblem_from_partial_solution(caplog):
                 },
             },
         },
-        successors={"task-1": ["task-2", "task-3"]},
+        successors={"task-1": {"task-2", "task-3"}},
         end_to_end_min_time_lags=[("task-3", "task-2", -1)],
         unary_resources={"worker1", "worker2"},
         unary_resources_availabilities={

--- a/tests/workforce/scheduling/test_transformations.py
+++ b/tests/workforce/scheduling/test_transformations.py
@@ -46,10 +46,4 @@ def test_transfo_to_from_generic_scheduling(problem):
     generic_problem_2 = transfo.transform_problem(
         source_problem=back_transfo.transform_problem(source_problem=generic_problem)
     )
-    solver_2 = GenericSchedulingAutoCpSatImplSolver(problem=generic_problem_2)
-    generic_solution_2: GenericSchedulingImplSolution = solver_2.solve(
-        parameters_cp=parameters_cp,
-        callbacks=[NbIterationStopper(nb_iteration_max=1)],
-    ).get_best_solution()
-
-    assert generic_solution_2.raw_sol == generic_solution.raw_sol
+    assert generic_problem == generic_problem_2


### PR DESCRIPTION
- simplify init part
- earn `__repr__`, `__eq__` and co

Also fix transfos/tests to call the generated `__init__()` correctly:
- do not set missing attributes to `None`
- successors must now be a `dict[Task, set[Task]]` rather than just a `dict[Task, Iterable[Task]]`
- tests in test_auto_impl.py based on other pbs like rcpsp, jsp, ... are now using the corresponding transfos instead of redoing it a la mano