### PR TITLE
Add a utility function to get all methods likely to be overriden

### DIFF
--- a/src/discrete_optimization/flex_scheduling/problem.py
+++ b/src/discrete_optimization/flex_scheduling/problem.py
@@ -26,9 +26,6 @@ from discrete_optimization.generic_tasks_tools.generic_scheduling import (
     GenericSchedulingSolution,
 )
 from discrete_optimization.generic_tasks_tools.multimode import MultimodeSolution
-from discrete_optimization.generic_tasks_tools.no_overlap import (
-    WithoutNoOverlapProblem,
-)
 from discrete_optimization.generic_tasks_tools.resource_blocking import (
     BlockingConstraintMetadata,
     FlexibleGapBlockingConstraint,
@@ -343,7 +340,6 @@ class FlexProblem(
     GenericSchedulingProblem[
         Task, NoUnaryResource, NoSkill, NonSkillCumulativeResource, NonRenewableResource
     ],
-    WithoutNoOverlapProblem[Task],
     WithoutSkillProblem[
         Task, NoUnaryResource, NonSkillCumulativeResource, NoUnaryResource
     ],

--- a/src/discrete_optimization/generic_tasks_tools/no_overlap.py
+++ b/src/discrete_optimization/generic_tasks_tools/no_overlap.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from abc import abstractmethod
 
 import numpy as np
 
@@ -10,6 +9,7 @@ from discrete_optimization.generic_tasks_tools.scheduling import (
     SchedulingSolution,
     Task,
 )
+from discrete_optimization.generic_tasks_tools.utils import optional_override
 
 logger = logging.getLogger(__name__)
 
@@ -20,13 +20,16 @@ class NoOverlapProblem(SchedulingProblem[Task]):
     is arbitrary, but still no overlap.
     """
 
-    @abstractmethod
+    @optional_override
     def get_no_overlap(self) -> set[frozenset[Task]]:
         """
         An object in this returned set is a (frozen) set of task,
-        where no task should overlap with another one in this set
+        where no task should overlap with another one in this set.
+
+        Default to no such sets.
+
         """
-        ...
+        return set()
 
     def get_forbidden_intervals(self, task: Task) -> list[tuple[int, int]]:
         """Get fixed intervals that should not overlap with given task.
@@ -118,8 +121,3 @@ class WithoutNoOverlapProblem(NoOverlapProblem[Task]):
 
     def get_no_overlap(self) -> set[frozenset[Task]]:
         return set()
-
-
-class WithoutNoOverlapSolution(NoOverlapSolution[Task]):
-    def check_no_overlap(self) -> bool:
-        return True

--- a/src/discrete_optimization/generic_tasks_tools/resource_blocking.py
+++ b/src/discrete_optimization/generic_tasks_tools/resource_blocking.py
@@ -16,7 +16,6 @@ Key features:
 from __future__ import annotations
 
 import logging
-from abc import abstractmethod
 from collections.abc import Hashable
 from dataclasses import dataclass
 from enum import Enum
@@ -38,6 +37,7 @@ from discrete_optimization.generic_tasks_tools.multimode import (
 from discrete_optimization.generic_tasks_tools.scheduling import (
     SchedulingSolution,
 )
+from discrete_optimization.generic_tasks_tools.utils import optional_override
 
 logger = logging.getLogger(__name__)
 
@@ -110,7 +110,7 @@ class ResourceBlockingProblem(
     resource definitions and capacity constraints.
     """
 
-    @abstractmethod
+    @optional_override
     def get_flexible_gap_blocking_constraints(
         self,
     ) -> list[
@@ -140,10 +140,13 @@ class ResourceBlockingProblem(
             - point2: START or END of second entity
             - resources: Dict mapping resources to consumption amounts
             - metadata: Blocking behavior configuration
-        """
-        ...
 
-    @abstractmethod
+        Default to no flexible gap blocking constraints.
+
+        """
+        return []
+
+    @optional_override
     def get_span_blocking_constraints(
         self,
     ) -> list[
@@ -163,9 +166,9 @@ class ResourceBlockingProblem(
             - resources: Dict mapping resources to consumption amounts
             - metadata: Blocking behavior configuration
 
-        Examples:
+        Default to no span blocking constraints.
         """
-        ...
+        return []
 
 
 class ResourceBlockingSolution(
@@ -604,60 +607,3 @@ class ResourceBlockingSolution(
 
         # Check blocking constraints
         return self.check_blocking_constraints()
-
-
-class WithoutResourceBlockingProblem(
-    ResourceBlockingProblem[Task, CumulativeResource, OtherCalendarResource]
-):
-    """Utility mixin for problems without resource blocking constraints.
-
-    Provides empty implementations of blocking constraint methods.
-    Use as an additional mixin with GenericSchedulingProblem when no blocking needed.
-    """
-
-    def get_flexible_gap_blocking_constraints(
-        self,
-    ) -> list[
-        tuple[
-            SchedulingEntity,
-            StartOrEnd,
-            SchedulingEntity,
-            StartOrEnd,
-            dict[CumulativeResource, int],
-            BlockingConstraintMetadata,
-        ]
-    ]:
-        """Return empty list (no blocking constraints)."""
-        return []
-
-    def get_span_blocking_constraints(
-        self,
-    ) -> list[
-        tuple[
-            frozenset[Task], dict[CumulativeResource, int], BlockingConstraintMetadata
-        ]
-    ]:
-        """Return empty list (no blocking constraints)."""
-        return []
-
-
-class WithoutResourceBlockingSolution(
-    ResourceBlockingSolution[Task, CumulativeResource, OtherCalendarResource]
-):
-    """Utility mixin for solutions without resource blocking constraints.
-
-    Provides optimized implementations that skip blocking computation.
-    Use as an additional mixin when no blocking needed.
-    """
-
-    def check_blocking_constraints(self) -> bool:
-        """Always satisfied (no constraints)."""
-        return True
-
-    def compute_blocking_consumption(
-        self,
-        horizon: int,
-        resource: CumulativeResource,
-    ) -> np.ndarray:
-        """Return zero consumption (no blocking)."""
-        return np.zeros(horizon, dtype=int)

--- a/src/discrete_optimization/generic_tasks_tools/utils.py
+++ b/src/discrete_optimization/generic_tasks_tools/utils.py
@@ -2,6 +2,15 @@
 #  This source code is licensed under the MIT license found in the
 #  LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from discrete_optimization.generic_tasks_tools.base import TasksProblem
+
 
 def optional_override(funcobj):
     """A decorator indicating primitive methods likely to be overriden when creating a new task problem class.
@@ -16,5 +25,85 @@ def optional_override(funcobj):
     Note: This does not modify the function behaviour, and is merely used as documentation.
 
     """
-    funcobj.__islikelytobeoverriden__ = True
+    funcobj.__is_optional_override__ = True
     return funcobj
+
+
+def get_mandatory_methods_to_implement(
+    cls: type[TasksProblem],
+) -> dict[str, Callable[[...], Any]]:
+    """Find methods mandatory to implement when deriving from the given class.
+
+    Args:
+        cls: class to inspect
+
+    Returns:
+        A dictionary mapping abstract method names to their class methods.
+
+    Example:
+        >>> from discrete_optimization.generic_tasks_tools.generic_scheduling import GenericSchedulingProblem
+        >>> get_mandatory_methods_to_implement(GenericSchedulingProblem)  # doctest:+ELLIPSIS
+        {...}
+
+
+    """
+    return {name: getattr(cls, name) for name in cls.__abstractmethods__}
+
+
+def get_optional_methods_to_override(
+    cls: type[TasksProblem] | TasksProblem, include_subclass_overrides: bool = False
+) -> dict[str, Callable[[...], Any]]:
+    """Find methods likely to be overriden when deriving from the given task problem class.
+
+    It finds methods decorated with @optional_override.
+    If the option is activated, it also finds such methods already overriden (including abstract methods).
+
+    Args:
+
+        cls: The class (or instance) to inspect.
+        include_subclass_overrides: If True, also includes
+          - methods that overrode an @optional_override method from a parent mixin without re-applying
+          the decorator
+          - methods that overrode an @abstractmethod method from a parent mixin
+
+    Returns:
+
+        A dictionary mapping method names to their class methods.
+
+    Example:
+        >>> from discrete_optimization.generic_tasks_tools.generic_scheduling import GenericSchedulingProblem
+        >>> optional_methods = get_optional_methods_to_override(GenericSchedulingProblem)
+        >>> optional_methods_including_subclasses = get_optional_methods_to_override(GenericSchedulingProblem, include_subclass_overrides=True)
+        >>> assert len(optional_methods_including_subclasses) > len(optional_methods)
+
+
+    """
+    # use the class if an instance was given:
+    if not isinstance(cls, type):
+        cls = type(cls)
+
+    optional_methods = {}
+    # loop over members
+    for name in dir(cls):
+        # Safely resolve the raw attribute without triggering properties or descriptors
+        raw_attr = inspect.getattr_static(cls, name)
+        # Unwrap @classmethod or @staticmethod descriptors if present
+        unwrapped = getattr(raw_attr, "__func__", raw_attr)
+        # Direct match: The current class method has the decorator
+        if getattr(unwrapped, "__is_optional_override__", False):
+            optional_methods[name] = getattr(cls, name)
+            continue
+        # Inherited match: Walk the MRO to check if a base class decorated it
+        if include_subclass_overrides:
+            for base in cls.__mro__:
+                base_raw = inspect.getattr_static(base, name, None)
+                if base_raw:
+                    base_unwrapped = getattr(base_raw, "__func__", base_raw)
+
+                    if getattr(
+                        base_unwrapped, "__is_optional_override__", False
+                    ) or getattr(base_unwrapped, "__isabstractmethod__", False):
+                        optional_methods[name] = getattr(cls, name)
+                        break
+
+    return optional_methods

--- a/src/discrete_optimization/rcpsp_multiskill/problem.py
+++ b/src/discrete_optimization/rcpsp_multiskill/problem.py
@@ -30,9 +30,6 @@ from discrete_optimization.generic_tasks_tools.generic_scheduling import (
     GenericSchedulingProblem,
     GenericSchedulingSolution,
 )
-from discrete_optimization.generic_tasks_tools.resource_blocking import (
-    WithoutResourceBlockingProblem,
-)
 from discrete_optimization.generic_tools.do_problem import (
     ModeOptim,
     ObjectiveDoc,
@@ -2009,7 +2006,6 @@ class MultiskillRcpspProblem(
     GenericSchedulingProblem[
         Task, UnaryResource, Skill, NonSkillCumulativeResource, NonRenewableResource
     ],
-    WithoutResourceBlockingProblem[Task, NonSkillCumulativeResource, UnaryResource],
 ):
     sgs: ScheduleGenerationScheme
     skills_set: set[str]

--- a/src/discrete_optimization/shop/base.py
+++ b/src/discrete_optimization/shop/base.py
@@ -23,10 +23,6 @@ from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
     WithoutNonRenewableResourceProblem,
     WithoutNonRenewableResourceSolution,
 )
-from discrete_optimization.generic_tasks_tools.resource_blocking import (
-    WithoutResourceBlockingProblem,
-    WithoutResourceBlockingSolution,
-)
 from discrete_optimization.generic_tasks_tools.skill import (
     NoSkill,
     WithoutSkillProblem,
@@ -96,7 +92,6 @@ class AnyShopSolution(
     ],
     WithoutNonRenewableResourceSolution[Task],
     WithoutAllocationSolution[Task],
-    WithoutResourceBlockingSolution[Task, NonSkillCumulativeResource, NoUnaryResource],
 ):
     problem: "CommonShopProblem"
     schedule: list[list[tuple[int, int]]]
@@ -176,7 +171,6 @@ class CommonShopProblem(
     ],
     WithoutNonRenewableResourceProblem[Task],
     WithoutAllocationProblem[Task],
-    WithoutResourceBlockingProblem[Task, NonSkillCumulativeResource, NoUnaryResource],
 ):
     n_machines: int
     n_jobs: int

--- a/src/discrete_optimization/shop/jsp/problem.py
+++ b/src/discrete_optimization/shop/jsp/problem.py
@@ -12,9 +12,6 @@ from discrete_optimization.generic_tasks_tools.multimode import (
 from discrete_optimization.generic_tasks_tools.multimode_scheduling import (
     SinglemodeSchedulingProblem,
 )
-from discrete_optimization.generic_tasks_tools.no_overlap import (
-    WithoutNoOverlapProblem,
-)
 from discrete_optimization.shop.base import AnyShopSolution, CommonShopProblem, Task
 
 
@@ -22,9 +19,7 @@ class JobShopSolution(AnyShopSolution, SinglemodeSolution[Task]):
     problem: JobShopProblem
 
 
-class JobShopProblem(
-    CommonShopProblem, WithoutNoOverlapProblem[Task], SinglemodeSchedulingProblem[Task]
-):
+class JobShopProblem(CommonShopProblem, SinglemodeSchedulingProblem[Task]):
     def get_task_duration(self, task: Task) -> int:
         return self.list_jobs[task[0]].subjobs[task[1]].recipes[0].processing_time
 

--- a/src/discrete_optimization/workforce/scheduling/problem.py
+++ b/src/discrete_optimization/workforce/scheduling/problem.py
@@ -27,17 +27,10 @@ from discrete_optimization.generic_tasks_tools.multimode import (
 from discrete_optimization.generic_tasks_tools.multimode_scheduling import (
     SinglemodeSchedulingProblem,
 )
-from discrete_optimization.generic_tasks_tools.no_overlap import (
-    WithoutNoOverlapProblem,
-)
 from discrete_optimization.generic_tasks_tools.non_renewable_resource import (
     NoNonRenewableResource,
     WithoutNonRenewableResourceProblem,
     WithoutNonRenewableResourceSolution,
-)
-from discrete_optimization.generic_tasks_tools.resource_blocking import (
-    WithoutResourceBlockingProblem,
-    WithoutResourceBlockingSolution,
 )
 from discrete_optimization.generic_tasks_tools.skill import (
     NoSkill,
@@ -77,7 +70,6 @@ class AllocSchedulingSolution(
         Task, UnaryResource, NonSkillCumulativeResource, UnaryResource
     ],
     WithoutNonRenewableResourceSolution[Task],
-    WithoutResourceBlockingSolution[Task, NonSkillCumulativeResource, UnaryResource],
     SinglemodeSolution[Task],
 ):
     problem: AllocSchedulingProblem
@@ -131,8 +123,6 @@ class AllocSchedulingProblem(
     ],
     WithoutSkillProblem[Task, UnaryResource, NonSkillCumulativeResource, UnaryResource],
     WithoutNonRenewableResourceProblem[Task],
-    WithoutNoOverlapProblem[Task],
-    WithoutResourceBlockingProblem[Task, NonSkillCumulativeResource, UnaryResource],
     SinglemodeSchedulingProblem[Task],
     WithoutModeConstraintSingleModeProblem[Task],
 ):

--- a/tests/generic_tasks_tools/solvers/cpsat/test_auto.py
+++ b/tests/generic_tasks_tools/solvers/cpsat/test_auto.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import copy
 import logging
 import re
-from abc import ABC
 from copy import deepcopy
 from typing import Any, Iterable, Optional
 
@@ -21,13 +20,6 @@ from discrete_optimization.generic_tasks_tools.generic_scheduling_utils import (
     Objective,
     RawSolution,
     TaskVariable,
-)
-from discrete_optimization.generic_tasks_tools.no_overlap import (
-    WithoutNoOverlapProblem,
-)
-from discrete_optimization.generic_tasks_tools.resource_blocking import (
-    WithoutResourceBlockingProblem,
-    WithoutResourceBlockingSolution,
 )
 from discrete_optimization.generic_tasks_tools.skill import (
     NoSkill,
@@ -68,8 +60,6 @@ class MySolution(
     WithoutSkillSolution[
         Task, UnaryResource, NonSkillCumulativeResource, UnaryResource
     ],
-    WithoutResourceBlockingSolution[Task, NonRenewableResource, UnaryResource],
-    ABC,
 ):
     problem: MyProblem
 
@@ -101,9 +91,7 @@ class MyProblem(
     GenericSchedulingProblem[
         Task, UnaryResource, Skill, NonSkillCumulativeResource, NonRenewableResource
     ],
-    WithoutNoOverlapProblem[Task],
     WithoutSkillProblem[Task, UnaryResource, NonSkillCumulativeResource, UnaryResource],
-    WithoutResourceBlockingProblem[Task, NonRenewableResource, UnaryResource],
 ):
     horizon = 10
     non_renewable_resources = ["non_renewable_resource"]

--- a/tests/generic_tasks_tools/test_utils.py
+++ b/tests/generic_tasks_tools/test_utils.py
@@ -1,0 +1,26 @@
+#  Copyright (c) 2026 AIRBUS and its affiliates.
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+from pytest_cases import parametrize
+
+from discrete_optimization.generic_tasks_tools.generic_scheduling import (
+    GenericSchedulingProblem,
+)
+from discrete_optimization.generic_tasks_tools.utils import (
+    get_mandatory_methods_to_implement,
+    get_optional_methods_to_override,
+)
+
+
+@parametrize("include_subclass_overrides", [True, False])
+def test_get_optional_methods_to_override(include_subclass_overrides):
+    methods = get_optional_methods_to_override(
+        GenericSchedulingProblem, include_subclass_overrides=include_subclass_overrides
+    )
+    assert "get_end_to_end_max_time_lags" in methods
+    assert ("get_last_tasks" in methods) == include_subclass_overrides
+
+
+def test_get_mandatory_methods_to_implement():
+    methods = get_mandatory_methods_to_implement(GenericSchedulingProblem)
+    assert "get_task_mode_duration" in methods


### PR DESCRIPTION
- Add default implementations to some tasks mixin (resource blocking and no overlap), using new decorator @optional_override to mark these methods

- Add a utility functions to get all methods mandatory to implement or likely to be overriden. 
  When creating a new task problem, we derive from mixins and they are:
  - mandatory methods to implement -> retrievable via `  get_mandatory_methods_to_implement()`,
  - optional methods to override (but needed by other computations) -> retrievable via `get_optional_methods_to_override()` with an option to get back to parent mixins for overriden default implementation or abstrat methods.